### PR TITLE
Ungzip recorded responses if --ungzip-recorded-responses cli param given

### DIFF
--- a/docs/source/record-playback.rst
+++ b/docs/source/record-playback.rst
@@ -32,6 +32,16 @@ for the body content.
 .. note::
     The WireMock recorder will ignore a request with a method and URL identical to those of a stub already recorded.
 
+GZip decompressing
+------------------
+
+WireMock can be configured to decompress any gzipped responses it receives when recording, making editing the resulting
+body files much easier. WireMock also removes the ``Content-Encoding: gzip`` header when playing back the response. To
+enable gzip decompression, add the ``--ungzip-recorded-responses`` argument when starting the standalone runner, e.g.:
+
+.. parsed-literal::
+
+    $ java -jar wiremock-|version|-standalone.jar --proxy-all="http://search.twitter.com" --record-mappings --ungzip-recorded-responses --verbose
 
 Playback
 ========

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -140,9 +140,13 @@ public class WireMockServer {
 		stubRequestHandler.addRequestListener(listener);
 	}
 	
-	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource) {
+	public void enableRecordMappings(
+            FileSource mappingsFileSource,
+            FileSource filesFileSource,
+            StubMappingJsonRecorder.DecompressionMode decompressionMode
+    ) {
 	    addMockServiceRequestListener(
-                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp));
+                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, decompressionMode));
 	    notifier.info("Recording mappings to " + mappingsFileSource.getPath());
 	}
 	

--- a/src/main/java/com/github/tomakehurst/wiremock/http/GzipDecompressor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/GzipDecompressor.java
@@ -1,0 +1,55 @@
+package com.github.tomakehurst.wiremock.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.zip.GZIPInputStream;
+
+import static com.google.common.base.Charsets.UTF_8;
+
+public class GzipDecompressor {
+    /**
+     * Decompress the binary gzipped content into a String.
+     *
+     * @param content the gzipped content to decompress
+     * @return decompressed String.
+     */
+    public String decompressToUtf8String(byte[] content) {
+        return new String(decompress(content), Charset.forName(UTF_8.name()));
+    }
+
+    /**
+     * Decompress the binary gzipped content.
+     *
+     * @param content the gzipped content to decompress
+     * @return decompressed bytes.
+     */
+    public byte[] decompress(byte[] content) {
+        GZIPInputStream gin = null;
+        try {
+            gin = new GZIPInputStream(new ByteArrayInputStream(content));
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+            byte[] buf = new byte[8192];
+
+            int read;
+            while ((read = gin.read(buf)) != -1) {
+                baos.write(buf,0,read);
+            }
+
+            return baos.toByteArray();
+
+        } catch (IOException e) {
+            return null;
+        } finally {
+            if (gin != null) {
+                try {
+                    gin.close();
+                } catch (IOException e) {
+
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
@@ -105,4 +105,23 @@ public class HttpHeader {
         return sb.toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HttpHeader that = (HttpHeader) o;
+
+        if (key != null ? !key.equals(that.key) : that.key != null) return false;
+        if (values != null ? !values.equals(that.values) : that.values != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = key != null ? key.hashCode() : 0;
+        result = 31 * result + (values != null ? values.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.standalone;
 
 import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import joptsimple.OptionParser;
@@ -29,6 +30,7 @@ public class CommandLineOptions implements Options {
 	
 	private static final String HELP = "help";
 	private static final String RECORD_MAPPINGS = "record-mappings";
+	private static final String UNGZIP_RECORDED_RESPONSES = "ungzip-recorded-responses";
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PROXY_VIA = "proxy-via";
 	private static final String PORT = "port";
@@ -52,6 +54,7 @@ public class CommandLineOptions implements Options {
 		optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
 		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
+		optionParser.accepts(UNGZIP_RECORDED_RESPONSES, "Decompresses all gzip responses when recording");
 		optionParser.accepts(VERBOSE, "Enable verbose logging to stdout");
 		optionParser.accepts(ENABLE_BROWSER_PROXYING, "Allow wiremock to be set as a browser's proxy server");
         optionParser.accepts(DISABLE_REQUEST_JOURNAL, "Disable the request journal (to avoid heap growth when running wiremock for long periods without reset)");
@@ -96,6 +99,13 @@ public class CommandLineOptions implements Options {
 	public boolean recordMappingsEnabled() {
 		return optionSet.has(RECORD_MAPPINGS);
 	}
+
+    public StubMappingJsonRecorder.DecompressionMode decompressionMode() {
+        if (optionSet.has(UNGZIP_RECORDED_RESPONSES)) {
+            return StubMappingJsonRecorder.DecompressionMode.DECOMPRESS_GZIP;
+        }
+        return StubMappingJsonRecorder.DecompressionMode.NO_DECOMPRESSION;
+    }
 	
 	private boolean specifiesPortNumber() {
 		return optionSet.has(PORT);

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -51,7 +51,7 @@ public class WireMockServerRunner {
         wireMockServer = new WireMockServer(options);
 
         if (options.recordMappingsEnabled()) {
-            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource);
+            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource, options.decompressionMode());
         }
 
 		if (options.specifiesProxyUrl()) {

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.standalone;
 
 import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
@@ -40,6 +41,18 @@ public class CommandLineOptionsTest {
 		CommandLineOptions options = new CommandLineOptions("--record-mappings");
 		assertThat(options.recordMappingsEnabled(), is(true));
 	}
+
+    @Test
+    public void returnsDecompressGzipWhenUngzipOptionPresent() {
+        CommandLineOptions options = new CommandLineOptions("--ungzip-recorded-responses");
+        assertThat(options.decompressionMode(), is(StubMappingJsonRecorder.DecompressionMode.DECOMPRESS_GZIP));
+    }
+
+    @Test
+    public void returnsNoDecompressionWhenUngzipOptionNotPresent() {
+        CommandLineOptions options = new CommandLineOptions("");
+        assertThat(options.decompressionMode(), is(StubMappingJsonRecorder.DecompressionMode.NO_DECOMPRESSION));
+    }
 	
 	@Test
 	public void returnsRecordMappingsFalseWhenOptionNotPresent() {


### PR DESCRIPTION
Hi,

This PR (hopefully) closes issue #56: it adds a new command line arg, `--ungzip-recorded-responses`, which decompresses gzipped recorded responses (and removes the "Content-Encoding: gzip" header from the stored mapping).

One thought I've had is that this is maybe a bit gzip-specific. Maybe it should just be `--decompress-recorded-responses` or something, in case WireMock ever ends up supporting any other kinds of decompression, so the cli args don't need to change? Or maybe I'm over-thinking that.

As always, happy to implement any changes you might suggest, if I can.

Thanks,
Rowan