### PR TITLE
Scenario builder generics

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -69,6 +69,9 @@ public class MappingBuilder {
 	}
 	
 	public StubMapping build() {
+		if (scenarioName == null && (requiredScenarioState != null || newScenarioState != null)) {
+			throw new IllegalStateException("Scenario name must be specified to require or set a new scenario state");
+		}
 		RequestPattern requestPattern = requestPatternBuilder.build();
 		ResponseDefinition response = responseDefBuilder.build();
 		StubMapping mapping = new StubMapping(requestPattern, response);

--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -20,58 +20,45 @@ import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
-public class MappingBuilder {
+public class MappingBuilder<T extends MappingBuilder> {
 	
 	private RequestPatternBuilder requestPatternBuilder;
 	private ResponseDefinitionBuilder responseDefBuilder;
 	private Integer priority;
 	private String scenarioName;
-	private String requiredScenarioState;
-	private String newScenarioState;
+	protected String requiredScenarioState;
+	protected String newScenarioState;
 	
 	public MappingBuilder(RequestMethod method, UrlMatchingStrategy urlMatchingStrategy) {
 		requestPatternBuilder = new RequestPatternBuilder(method, urlMatchingStrategy);
 	}
 
-	public MappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder) {
+	public T willReturn(ResponseDefinitionBuilder responseDefBuilder) {
 		this.responseDefBuilder = responseDefBuilder;
-		return this;
+		return (T)this;
 	}
 	
-	public MappingBuilder atPriority(Integer priority) {
+	public T atPriority(Integer priority) {
 		this.priority = priority;
-		return this;
+		return (T)this;
 	}
 	
-	public MappingBuilder withHeader(String key, ValueMatchingStrategy headerMatchingStrategy) {
+	public T withHeader(String key, ValueMatchingStrategy headerMatchingStrategy) {
 		requestPatternBuilder.withHeader(key, headerMatchingStrategy);
-		return this;
+		return (T)this;
 	}
 	
-	public MappingBuilder withRequestBody(ValueMatchingStrategy bodyMatchingStrategy) {
+	public T withRequestBody(ValueMatchingStrategy bodyMatchingStrategy) {
 		requestPatternBuilder.withRequestBody(bodyMatchingStrategy);
-		return this;
+		return (T)this;
 	}
 	
-	public MappingBuilder inScenario(String scenarioName) {
+	public ScenarioMappingBuilder inScenario(String scenarioName) {
 		this.scenarioName = scenarioName;
-		return this;
-	}
-	
-	public MappingBuilder whenScenarioStateIs(String stateName) {
-		this.requiredScenarioState = stateName;
-		return this;
-	}
-	
-	public MappingBuilder willSetStateTo(String stateName) {
-		this.newScenarioState = stateName;
-		return this;
+		return (ScenarioMappingBuilder) this;
 	}
 	
 	public StubMapping build() {
-		if (scenarioName == null && (requiredScenarioState != null || newScenarioState != null)) {
-			throw new IllegalStateException("Scenario name must be specified to require or set a new scenario state");
-		}
 		RequestPattern requestPattern = requestPatternBuilder.build();
 		ResponseDefinition response = responseDefBuilder.build();
 		StubMapping mapping = new StubMapping(requestPattern, response);

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
@@ -1,0 +1,19 @@
+package com.github.tomakehurst.wiremock.client;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+
+public class ScenarioMappingBuilder extends MappingBuilder<ScenarioMappingBuilder> {
+	public ScenarioMappingBuilder(RequestMethod method, UrlMatchingStrategy urlMatchingStrategy) {
+		super(method, urlMatchingStrategy);
+	}
+
+	public ScenarioMappingBuilder whenScenarioStateIs(String stateName) {
+		this.requiredScenarioState = stateName;
+		return this;
+	}
+
+	public ScenarioMappingBuilder willSetStateTo(String stateName) {
+		this.newScenarioState = stateName;
+		return this;
+	}
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -170,35 +170,35 @@ public class WireMock {
     }
 	
 	public static MappingBuilder get(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.GET, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.GET, urlMatchingStrategy);
 	}
 	
 	public static MappingBuilder post(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.POST, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.POST, urlMatchingStrategy);
 	}
 	
 	public static MappingBuilder put(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.PUT, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.PUT, urlMatchingStrategy);
 	}
 	
 	public static MappingBuilder delete(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.DELETE, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.DELETE, urlMatchingStrategy);
 	}
 	
 	public static MappingBuilder head(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.HEAD, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.HEAD, urlMatchingStrategy);
 	}
 	
 	public static MappingBuilder options(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.OPTIONS, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.OPTIONS, urlMatchingStrategy);
 	}
 	
 	public static MappingBuilder trace(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.TRACE, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.TRACE, urlMatchingStrategy);
 	}
 	
 	public static MappingBuilder any(UrlMatchingStrategy urlMatchingStrategy) {
-		return new MappingBuilder(RequestMethod.ANY, urlMatchingStrategy);
+		return new ScenarioMappingBuilder(RequestMethod.ANY, urlMatchingStrategy);
 	}
 	
 	public static ResponseDefinitionBuilder aResponse() {

--- a/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
@@ -90,17 +90,20 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 		assertThat(testClient.get("/stateful/resource").content(), is("Expected content"));
 	}
 
-    @Test(expected = IllegalStateException.class)
-    public void scenarioStateCannotBeSetIfScenarioIsNotNamed() {
-        givenThat(get(urlEqualTo("/some/resource"))
-                .willReturn(aResponse().withBody("Initial"))
-                .whenScenarioStateIs(STARTED));
-    }
+	@Test
+	public void scenarioBuilderMethodsDoNotNeedToBeContiguous() {
+		// This test has no assertions, but is here to ensure that the following compiles - i.e. that
+		// whenScenarioStatesIs and willSetStateTo don't have to immediately follow inScenario() calls, but can have
+		// other builder calls in between them.
+		//
+		// It should *not* be possible to call either before inScenario is called, however. We can't add a test for that
+		// of course, as it doesn't compile!
 
-    @Test(expected = IllegalStateException.class)
-    public void scenarioStateTransitionCannotBeSetIfScenarioIsNotNamed() {
-        givenThat(put(urlEqualTo("/some/resource"))
-                .willReturn(aResponse().withStatus(HTTP_OK))
-                .willSetStateTo("BodyModified"));
-    }
+		get(urlEqualTo("/"))
+				.inScenario("Scenario")
+				.willReturn(aResponse())
+				.whenScenarioStateIs("Prior State")
+				.atPriority(1)
+				.willSetStateTo("Next State");
+	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
@@ -90,23 +90,17 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 		assertThat(testClient.get("/stateful/resource").content(), is("Expected content"));
 	}
 
-    @Test
-    public void scenarioStateRequirementsAreIgnoredIfScenarioIsNotNamed() {
+    @Test(expected = IllegalStateException.class)
+    public void scenarioStateCannotBeSetIfScenarioIsNotNamed() {
         givenThat(get(urlEqualTo("/some/resource"))
                 .willReturn(aResponse().withBody("Initial"))
                 .whenScenarioStateIs(STARTED));
+    }
 
+    @Test(expected = IllegalStateException.class)
+    public void scenarioStateTransitionCannotBeSetIfScenarioIsNotNamed() {
         givenThat(put(urlEqualTo("/some/resource"))
                 .willReturn(aResponse().withStatus(HTTP_OK))
-                .willSetStateTo("BodyModified")
-                .whenScenarioStateIs(STARTED));
-
-        givenThat(get(urlEqualTo("/some/resource"))
-                .willReturn(aResponse().withBody("Modified"))
-                .whenScenarioStateIs("BodyModified"));
-
-        assertThat(testClient.get("/some/resource").content(), is("Modified"));
-        testClient.put("/some/resource");
-        assertThat(testClient.get("/some/resource").content(), is("Modified"));
+                .willSetStateTo("BodyModified"));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
@@ -89,4 +89,24 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 		
 		assertThat(testClient.get("/stateful/resource").content(), is("Expected content"));
 	}
+
+    @Test
+    public void scenarioStateRequirementsAreIgnoredIfScenarioIsNotNamed() {
+        givenThat(get(urlEqualTo("/some/resource"))
+                .willReturn(aResponse().withBody("Initial"))
+                .whenScenarioStateIs(STARTED));
+
+        givenThat(put(urlEqualTo("/some/resource"))
+                .willReturn(aResponse().withStatus(HTTP_OK))
+                .willSetStateTo("BodyModified")
+                .whenScenarioStateIs(STARTED));
+
+        givenThat(get(urlEqualTo("/some/resource"))
+                .willReturn(aResponse().withBody("Modified"))
+                .whenScenarioStateIs("BodyModified"));
+
+        assertThat(testClient.get("/some/resource").content(), is("Modified"));
+        testClient.put("/some/resource");
+        assertThat(testClient.get("/some/resource").content(), is("Modified"));
+    }
 }


### PR DESCRIPTION
This follows on from #84: instead of throwing an exception when building a mapping that specifies a required / next state without specifying a scenario name, this patch makes use of the type checker to ensure that isn't possible.

I'm not really certain this is the best way to go, but after sitting on it for way too long, I figured I may as well just put up a PR and let there be a discussion about it; I won't be offended if we just chuck this away!

Pros:
 - The API doesn't allow invalid use of itself
 - IDEs will be helpful and only suggest methods that make sense.

Cons:
 - It's overly restrictive, and so not 100% backwards compatible: it'll cause any existing code that calls whenScenarioStateIs / willSetStateTo before inScenario to fail to compile now (although it's a simple fix)
 - It's fiddly generics code that's possibly more complicated than it's worth