### PR TITLE
Jetty options: acceptors and accept queue size

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
@@ -1,0 +1,59 @@
+package com.github.tomakehurst.wiremock.common;
+
+/**
+ * Exposed Jetty tuning options. See: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/server/AbstractConnector.html
+ */
+public class JettySettings {
+    private final int acceptors;
+    private final int acceptQueueSize;
+
+    public JettySettings(int acceptors, int acceptQueueSize) {
+        this.acceptors = acceptors;
+        this.acceptQueueSize = acceptQueueSize;
+    }
+
+    public int getAcceptors() {
+        return acceptors;
+    }
+
+    public int getAcceptQueueSize() {
+        return acceptQueueSize;
+    }
+
+    @Override
+    public String toString() {
+        return "JettySettings{" +
+                "acceptors=" + acceptors +
+                ", acceptQueueSize=" + acceptQueueSize +
+                '}';
+    }
+
+    public static class Builder {
+        private int acceptors;
+        private int acceptQueueSize;
+
+        private Builder() {
+        }
+
+        public static Builder aJettySettings() {
+            return new Builder();
+        }
+
+        public Builder withAcceptors(int acceptors) {
+            this.acceptors = acceptors;
+            return this;
+        }
+
+        public Builder withAcceptQueueSize(int acceptQueueSize) {
+            this.acceptQueueSize = acceptQueueSize;
+            return this;
+        }
+
+        public JettySettings build() {
+            JettySettings jettySettings = new JettySettings(acceptors, acceptQueueSize);
+            return jettySettings;
+        }
+    }
+
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
@@ -1,22 +1,24 @@
 package com.github.tomakehurst.wiremock.common;
 
+import com.google.common.base.Optional;
+
 /**
  * Exposed Jetty tuning options. See: http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/server/AbstractConnector.html
  */
 public class JettySettings {
-    private final int acceptors;
-    private final int acceptQueueSize;
+    private final Optional<Integer> acceptors;
+    private final Optional<Integer> acceptQueueSize;
 
-    public JettySettings(int acceptors, int acceptQueueSize) {
+    private JettySettings(Optional<Integer> acceptors, Optional<Integer> acceptQueueSize) {
         this.acceptors = acceptors;
         this.acceptQueueSize = acceptQueueSize;
     }
 
-    public int getAcceptors() {
+    public Optional<Integer> getAcceptors() {
         return acceptors;
     }
 
-    public int getAcceptQueueSize() {
+    public Optional<Integer> getAcceptQueueSize() {
         return acceptQueueSize;
     }
 
@@ -29,8 +31,8 @@ public class JettySettings {
     }
 
     public static class Builder {
-        private int acceptors;
-        private int acceptQueueSize;
+        private Integer acceptors;
+        private Integer acceptQueueSize;
 
         private Builder() {
         }
@@ -39,18 +41,18 @@ public class JettySettings {
             return new Builder();
         }
 
-        public Builder withAcceptors(int acceptors) {
+        public Builder withAcceptors(Integer acceptors) {
             this.acceptors = acceptors;
             return this;
         }
 
-        public Builder withAcceptQueueSize(int acceptQueueSize) {
+        public Builder withAcceptQueueSize(Integer acceptQueueSize) {
             this.acceptQueueSize = acceptQueueSize;
             return this;
         }
 
         public JettySettings build() {
-            JettySettings jettySettings = new JettySettings(acceptors, acceptQueueSize);
+            JettySettings jettySettings = new JettySettings(Optional.fromNullable(acceptors), Optional.fromNullable(acceptQueueSize));
             return jettySettings;
         }
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -17,10 +17,7 @@ package com.github.tomakehurst.wiremock.core;
 
 import java.util.List;
 
-import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.common.HttpsSettings;
-import com.github.tomakehurst.wiremock.common.Notifier;
-import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.google.common.base.Optional;
 
@@ -32,6 +29,7 @@ public interface Options {
 
     int portNumber();
     HttpsSettings httpsSettings();
+    JettySettings jettySettings();
     int containerThreads();
     boolean browserProxyingEnabled();
     ProxySettings proxyVia();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -49,6 +49,8 @@ public class WireMockConfiguration implements Options {
 
     private boolean preserveHostHeader;
     private String proxyHostHeader;
+    private int jettyAcceptors;
+    private int jettyAcceptQueueSize;
 
     public static WireMockConfiguration wireMockConfig() {
         return new WireMockConfiguration();
@@ -66,6 +68,16 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration containerThreads(Integer containerThreads) {
         this.containerThreads = containerThreads;
+        return this;
+    }
+
+    public WireMockConfiguration jettyAcceptors(Integer jettyAcceptors) {
+        this.jettyAcceptors = jettyAcceptors;
+        return this;
+    }
+
+    public WireMockConfiguration jettyAcceptQueueSize(Integer jettyAcceptQueueSize) {
+        this.jettyAcceptQueueSize = jettyAcceptQueueSize;
         return this;
     }
 
@@ -187,7 +199,10 @@ public class WireMockConfiguration implements Options {
 
     @Override
     public JettySettings jettySettings() {
-        return null;
+        return JettySettings.Builder.aJettySettings()
+                .withAcceptors(jettyAcceptors)
+                .withAcceptQueueSize(jettyAcceptQueueSize)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -186,6 +186,11 @@ public class WireMockConfiguration implements Options {
     }
 
     @Override
+    public JettySettings jettySettings() {
+        return null;
+    }
+
+    @Override
     public boolean browserProxyingEnabled() {
         return browserProxyingEnabled;
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -49,8 +49,8 @@ public class WireMockConfiguration implements Options {
 
     private boolean preserveHostHeader;
     private String proxyHostHeader;
-    private int jettyAcceptors;
-    private int jettyAcceptQueueSize;
+    private Integer jettyAcceptors;
+    private Integer jettyAcceptQueueSize;
 
     public static WireMockConfiguration wireMockConfig() {
         return new WireMockConfiguration();

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -58,6 +58,7 @@ public class CommandLineOptions implements Options {
     private static final String ENABLE_BROWSER_PROXYING = "enable-browser-proxying";
     private static final String DISABLE_REQUEST_JOURNAL = "no-request-journal";
     private static final String MAX_ENTRIES_REQUEST_JOURNAL = "max-request-journal-entries";
+    private static final String JETTY_ACCEPTOR_THREAD_COUNT = "jetty-acceptor-threads";
     private static final String ROOT_DIR = "root-dir";
     private static final String CONTAINER_THREADS = "container-threads";
 
@@ -85,6 +86,7 @@ public class CommandLineOptions implements Options {
 		optionParser.accepts(ENABLE_BROWSER_PROXYING, "Allow wiremock to be set as a browser's proxy server");
         optionParser.accepts(DISABLE_REQUEST_JOURNAL, "Disable the request journal (to avoid heap growth when running wiremock for long periods without reset)");
         optionParser.accepts(MAX_ENTRIES_REQUEST_JOURNAL, "Set maximum number of entries in request journal (if enabled) to discard old entries if the log becomes too large. Default: no discard").withRequiredArg();
+        optionParser.accepts(JETTY_ACCEPTOR_THREAD_COUNT, "Number of Jetty acceptor threads").withRequiredArg();
 		optionParser.accepts(HELP, "Print this message");
 		
 		optionSet = optionParser.parse(args);
@@ -165,6 +167,13 @@ public class CommandLineOptions implements Options {
                 .trustStorePath((String) optionSet.valueOf(HTTPS_TRUSTSTORE))
                 .trustStorePassword((String) optionSet.valueOf(HTTPS_TRUSTSTORE_PASSWORD))
                 .needClientAuth(optionSet.has(REQUIRE_CLIENT_CERT)).build();
+    }
+
+    @Override
+    public JettySettings jettySettings() {
+        return JettySettings.Builder.aJettySettings()
+                .withAcceptors(Integer.parseInt((String) optionSet.valueOf(JETTY_ACCEPTOR_THREAD_COUNT)))
+                .build();
     }
 
     private int httpsPortNumber() {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -59,6 +59,7 @@ public class CommandLineOptions implements Options {
     private static final String DISABLE_REQUEST_JOURNAL = "no-request-journal";
     private static final String MAX_ENTRIES_REQUEST_JOURNAL = "max-request-journal-entries";
     private static final String JETTY_ACCEPTOR_THREAD_COUNT = "jetty-acceptor-threads";
+    private static final String JETTY_ACCEPT_QUEUE_SIZE = "jetty-accept-queue-size";
     private static final String ROOT_DIR = "root-dir";
     private static final String CONTAINER_THREADS = "container-threads";
 
@@ -87,6 +88,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(DISABLE_REQUEST_JOURNAL, "Disable the request journal (to avoid heap growth when running wiremock for long periods without reset)");
         optionParser.accepts(MAX_ENTRIES_REQUEST_JOURNAL, "Set maximum number of entries in request journal (if enabled) to discard old entries if the log becomes too large. Default: no discard").withRequiredArg();
         optionParser.accepts(JETTY_ACCEPTOR_THREAD_COUNT, "Number of Jetty acceptor threads").withRequiredArg();
+        optionParser.accepts(JETTY_ACCEPT_QUEUE_SIZE, "The size of Jetty's accept queue size").withRequiredArg();
 		optionParser.accepts(HELP, "Print this message");
 		
 		optionSet = optionParser.parse(args);
@@ -171,9 +173,17 @@ public class CommandLineOptions implements Options {
 
     @Override
     public JettySettings jettySettings() {
-        return JettySettings.Builder.aJettySettings()
-                .withAcceptors(Integer.parseInt((String) optionSet.valueOf(JETTY_ACCEPTOR_THREAD_COUNT)))
-                .build();
+        JettySettings.Builder builder = JettySettings.Builder.aJettySettings();
+
+        if (optionSet.hasArgument(JETTY_ACCEPTOR_THREAD_COUNT)) {
+            builder = builder.withAcceptors(Integer.parseInt((String) optionSet.valueOf(JETTY_ACCEPTOR_THREAD_COUNT)));
+        }
+
+        if (optionSet.hasArgument(JETTY_ACCEPT_QUEUE_SIZE)) {
+            builder = builder.withAcceptQueueSize(Integer.parseInt((String) optionSet.valueOf(JETTY_ACCEPT_QUEUE_SIZE)));
+        }
+
+        return builder.build();
     }
 
     private int httpsPortNumber() {

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -203,6 +203,12 @@ public class CommandLineOptionsTest {
         assertThat(options.jettySettings().getAcceptors(), is(400));
     }
 
+    @Test
+    public void returnsCorrectlyParsedJettyAcceptQueueSize() {
+        CommandLineOptions options = new CommandLineOptions("--jetty-accept-queue-size", "10");
+        assertThat(options.jettySettings().getAcceptQueueSize(), is(10));
+    }
+
     @Test(expected=IllegalArgumentException.class)
     public void preventsRecordingWhenRequestJournalDisabled() {
         new CommandLineOptions("--no-request-journal", "--record-mappings");

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -197,6 +197,12 @@ public class CommandLineOptionsTest {
         assertThat(options.containerThreads(), is(200));
     }
 
+    @Test
+    public void returnsCorrectlyParsedJettyAcceptorThreads() {
+        CommandLineOptions options = new CommandLineOptions("--jetty-acceptor-threads", "400");
+        assertThat(options.jettySettings().getAcceptors(), is(400));
+    }
+
     @Test(expected=IllegalArgumentException.class)
     public void preventsRecordingWhenRequestJournalDisabled() {
         new CommandLineOptions("--no-request-journal", "--record-mappings");

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -200,13 +200,25 @@ public class CommandLineOptionsTest {
     @Test
     public void returnsCorrectlyParsedJettyAcceptorThreads() {
         CommandLineOptions options = new CommandLineOptions("--jetty-acceptor-threads", "400");
-        assertThat(options.jettySettings().getAcceptors(), is(400));
+        assertThat(options.jettySettings().getAcceptors().get(), is(400));
     }
 
     @Test
     public void returnsCorrectlyParsedJettyAcceptQueueSize() {
         CommandLineOptions options = new CommandLineOptions("--jetty-accept-queue-size", "10");
-        assertThat(options.jettySettings().getAcceptQueueSize(), is(10));
+        assertThat(options.jettySettings().getAcceptQueueSize().get(), is(10));
+    }
+
+    @Test
+    public void returnsAbsentIfJettyAcceptQueueSizeNotSet() {
+        CommandLineOptions options = new CommandLineOptions();
+        assertThat(options.jettySettings().getAcceptQueueSize().isPresent(), is(false));
+    }
+
+    @Test
+    public void returnsAbsentIfJettyAcceptorsNotSet() {
+        CommandLineOptions options = new CommandLineOptions();
+        assertThat(options.jettySettings().getAcceptors().isPresent(), is(false));
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
Two options we override when using wiremock for load tests