### PR TITLE
Support for parametrization in reponse body files via Velocity templates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ copy-admin.sh
 .DS_Store
 **/.DS_Store
 
+tmp

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
         	"com.fasterxml.jackson.core:jackson-annotations:2.4.2",
         	"com.fasterxml.jackson.core:jackson-databind:2.4.2"
 	compile "org.apache.httpcomponents:httpclient:4.3.5"
+	compile "org.apache.velocity:velocity:1.7"
     compile "org.skyscreamer:jsonassert:1.2.3"
     compile "xmlunit:xmlunit:1.5"
     compile "com.jayway.jsonpath:json-path:0.8.1"

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -37,6 +37,9 @@ import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
 import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.stubbing.StubMappings;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.Velocity;
 import org.mortbay.log.Log;
 
 import java.util.List;
@@ -57,6 +60,8 @@ public class WireMockServer implements Container, Stubbing {
 	private final Notifier notifier;
 
     private final Options options;
+    
+    private final VelocityContext velocityContext;
 
     protected final WireMock client;
 
@@ -64,6 +69,10 @@ public class WireMockServer implements Container, Stubbing {
         this.options = options;
         this.fileSource = options.filesRoot();
         this.notifier = options.notifier();
+        
+        Velocity.init();
+        velocityContext = new VelocityContext();
+        velocityContext.put( "name", new String("Wiremock Request Context") );
 
         RequestDelayControl requestDelayControl = new ThreadSafeRequestDelayControl();
         MappingsLoader defaultMappingsLoader = makeDefaultMappingsLoader();
@@ -90,8 +99,10 @@ public class WireMockServer implements Container, Stubbing {
                         new ProxyResponseRenderer(options.proxyVia(),
                                 options.shouldPreserveHostHeader(),
                                 options.proxyHostHeader()
-                        )
-                )
+                        ),
+                        velocityContext
+                ),
+                velocityContext
         );
         HttpServerFactory httpServerFactory = new Jetty6HttpServerFactory();
         httpServer = httpServerFactory.buildHttpServer(

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockWebContextListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockWebContextListener.java
@@ -28,6 +28,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import org.apache.velocity.VelocityContext;
+
 import static com.google.common.base.Optional.fromNullable;
 
 public class WireMockWebContextListener implements ServletContextListener {
@@ -58,10 +60,13 @@ public class WireMockWebContextListener implements ServletContextListener {
                 new NotImplementedContainer()
         );
         AdminRequestHandler adminRequestHandler = new AdminRequestHandler(wireMockApp, new BasicResponseRenderer());
+        final VelocityContext velocityContext = new VelocityContext();
         StubRequestHandler stubRequestHandler = new StubRequestHandler(wireMockApp,
                 new StubResponseRenderer(fileSource.child(FILES_ROOT),
                         wireMockApp.getGlobalSettingsHolder(),
-                        new ProxyResponseRenderer()));
+                        new ProxyResponseRenderer(),
+                        velocityContext),
+                        velocityContext);
         context.setAttribute(APP_CONTEXT_KEY, wireMockApp);
         context.setAttribute(StubRequestHandler.class.getName(), stubRequestHandler);
         context.setAttribute(AdminRequestHandler.class.getName(), adminRequestHandler);

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -341,6 +341,11 @@ public class StandaloneAcceptanceTest {
         }
         fail("WireMock did not shut down");
     }
