### PR TITLE
Groovy request stubbing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	compile ("junit:junit:4.11") {
         exclude group: "org.hamcrest", module: "hamcrest-core"
     }
+    compile "org.codehaus.groovy:groovy-all:2.3.8"
 	
     testCompile "org.hamcrest:hamcrest-all:1.3"
 	testCompile ("org.jmock:jmock:2.5.1") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 14 20:07:39 BST 2014
+#Fri Dec 19 01:01:18 CET 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-all.zip

--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -33,6 +33,10 @@ public class MappingBuilder {
 		requestPatternBuilder = new RequestPatternBuilder(method, urlMatchingStrategy);
 	}
 
+	public MappingBuilder(String groovyPattern) {
+		requestPatternBuilder = new RequestPatternBuilder(groovyPattern);
+	}
+
 	public MappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder) {
 		this.responseDefBuilder = responseDefBuilder;
 		return this;

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -199,6 +199,10 @@ public class WireMock {
         return matchingStrategy;
     }
 	
+	public static MappingBuilder groovy(String groovyPattern) {
+		return new MappingBuilder(groovyPattern);
+	}
+
 	public static MappingBuilder get(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.GET, urlMatchingStrategy);
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -158,6 +158,21 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         response = testClient.putWithBody("/match/this/body", "BlahBlah@56565@Blah", "text/plain");
         assertThat(response.statusCode(), is(HTTP_OK));
 	}
+
+	@Test
+	public void matchingOnRequestBodyByGroovyPattern() {
+		stubFor(groovy("method == 'PUT' && url == '/match/this/body' && body.matches('.*Blah.*') && body.matches('.*@[0-9]{5}@.*')")
+				.willReturn(aResponse()
+						.withStatus(HTTP_OK)));
+
+        WireMockResponse response = testClient.putWithBody("/match/this/body", "Blah...but not the rest", "text/plain");
+        assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+        response = testClient.putWithBody("/match/this/body", "@12345@...but not the rest", "text/plain");
+        assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+
+        response = testClient.putWithBody("/match/this/body", "BlahBlah@56565@Blah", "text/plain");
+        assertThat(response.statusCode(), is(HTTP_OK));
+	}
 	
 	@Test
     public void matchingOnRequestBodyWithAContainsAndANegativeRegex() {

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RequestPatternTest.java
@@ -321,6 +321,82 @@ public class RequestPatternTest {
 		requestPattern.isMatchedBy(request);
 	}
 
+	@Test
+	public void shouldParseGroovyExpressionFromPattern() {
+		String groovyPattern = "[1,2].every {it > 0}";
+		RequestPattern requestPattern = new RequestPattern(groovyPattern);
+
+		Request request = aRequest(context).build();
+
+		requestPattern.isMatchedBy(request);
+	}
+
+	@Test
+	public void shouldParseGroovyExpressionFromPatternWithUrlBinding() {
+		String groovyPattern = "url == 'someUrl'";
+		RequestPattern requestPattern = new RequestPattern(groovyPattern);
+
+		Request request = aRequest(context).withUrl("someUrl").build();
+
+		requestPattern.isMatchedBy(request);
+	}
+
+	@Test
+	public void shouldParseGroovyExpressionFromPatternWithAbsoluteUrlBinding() {
+		String groovyPattern = "absoluteUrl.endsWith('someUrl')";
+		RequestPattern requestPattern = new RequestPattern(groovyPattern);
+
+		Request request = aRequest(context).withUrl("/someUrl").build();
+
+		requestPattern.isMatchedBy(request);
+	}
+
+	@Test
+	public void shouldParseGroovyExpressionFromPatternWithAllHeaderKeysBinding() {
+		String groovyPattern = "allHeaderKeys.containsAll(['key','key2'])";
+		RequestPattern requestPattern = new RequestPattern(groovyPattern);
+
+		Request request = aRequest(context).
+							withHeader("key", "value").
+							withHeader("key2", "value").
+							build();
+
+		requestPattern.isMatchedBy(request);
+	}
+
+	@Test
+	public void shouldParseGroovyExpressionFromPatternWithHeadersBinding() {
+		String groovyPattern = "headers.contentTypeHeader.containsValue('application/json')";
+		RequestPattern requestPattern = new RequestPattern(groovyPattern);
+
+		Request request = aRequest(context).
+							withHeader("key", "value").
+							withHeader("Content-Type", "application/json").
+							build();
+
+		requestPattern.isMatchedBy(request);
+	}
+
+	@Test
+	public void shouldParseGroovyExpressionFromPatternWithBodyAsStringBinding() {
+		String groovyPattern = "body == 'someBody'";
+		RequestPattern requestPattern = new RequestPattern(groovyPattern);
+
+		Request request = aRequest(context).withBody("someBody").build();
+
+		requestPattern.isMatchedBy(request);
+	}
+
+	@Test
+	public void shouldParseGroovyExpressionFromPatternWithMethodBinding() {
+		String groovyPattern = "method == 'DELETE'";
+		RequestPattern requestPattern = new RequestPattern(groovyPattern);
+
+		Request request = aRequest(context).withMethod(DELETE).build();
+
+		requestPattern.isMatchedBy(request);
+	}
+
     private void ignoringNotifier() {
         context.checking(new Expectations() {{
             ignoring(notifier);


### PR DESCRIPTION
Hi!

This is a preeliminary suggestion of adding Groovy support for Wiremock.

The concept is such that instead of providing all the parameters of request mappings like this:

```
	@Test
	public void matchingOnRequestBodyWithTwoRegexes() {
		stubFor(put(urlEqualTo("/match/this/body"))
	            .withRequestBody(matching(".*Blah.*"))
	            .withRequestBody(matching(".*@[0-9]{5}@.*"))
	            .willReturn(aResponse()
                .withStatus(HTTP_OK)
                .withBodyFile("plain-example.txt")));
        
        WireMockResponse response = testClient.putWithBody("/match/this/body", "Blah...but not the rest", "text/plain");
        assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
        response = testClient.putWithBody("/match/this/body", "@12345@...but not the rest", "text/plain");
        assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
        
        response = testClient.putWithBody("/match/this/body", "BlahBlah@56565@Blah", "text/plain");
        assertThat(response.statusCode(), is(HTTP_OK));
	}
```

you can write one using Groovy

```
@Test
	public void matchingOnRequestBodyByGroovyPattern() {
		stubFor(groovy("method == 'PUT' && url == '/match/this/body' && body.matches('.*Blah.*') && body.matches('.*@[0-9]{5}@.*')")
				.willReturn(aResponse()
						.withStatus(HTTP_OK)));

        WireMockResponse response = testClient.putWithBody("/match/this/body", "Blah...but not the rest", "text/plain");
        assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
        response = testClient.putWithBody("/match/this/body", "@12345@...but not the rest", "text/plain");
        assertThat(response.statusCode(), is(HTTP_NOT_FOUND));

        response = testClient.putWithBody("/match/this/body", "BlahBlah@56565@Blah", "text/plain");
        assertThat(response.statusCode(), is(HTTP_OK));
	}
```

Of course the same applies to JSON files.

This is only a suggestion but I'm really open to discussions and hints on final API.