### PR TITLE
Adding the possibility to define a bidding address.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -62,6 +62,7 @@ public class WireMockServer {
 	private final FileSource fileSource;
 	private final Notifier notifier;
 	private final int port;
+	private final String biddingAddress;
 
     private final Options options;
 
@@ -69,6 +70,7 @@ public class WireMockServer {
         this.options = options;
         this.fileSource = options.filesRoot();
         this.port = options.portNumber();
+        this.biddingAddress = options.bindAddress();
         this.notifier = options.notifier();
 
         requestDelayControl = new ThreadSafeRequestDelayControl();
@@ -171,6 +173,7 @@ public class WireMockServer {
 
     private DelayableSocketConnector createHttpConnector() {
         DelayableSocketConnector connector = new DelayableSocketConnector(requestDelayControl);
+        connector.setHost(biddingAddress);
         connector.setPort(port);
         connector.setHeaderBufferSize(8192);
         return connector;

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -62,7 +62,7 @@ public class WireMockServer {
 	private final FileSource fileSource;
 	private final Notifier notifier;
 	private final int port;
-	private final String biddingAddress;
+	private final String bindAddress;
 
     private final Options options;
 
@@ -70,7 +70,7 @@ public class WireMockServer {
         this.options = options;
         this.fileSource = options.filesRoot();
         this.port = options.portNumber();
-        this.biddingAddress = options.bindAddress();
+        this.bindAddress = options.bindAddress();
         this.notifier = options.notifier();
 
         requestDelayControl = new ThreadSafeRequestDelayControl();
@@ -173,7 +173,7 @@ public class WireMockServer {
 
     private DelayableSocketConnector createHttpConnector() {
         DelayableSocketConnector connector = new DelayableSocketConnector(requestDelayControl);
-        connector.setHost(biddingAddress);
+        connector.setHost(bindAddress);
         connector.setPort(port);
         connector.setHeaderBufferSize(8192);
         return connector;

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.common.ProxySettings;
 public interface Options {
 
     public static final int DEFAULT_PORT = 8080;
+    public static final String DEFAULT_BIDDINGADDRESS = "0.0.0.0";
 
     int portNumber();
     HttpsSettings httpsSettings();
@@ -31,5 +32,6 @@ public interface Options {
     FileSource filesRoot();
     Notifier notifier();
     boolean requestJournalDisabled();
+    String bindAddress();
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.common.*;
 public class WireMockConfiguration implements Options {
 
     private int portNumber = DEFAULT_PORT;
+    private String biddingAddress = DEFAULT_BIDDINGADDRESS;
     private Integer httpsPort = null;
     private String keyStorePath = null;
     private boolean browserProxyingEnabled = false;
@@ -34,6 +35,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration port(int portNumber) {
         this.portNumber = portNumber;
+        return this;
+    }
+
+    public WireMockConfiguration biddingAddress(String biddingAddress) {
+        this.biddingAddress = biddingAddress;
         return this;
     }
 
@@ -85,6 +91,11 @@ public class WireMockConfiguration implements Options {
     @Override
     public int portNumber() {
         return portNumber;
+    }
+
+    @Override
+    public String bindAddress(){
+        return biddingAddress;
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -149,6 +149,8 @@ public class RequestPattern {
 		
 		if (!matches) {
 			notifier().info(String.format("URL %s is match, but body is not: %s", request.getUrl(), request.getBodyAsString()));
+		} else {
+		    notifier().info(String.format("URL %s and body is match: %s", request.getUrl(), request.getBodyAsString()));
 		}
 		
 		return matches;

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -32,7 +32,7 @@ public class CommandLineOptions implements Options {
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PROXY_VIA = "proxy-via";
 	private static final String PORT = "port";
-	private static final String BIDDING_ADDRESS = "bind-address";
+	private static final String BIND_ADDRESS = "bind-address";
     private static final String HTTPS_PORT = "https-port";
     private static final String HTTPS_KEYSTORE = "https-keystore";
 	private static final String VERBOSE = "verbose";
@@ -48,7 +48,7 @@ public class CommandLineOptions implements Options {
 
 		OptionParser optionParser = new OptionParser();
 		optionParser.accepts(PORT, "The port number for the server to listen on").withRequiredArg();
-		optionParser.accepts(BIDDING_ADDRESS, "The IP to listen connections").withRequiredArg();
+		optionParser.accepts(BIND_ADDRESS, "The IP to listen connections").withRequiredArg();
         optionParser.accepts(HTTPS_PORT, "If this option is present WireMoc k will enable HTTPS on the specified port").withRequiredArg();
         optionParser.accepts(HTTPS_KEYSTORE, "Path to an alternative keystore for HTTPS. Must have a password of \"password\".").withRequiredArg();
 		optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
@@ -113,8 +113,8 @@ public class CommandLineOptions implements Options {
 	}
 
 	public String bindAddress(){
-		if (optionSet.has(BIDDING_ADDRESS)) {
-            return (String) optionSet.valueOf(BIDDING_ADDRESS);
+		if (optionSet.has(BIND_ADDRESS)) {
+            return (String) optionSet.valueOf(BIND_ADDRESS);
         }
 
         return DEFAULT_BIDDINGADDRESS;

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -32,6 +32,7 @@ public class CommandLineOptions implements Options {
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PROXY_VIA = "proxy-via";
 	private static final String PORT = "port";
+	private static final String BIDDING_ADDRESS = "bind-address";
     private static final String HTTPS_PORT = "https-port";
     private static final String HTTPS_KEYSTORE = "https-keystore";
 	private static final String VERBOSE = "verbose";
@@ -47,7 +48,8 @@ public class CommandLineOptions implements Options {
 
 		OptionParser optionParser = new OptionParser();
 		optionParser.accepts(PORT, "The port number for the server to listen on").withRequiredArg();
-        optionParser.accepts(HTTPS_PORT, "If this option is present WireMock will enable HTTPS on the specified port").withRequiredArg();
+		optionParser.accepts(BIDDING_ADDRESS, "The IP to listen connections").withRequiredArg();
+        optionParser.accepts(HTTPS_PORT, "If this option is present WireMoc k will enable HTTPS on the specified port").withRequiredArg();
         optionParser.accepts(HTTPS_KEYSTORE, "Path to an alternative keystore for HTTPS. Must have a password of \"password\".").withRequiredArg();
 		optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
@@ -108,6 +110,14 @@ public class CommandLineOptions implements Options {
         }
 
         return DEFAULT_PORT;
+	}
+
+	public String bindAddress(){
+		if (optionSet.has(BIDDING_ADDRESS)) {
+            return (String) optionSet.valueOf(BIDDING_ADDRESS);
+        }
+
+        return DEFAULT_BIDDINGADDRESS;
 	}
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -15,6 +15,8 @@
  */
 package com.github.tomakehurst.wiremock.stubbing;
 
+import java.util.Arrays;
+
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.IdGenerator;
 import com.github.tomakehurst.wiremock.common.UniqueFilenameGenerator;
@@ -25,6 +27,7 @@ import com.github.tomakehurst.wiremock.http.RequestListener;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.matching.ValuePattern;
 import com.github.tomakehurst.wiremock.verification.VerificationResult;
 
 import static com.github.tomakehurst.wiremock.common.Json.write;
@@ -47,6 +50,7 @@ public class StubMappingJsonRecorder implements RequestListener {
 	@Override
 	public void requestReceived(Request request, Response response) {
 		RequestPattern requestPattern = new RequestPattern(request.getMethod(), request.getUrl());
+		requestPattern.setBodyPatterns(Arrays.asList(ValuePattern.equalTo(request.getBodyAsString())));
 		
 		if (requestNotAlreadyReceived(requestPattern) && response.isFromProxy()) {
 		    notifier().info(String.format("Recording mappings for %s", request.getUrl()));

--- a/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BindAddressTest.java
@@ -1,0 +1,79 @@
+package com.github.tomakehurst.wiremock;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.Enumeration;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+
+public class BindAddressTest {
+
+    private final int port = 8090;
+    private String bindAddress = "127.0.0.1";
+    private String nonBindAddress;
+    private WireMockServer wireMockServer;
+
+    @Test
+    public void shouldRespondInTheBindAddressOnly() throws Exception {
+        executeGetIn(bindAddress);
+        try {
+            executeGetIn(nonBindAddress);
+            Assert.fail("Should not accept the connection in [" + nonBindAddress + "]");
+        } catch (Exception ex) {
+        }
+    }
+
+    @Before
+    public void prepare() throws Exception {
+        nonBindAddress = getIpAddressDifferentThan(bindAddress);
+        if (nonBindAddress == null)
+            Assert.fail("Impossible to validate the binding address. This machine has only a one Ip address ["
+                    + bindAddress + "]");
+
+        WireMockConfiguration cfg = new WireMockConfiguration();
+        cfg.biddingAddress(bindAddress);
+        cfg.port(port);
+
+        wireMockServer = new WireMockServer(cfg);
+        wireMockServer.start();
+    }
+
+    @After
+    public void stop() {
+        if (wireMockServer != null)
+            wireMockServer.stop();
+    }
+
+    private void executeGetIn(String address) {
+        WireMockTestClient wireMockClient = new WireMockTestClient(port, address);
+        wireMockClient.addResponse(MappingJsonSamples.BASIC_MAPPING_REQUEST_WITH_RESPONSE_HEADER);
+        WireMockResponse response = wireMockClient.get("/a/registered/resource");
+        assertThat(response.statusCode(), is(401));
+    }
+
+    private String getIpAddressDifferentThan(String lopbackAddress) throws SocketException {
+        Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+        for (NetworkInterface netInterface : Collections.list(networkInterfaces)) {
+            Enumeration<InetAddress> inetAddresses = netInterface.getInetAddresses();
+            for (InetAddress address : Collections.list(inetAddresses))
+                if (address instanceof Inet4Address && !address.getHostAddress().equals(lopbackAddress)) {
+                    return address.getHostAddress();
+                }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -119,6 +119,12 @@ public class CommandLineOptionsTest {
     }
 
     @Test
+    public void returnsCorrecteyParsedBindAddress(){
+        CommandLineOptions options = new CommandLineOptions("--bind-address", "127.0.0.1");
+        assertThat(options.bindAddress(), is("127.0.0.1"));
+    }
+    
+    @Test
     public void returnsNoProxyWhenNoProxyViaSpecified() {
         CommandLineOptions options = new CommandLineOptions();
         assertThat(options.proxyVia(), is(ProxySettings.NO_PROXY));

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RequestPatternTest.java
@@ -195,6 +195,8 @@ public class RequestPatternTest {
 	
 	@Test
 	public void shouldMatchOnBodyPattern() {
+	    ignoringNotifier();
+	    
 		RequestPattern requestPattern = new RequestPattern(GET, "/with/body");
 		requestPattern.setBodyPatterns(asList(ValuePattern.matches(".*<important>Value</important>.*")));
 		

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -62,7 +62,10 @@ public class StubMappingJsonRecorderTest {
 		"{ 													             \n" +
 		"	\"request\": {									             \n" +
 		"		\"method\": \"GET\",						             \n" +
-		"		\"url\": \"/recorded/content\"				             \n" +
+		"		\"url\": \"/recorded/content\", 			             \n" +
+		"       \"bodyPatterns\" : [ {                                   \n" + 
+		"           \"equalTo\" : \"\"                                   \n" +
+		"       } ]                                                      \n" +
 		"	},												             \n" +
 		"	\"response\": {									             \n" +
 		"		\"status\": 200,							             \n" +
@@ -98,7 +101,10 @@ public class StubMappingJsonRecorderTest {
         "{                                                                  \n" +
         "   \"request\": {                                                  \n" +
         "       \"method\": \"GET\",                                        \n" +
-        "       \"url\": \"/headered/content\"                              \n" +
+        "       \"url\": \"/headered/content\",                             \n" +
+        "       \"bodyPatterns\" : [ {                                      \n" + 
+        "           \"equalTo\" : \"\"                                      \n" +
+        "       } ]                                                         \n" +        
         "   },                                                              \n" +
         "   \"response\": {                                                 \n" +
         "       \"status\": 200,                                            \n" +

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.testsupport;
 
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -38,15 +39,21 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 public class WireMockTestClient {
 
-	private static final String LOCAL_WIREMOCK_ROOT = "http://localhost:%d%s";
-	private static final String LOCAL_WIREMOCK_NEW_RESPONSE_URL = "http://localhost:%d/__admin/mappings/new";
-	private static final String LOCAL_WIREMOCK_RESET_URL = "http://localhost:%d/__admin/reset";
-	private static final String LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL = "http://localhost:%d/__admin/mappings/reset";
+	private static final String LOCAL_WIREMOCK_ROOT = "http://%s:%d%s";
+	private static final String LOCAL_WIREMOCK_NEW_RESPONSE_URL = "http://%s:%d/__admin/mappings/new";
+	private static final String LOCAL_WIREMOCK_RESET_URL = "http://%s:%d/__admin/reset";
+	private static final String LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL = "http://%s:%d/__admin/mappings/reset";
 
 	private int port;
+    private String address;
+	
+	public WireMockTestClient(int port, String address) {
+        this.port = port;
+        this.address = address;
+    }
 	
 	public WireMockTestClient(int port) {
-		this.port = port;
+		this(port, "localhost");
 	}
 	
 	public WireMockTestClient() {
@@ -54,19 +61,19 @@ public class WireMockTestClient {
 	}
 	
 	private String mockServiceUrlFor(String path) {
-		return String.format(LOCAL_WIREMOCK_ROOT, port, path);
+		return String.format(LOCAL_WIREMOCK_ROOT, address, port, path);
 	}
 	
 	private String newMappingUrl() {
-		return String.format(LOCAL_WIREMOCK_NEW_RESPONSE_URL, port);
+		return String.format(LOCAL_WIREMOCK_NEW_RESPONSE_URL, address, port);
 	}
 	
 	private String resetUrl() {
-		return String.format(LOCAL_WIREMOCK_RESET_URL, port);
+		return String.format(LOCAL_WIREMOCK_RESET_URL, address, port);
 	}
 
     private String resetDefaultMappingsUrl() {
-        return String.format(LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL, port);
+        return String.format(LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL, address, port);
     }
 
 	public WireMockResponse get(String url, TestHttpHeader... headers) {
@@ -77,7 +84,7 @@ public class WireMockTestClient {
 	public WireMockResponse getViaProxy(String url) {
 		URI targetUri = URI.create(url);
 		
-		HttpHost proxy = new HttpHost("localhost", 8080, "http");
+		HttpHost proxy = new HttpHost(address, 8080, "http");
 
         DefaultHttpClient httpclient = new DefaultHttpClient();
         try {


### PR DESCRIPTION
    Now it is possible to pass a configuraion option defining the address that
the wiremock will listen connections. The default value is the address 0.0.0.0
that means all interfaces, kepping the curent behavior.