### PR TITLE
Added remove a mapping feature

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminTasks.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminTasks.java
@@ -21,8 +21,7 @@ import com.google.common.collect.ImmutableBiMap;
 
 import static com.github.tomakehurst.wiremock.admin.RequestSpec.requestSpec;
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
-import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 
 public class AdminTasks {
 
@@ -40,6 +39,7 @@ public class AdminTasks {
                 .put(requestSpec(POST, "/socket-delay"), SocketDelayTask.class)
                 .put(requestSpec(POST, "/settings"), GlobalSettingsUpdateTask.class)
                 .put(requestSpec(POST, "/shutdown"), ShutdownServerTask.class)
+                .put(requestSpec(DELETE, "/mappings/remove"), RemoveMappingTask.class)
                 .build();
 
     public static AdminTask taskFor(RequestMethod method, String path) {

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/NewStubMappingTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/NewStubMappingTask.java
@@ -25,7 +25,9 @@ public class NewStubMappingTask implements AdminTask {
     @Override
     public ResponseDefinition execute(Admin admin, Request request) {
         StubMapping newMapping = StubMapping.buildFrom(request.getBodyAsString());
-        admin.addStubMapping(newMapping);
-        return ResponseDefinition.created();
+        Long id = admin.addStubMapping(newMapping);
+        ResponseDefinition resp = ResponseDefinition.created();
+        resp.setBody("{\"id\":" + id + "}");
+        return resp;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/RemoveMappingTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/RemoveMappingTask.java
@@ -1,0 +1,28 @@
+package com.github.tomakehurst.wiremock.admin;
+
+import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+
+import java.util.HashMap;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: shwet.shashank
+ * Date: 07/02/14
+ * Time: 5:09 PM
+ * To change this template use File | Settings | File Templates.
+ */
+public class RemoveMappingTask implements AdminTask{
+
+    @Override
+    public ResponseDefinition execute(Admin admin, Request request) {
+        HashMap<String, Object> reqBody = Json.read(request.getBodyAsString(), HashMap.class);
+        if(admin.removeMapping(new Long((Integer)reqBody.get("id")))){
+            return ResponseDefinition.ok();
+        }
+        return ResponseDefinition.notFound();
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -63,11 +63,12 @@ public class HttpAdminClient implements Admin {
 	}
 
 	@Override
-	public void addStubMapping(StubMapping stubMapping) {
+	public Long addStubMapping(StubMapping stubMapping) {
         postJsonAssertOkAndReturnBody(
                 urlFor(NewStubMappingTask.class),
                 Json.write(stubMapping),
                 HTTP_CREATED);
+        return stubMapping.getInsertionIndex();
 	}
 
     @Override
@@ -135,6 +136,13 @@ public class HttpAdminClient implements Admin {
     @Override
     public void shutdownServer() {
         postJsonAssertOkAndReturnBody(urlFor(ShutdownServerTask.class), null, HTTP_OK);
+    }
+
+    @Override
+    public boolean removeMapping(Long stubId) {
+        String body = "{\"id\":" + stubId + "}";
+        postJsonAssertOkAndReturnBody(urlFor(RemoveMappingTask.class),body, HTTP_OK);
+        return true;
     }
 
     private String postJsonAssertOkAndReturnBody(String url, String json, int expectedStatus) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -24,11 +24,19 @@ public final class Json {
 	
 	private Json() {}
 
+    private static ObjectMapper readMapper;
+    private static ObjectMapper writeMapper;
+
+    static {
+        readMapper = new ObjectMapper();
+        writeMapper = new ObjectMapper();
+        readMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+    }
+
     public static <T> T read(String json, Class<T> clazz) {
 		try {
-			ObjectMapper mapper = new ObjectMapper();
-			mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
-			return mapper.readValue(json, clazz);
+			readMapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+			return readMapper.readValue(json, clazz);
 		} catch (IOException ioe) {
 			throw new RuntimeException("Unable to bind JSON to object. Reason: " + ioe.getMessage() + "  JSON:" + json, ioe);
 		}
@@ -36,8 +44,7 @@ public final class Json {
 	
 	public static <T> String write(T object) {
 		try {
-			ObjectMapper mapper = new ObjectMapper();
-			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+			return writeMapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
 		} catch (IOException ioe) {
 			throw new RuntimeException("Unable to generate JSON from object. Reason: " + ioe.getMessage(), ioe);
 		}

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -25,7 +25,7 @@ import com.github.tomakehurst.wiremock.verification.VerificationResult;
 
 public interface Admin {
 
-	void addStubMapping(StubMapping stubMapping);
+	Long addStubMapping(StubMapping stubMapping);
     ListStubMappingsResult listAllStubMappings();
     void saveMappings();
 	void resetMappings();
@@ -36,4 +36,5 @@ public interface Admin {
 	void updateGlobalSettings(GlobalSettings settings);
     void addSocketAcceptDelay(RequestDelaySpec spec);
     void shutdownServer();
+    boolean removeMapping(Long stubId);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -87,8 +87,8 @@ public class WireMockApp implements StubServer, Admin {
     }
 
     @Override
-    public void addStubMapping(StubMapping stubMapping) {
-        stubMappings.addMapping(stubMapping);
+    public Long addStubMapping(StubMapping stubMapping) {
+       return stubMappings.addMapping(stubMapping);
     }
 
     @Override
@@ -151,6 +151,11 @@ public class WireMockApp implements StubServer, Admin {
     @Override
     public void shutdownServer() {
         container.shutdown();
+    }
+
+    @Override
+    public boolean removeMapping(Long stubId) {
+        return  stubMappings.removeMapping(stubId);
     }
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
@@ -33,7 +33,7 @@ public class InMemoryStubMappings implements StubMappings {
 	
 	private final SortedConcurrentMappingSet mappings = new SortedConcurrentMappingSet();
 	private final ConcurrentHashMap<String, Scenario> scenarioMap = new ConcurrentHashMap<String, Scenario>();
-	
+
 	@Override
 	public ResponseDefinition serveFor(Request request) {
 		StubMapping matchingMapping = find(
@@ -53,15 +53,29 @@ public class InMemoryStubMappings implements StubMappings {
 	}
 
 	@Override
-	public void addMapping(StubMapping mapping) {
+	public Long addMapping(StubMapping mapping) {
 		if (mapping.isInScenario()) {
 			scenarioMap.putIfAbsent(mapping.getScenarioName(), Scenario.inStartedState());
 			Scenario scenario = scenarioMap.get(mapping.getScenarioName());
 			mapping.setScenario(scenario);
 		}
-		
 		mappings.add(mapping);
+        return mapping.getInsertionIndex();
 	}
+
+    @Override
+    public boolean removeMapping(Long stubId) {
+        StubMapping mapping = mappings.remove(stubId);
+        if(mapping==null) return false;
+        if(mapping.isInScenario()){
+            if(scenarioMap.containsKey(mapping.getScenarioName())){
+                scenarioMap.remove(mapping.getScenarioName());
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
 
 	@Override
 	public void reset() {

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.stubbing;
 
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -24,10 +25,12 @@ public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
 
 	private AtomicLong insertionCount;
 	private ConcurrentSkipListSet<StubMapping> mappingSet;
+    private ConcurrentHashMap<Long, StubMapping> idStubMappingMap;
 	
 	public SortedConcurrentMappingSet() {
 		insertionCount = new AtomicLong();
 		mappingSet = new ConcurrentSkipListSet<StubMapping>(sortedByPriorityThenReverseInsertionOrder());
+        idStubMappingMap = new ConcurrentHashMap<Long, StubMapping>();
 	}
 	
 	private Comparator<StubMapping> sortedByPriorityThenReverseInsertionOrder() {
@@ -37,7 +40,7 @@ public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
 				if (priorityComparison != 0) {
 					return priorityComparison;
 				}
-				
+				if(two.getInsertionIndex()==one.getInsertionIndex()) return 0;
 				return (two.getInsertionIndex() > one.getInsertionIndex()) ? 1 : -1;
 			}
 		};
@@ -51,7 +54,16 @@ public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
 	public void add(StubMapping mapping) {
 		mapping.setInsertionIndex(insertionCount.getAndIncrement());
 		mappingSet.add(mapping);
+        idStubMappingMap.put(mapping.getInsertionIndex(), mapping);
 	}
+
+    public StubMapping remove(Long stubId) {
+        StubMapping mapping = idStubMappingMap.get(stubId);
+        if(mapping==null) return null;
+        mappingSet.remove(mapping);
+        idStubMappingMap.remove(stubId);
+        return mapping;
+    }
 	
 	public void clear() {
 		mappingSet.clear();

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
@@ -24,9 +24,10 @@ import java.util.List;
 public interface StubMappings {
 
 	ResponseDefinition serveFor(Request request);
-	void addMapping(StubMapping mapping);
+	Long addMapping(StubMapping mapping);
 	void reset();
 	void resetScenarios();
+    boolean removeMapping(Long stubId);
 
     List<StubMapping> getAll();
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryMappingsTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
+import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -66,6 +67,19 @@ public class InMemoryMappingsTest {
 		
 		assertThat(response.getStatus(), is(204));
 	}
+
+    @Test
+    public void createAndRemoveMapping(){
+        Long stubId = mappings.addMapping(new StubMapping(new RequestPattern(POST, "/some/willdelete"),
+                new ResponseDefinition(201, "Testing delete")));
+        Request request = aRequest(context).withMethod(POST).withUrl("/some/willdelete").build();
+        ResponseDefinition response = mappings.serveFor(request);
+        assertThat(response.getStatus(), is(HTTP_CREATED));
+        boolean deleted = mappings.removeMapping(stubId);
+        assertThat(deleted, is(true));
+        response = mappings.serveFor(request);
+        assertThat(response.getStatus(), is(HTTP_NOT_FOUND));
+    }
 	
 	@Test
 	public void returnsNotFoundWhenMethodIncorrect() {


### PR DESCRIPTION
Have created a new Pull request after rebasing.

Objective:  Allow users to delete a particular mapping.
Implementation:
1.Now whenever a new mapping is created it returns the id of the mapping which is like an index.
eg {"id":0}
2. I have added an end point "__admin/mappings/remove" it takes a body eg {"id":0}, User needs to make a DELETE call on the url, if a mapping exists with the given id it will be deleted else it will return 404.