+    
+    @Test
+    public void templateIsRenderedWithRequestParamters() {
+    	
+    }
 
     private String contentsOfFirstFileNamedLike(String namePart) throws IOException {
         return Files.toString(firstFileWithNameLike(mappingsDirectory, namePart), UTF_8);

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.standalone.WireMockServerRunner;
 import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -32,11 +33,13 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mortbay.util.ajax.JSON;
 
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
@@ -211,12 +214,55 @@ public class StandaloneAcceptanceTest {
 		"	}												\n" +
 		"}													";
 	
+	private static final String BODY_FILE_TEMPLATE_MAPPING_REQUEST =
+			"{ 																\n" +
+			"	\"request\": {												\n" +
+			"		\"method\": \"GET\",									\n" +
+			"		\"url\": \"/body/file?param1=value&param2=value2\"		\n" +
+			"	},															\n" +
+			"	\"response\": {												\n" +
+			"		\"status\": 200,										\n" +
+			"		\"bodyFileName\": \"body-template-test.vm\"				\n" +
+			"	}															\n" +
+			"}																";
+	
+	private static final String BODY_FILE_TEMPLATE_RESPONSE = 
+			"{																			\n" +
+		    "	\"stdProp\":\"stdValue\", 												\n" +
+		    "	\"requestAbsoluteUrl\" : \"$requestAbsoluteUrl.split('/')[2]\", 		\n" +
+		    "	\"requestMethod\" : \"$requestMethod\",									\n" +
+		    "	\"requestHeaderHost\" : \"$requestHeaderHost\",							\n" +
+		    "	\"requestHeaderUser-Agent\" : \"$requestHeaderUser-Agent\",				\n" +
+		    "	\"requestHeaderAccept-Encoding\" : \"$requestHeaderAccept-Encoding\",	\n" +
+		    "	\"requestHeaderConnection\" : \"$requestHeaderConnection\"				\n" +
+		    "}																			";
+	
 	@Test
 	public void readsBodyFileFromFilesDir() {
 		writeMappingFile("test-mapping-2.json", BODY_FILE_MAPPING_REQUEST);
 		writeFileToFilesDir("body-test.xml", "<body>Content</body>");
 		startRunner();
 		assertThat(testClient.get("/body/file").content(), is("<body>Content</body>"));
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void readsBodyFileTemplateFromFilesDir() {
+		writeMappingFile("test-template-mapping.json", BODY_FILE_TEMPLATE_MAPPING_REQUEST);
+		writeFileToFilesDir("body-template-test.vm", BODY_FILE_TEMPLATE_RESPONSE);
+		startRunner();
+		final WireMockResponse response = testClient.get("/body/file?param1=value&param2=value2");
+		LinkedHashMap<String,String> map = Json.read(response.content(), LinkedHashMap.class);
+		final String requestAbsoluteUrl = map.get("requestAbsoluteUrl");
+		final String requestMethod = map.get("requestMethod");
+		final String requestHeaderHost = map.get("requestHeaderHost");
+		final String requestHeaderAcceptEncoding = map.get("requestHeaderAccept-Encoding");
+		final String requestHeaderConnection = map.get("requestHeaderConnection");
+		assertThat(requestAbsoluteUrl, is("localhost:8080"));
+		assertThat(requestMethod, is("GET"));
+		assertThat(requestHeaderHost, is("[localhost:8080]"));
+		assertThat(requestHeaderAcceptEncoding, is("[gzip,deflate]"));
+		assertThat(requestHeaderConnection, is("[Keep-Alive]"));
 	}
 
     @Test
@@ -342,11 +388,6 @@ public class StandaloneAcceptanceTest {
         fail("WireMock did not shut down");
     }
     
-    @Test
-    public void templateIsRenderedWithRequestParamters() {
-    	
-    }
-
     private String contentsOfFirstFileNamedLike(String namePart) throws IOException {
         return Files.toString(firstFileWithNameLike(mappingsDirectory, namePart), UTF_8);
     }


### PR DESCRIPTION
Hi Tom , hope all is well. 

Recently I had the need to support parametrization in stubbed service calls. Essentially I was stubbing part of a user registration flow and using JMeter to help load test.The flow requires a unique user guid to be passed in, and it in turn does a look up on this id, and generates a hash derived from the guid passed via the request. Because I am using an incrementer from within a JMeter plan and invoking tens of thousands of requests concurrently, I was having to generate tens of thousands of mocks. A wild card, catch all response mapping would not work in this scenario.

I added in support for Velocity templates. The request is processed in the handler , and stored in a context object. Before the response is rendered , I do a check to see if the body file is of type .vm , if so the context object is merged with template, and I can process or extrapolate information from the request into the response dynamically. 

Thought perhaps this may benefit others.

Cheers !
-adam