### PR TITLE
Dynamic port allocation during tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
 test {
     // Set the timezone for testing somewhere other than my machine to increase the chances of catching timezone bugs
     systemProperty 'user.timezone', 'Australia/Sydney'
+
+    maxParallelForks = 1
 }
 
 buildscript {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-bin.zip

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -135,6 +135,10 @@ public class HttpAdminClient implements Admin {
         postJsonAssertOkAndReturnBody(urlFor(ShutdownServerTask.class), null, HTTP_OK);
     }
 
+    public int port() {
+        return port;
+    }
+
     private String postJsonAssertOkAndReturnBody(String url, String json, int expectedStatus) {
 		HttpPost post = new HttpPost(url);
 		try {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -335,6 +335,10 @@ public class WireMock {
         defaultInstance.addDelayBeforeProcessingRequests(milliseconds);
     }
 
+    public int port() {
+        return admin.port();
+    }
+
     public void shutdown() {
         admin.shutdownServer();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -45,6 +45,10 @@ public class WireMock {
         this.admin = admin;
     }
 
+    public WireMock(int port) {
+        this(DEFAULT_HOST, port);
+    }
+
     public WireMock(String host, int port) {
 		admin = new HttpAdminClient(host, port);
 	}
@@ -68,7 +72,11 @@ public class WireMock {
     public static ListStubMappingsResult listAllStubMappings() {
         return defaultInstance.allStubMappings();
     }
-	
+
+    public static void configureFor(int port) {
+        defaultInstance = new WireMock(port);
+    }
+
 	public static void configureFor(String host, int port) {
 		defaultInstance = new WireMock(host, port);
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -37,5 +37,6 @@ public interface Admin {
     FindRequestsResult findRequestsMatching(RequestPattern requestPattern);
 	void updateGlobalSettings(GlobalSettings settings);
     void addSocketAcceptDelay(RequestDelaySpec spec);
+    int port();
     void shutdownServer();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Container.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Container.java
@@ -19,6 +19,9 @@ package com.github.tomakehurst.wiremock.core;
  * A container of a WireMockApp instance
  */
 public interface Container {
+
+    int port();
+
     /**
      * Shuts down the container, stopping execution of WireMock, gracefully if possible.
      */

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public interface Options {
 
     public static final int DEFAULT_PORT = 8080;
+    public static final int DYNAMIC_PORT = 0;
     public static final int DEFAULT_CONTAINER_THREADS = 200;
     public static final String DEFAULT_BIND_ADDRESS = "0.0.0.0";
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -182,6 +182,11 @@ public class WireMockApp implements StubServer, Admin {
     }
 
     @Override
+    public int port() {
+        return container.port();
+    }
+
+    @Override
     public void shutdownServer() {
         container.shutdown();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -70,8 +70,18 @@ public class WireMockConfiguration implements Options {
         return this;
     }
 
+    public WireMockConfiguration dynamicPort() {
+        this.portNumber = DYNAMIC_PORT;
+        return this;
+    }
+
     public WireMockConfiguration httpsPort(Integer httpsPort) {
         this.httpsPort = httpsPort;
+        return this;
+    }
+
+    public WireMockConfiguration dynamicHttpsPort() {
+        this.httpsPort = DYNAMIC_PORT;
         return this;
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
@@ -16,19 +16,14 @@
 package com.github.tomakehurst.wiremock.junit;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.MappingBuilder;
-import com.github.tomakehurst.wiremock.client.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.Options;
-import com.github.tomakehurst.wiremock.http.RequestListener;
-import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
-import java.util.List;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/NotImplementedContainer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/NotImplementedContainer.java
@@ -19,6 +19,11 @@ import com.github.tomakehurst.wiremock.core.Container;
 
 public class NotImplementedContainer implements Container {
     @Override
+    public int port() {
+        throw new UnsupportedOperationException("Server port number cannot be retrieved");
+    }
+
+    @Override
     public void shutdown() {
         throw new UnsupportedOperationException("Stopping the server is not supported");
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -104,6 +104,8 @@ public class WireMockServerRunner {
         return wireMockServer.isRunning();
     }
 
+    public int port() { return wireMockServer.port(); }
+
 	public static void main(String... args) {
 		new WireMockServerRunner().run(args);
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -24,7 +24,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 
 public class AcceptanceTestBase {
 
@@ -42,14 +41,14 @@ public class AcceptanceTestBase {
 	}
 
     public static void setupServer(WireMockConfiguration options) {
-        if(options.portNumber() == WireMockConfiguration.DEFAULT_PORT) {
-            options.port(findFreePort());
+        if(options.portNumber() == Options.DEFAULT_PORT) {
+            options.dynamicPort();
         }
 
         wireMockServer = new WireMockServer(options);
         wireMockServer.start();
-        testClient = new WireMockTestClient(options.portNumber());
-        WireMock.configureFor(options.portNumber());
+        testClient = new WireMockTestClient(wireMockServer.port());
+        WireMock.configureFor(wireMockServer.port());
     }
 
 	@Before

--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -17,12 +17,14 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 
 public class AcceptanceTestBase {
 
@@ -39,11 +41,15 @@ public class AcceptanceTestBase {
 		wireMockServer.stop();
 	}
 
-    public static void setupServer(Options options) {
+    public static void setupServer(WireMockConfiguration options) {
+        if(options.portNumber() == WireMockConfiguration.DEFAULT_PORT) {
+            options.port(findFreePort());
+        }
+
         wireMockServer = new WireMockServer(options);
         wireMockServer.start();
-        testClient = new WireMockTestClient();
-        WireMock.configure();
+        testClient = new WireMockTestClient(options.portNumber());
+        WireMock.configureFor(options.portNumber());
     }
 
 	@Before

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
@@ -39,9 +39,7 @@ public class MappingsLoaderAcceptanceTest {
 
 	@Before
 	public void init() {
-        int port = findFreePort();
-        configuration = wireMockConfig().port(port);
-        testClient = new WireMockTestClient(port);
+        configuration = wireMockConfig().dynamicPort();
 	}
 
 	@After
@@ -52,6 +50,7 @@ public class MappingsLoaderAcceptanceTest {
     private void buildWireMock(Options options) {
         wireMockServer = new WireMockServer(options);
         wireMockServer.start();
+        testClient = new WireMockTestClient(wireMockServer.port());
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsLoader;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -26,17 +27,21 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class MappingsLoaderAcceptanceTest {
-	
+
+    private WireMockConfiguration configuration;
 	private WireMockServer wireMockServer;
 	private WireMockTestClient testClient;
 
 	@Before
 	public void init() {
-		testClient = new WireMockTestClient();
+        int port = findFreePort();
+        configuration = wireMockConfig().port(port);
+        testClient = new WireMockTestClient(port);
 	}
 
 	@After
@@ -51,7 +56,7 @@ public class MappingsLoaderAcceptanceTest {
 
     @Test
 	public void mappingsLoadedFromJsonFiles() {
-        buildWireMock(wireMockConfig());
+        buildWireMock(configuration);
         wireMockServer.loadMappingsUsing(new JsonFileMappingsLoader(new SingleRootFileSource("src/test/resources/test-requests")));
 
 		WireMockResponse response = testClient.get("/canned/resource/1");
@@ -63,7 +68,7 @@ public class MappingsLoaderAcceptanceTest {
 
     @Test
     public void mappingsLoadedViaClasspath() {
-        buildWireMock(wireMockConfig().usingFilesUnderClasspath("classpath-filesource"));
+        buildWireMock(configuration.usingFilesUnderClasspath("classpath-filesource"));
         assertThat(testClient.get("/test").content(), is("THINGS!"));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -17,7 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.testsupport.TestHttpHeader;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
@@ -28,6 +28,8 @@ import org.junit.Test;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
+import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
+
 import static com.google.common.collect.Iterables.getLast;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -35,10 +37,8 @@ import static org.junit.Assert.assertThat;
 
 public class ProxyAcceptanceTest {
 
-    private static final int TARGET_SERVICE_PORT = 8087;
-    private static final int TARGET_SERVICE_HTTPS_PORT = 8487;
-    private static final String TARGET_SERVICE_BASE_URL = "http://localhost:" + TARGET_SERVICE_PORT;
-    private static final String TARGET_SERVICE_BASE_HTTPS_URL = "https://localhost:" + TARGET_SERVICE_HTTPS_PORT;
+    private String targetServiceBaseUrl;
+    private String targetServiceBaseHttpsUrl;
 
     WireMockServer targetService;
 	WireMock targetServiceAdmin;
@@ -48,15 +48,22 @@ public class ProxyAcceptanceTest {
 
     WireMockTestClient testClient;
 
-	void init(Options proxyingServiceOptions) {
-		targetService = new WireMockServer(wireMockConfig().port(TARGET_SERVICE_PORT).httpsPort(TARGET_SERVICE_HTTPS_PORT));
-		targetService.start();
-		targetServiceAdmin = new WireMock("localhost", TARGET_SERVICE_PORT);
+	void init(WireMockConfiguration proxyingServiceOptions) {
+        int targetServicePort = findFreePort();
+        int targetServiceHttpsPort = findFreePort();
+        targetServiceBaseUrl = "http://localhost:" + targetServicePort;
+        targetServiceBaseHttpsUrl = "https://localhost:" + targetServiceHttpsPort;
 
+		targetService = new WireMockServer(wireMockConfig().port(targetServicePort).httpsPort(targetServiceHttpsPort));
+		targetService.start();
+		targetServiceAdmin = new WireMock("localhost", targetServicePort);
+
+        int proxyPort = findFreePort();
+        proxyingServiceOptions.port(proxyPort);
         proxyingService = new WireMockServer(proxyingServiceOptions);
         proxyingService.start();
-        proxyingServiceAdmin = new WireMock();
-        testClient = new WireMockTestClient();
+        proxyingServiceAdmin = new WireMock(proxyPort);
+        testClient = new WireMockTestClient(proxyPort);
         WireMock.configure();
 	}
 
@@ -82,7 +89,7 @@ public class ProxyAcceptanceTest {
 
         proxyingServiceAdmin.register(any(urlEqualTo("/proxied/resource?param=value")).atPriority(10)
 				.willReturn(aResponse()
-				.proxiedFrom(TARGET_SERVICE_BASE_URL)));
+				.proxiedFrom(targetServiceBaseUrl)));
 		
 		WireMockResponse response = testClient.get("/proxied/resource?param=value");
 		
@@ -96,7 +103,7 @@ public class ProxyAcceptanceTest {
 
         proxyingServiceAdmin.register(any(urlEqualTo("/additional/headers")).atPriority(10)
 				.willReturn(aResponse()
-				.proxiedFrom(TARGET_SERVICE_BASE_URL)
+				.proxiedFrom(targetServiceBaseUrl)
                         .withAdditionalRequestHeader("a", "b")
                         .withAdditionalRequestHeader("c", "d")));
 
@@ -119,7 +126,7 @@ public class ProxyAcceptanceTest {
 
         proxyingServiceAdmin.register(any(urlEqualTo("/proxied/resource?param=value")).atPriority(10)
 				.willReturn(aResponse()
-				.proxiedFrom(TARGET_SERVICE_BASE_URL)
+				.proxiedFrom(targetServiceBaseUrl)
 				.withAdditionalRequestHeader("a", "b")));
 		
 		WireMockResponse response = testClient.get("/proxied/resource?param=value", 
@@ -138,7 +145,7 @@ public class ProxyAcceptanceTest {
 
         proxyingServiceAdmin.register(any(urlEqualTo("/proxied/resource")).atPriority(10)
 				.willReturn(aResponse()
-				.proxiedFrom(TARGET_SERVICE_BASE_URL)));
+				.proxiedFrom(targetServiceBaseUrl)));
 		
 		WireMockResponse response = testClient.postWithBody("/proxied/resource", "Post content", "text/plain", "utf-8");
 		
@@ -156,7 +163,7 @@ public class ProxyAcceptanceTest {
 
         proxyingServiceAdmin.register(any(urlEqualTo("/%26%26The%20Lord%20of%20the%20Rings%26%26")).atPriority(10)
                 .willReturn(aResponse()
-                        .proxiedFrom(TARGET_SERVICE_BASE_URL)));
+                        .proxiedFrom(targetServiceBaseUrl)));
 		
 		WireMockResponse response = testClient.get("/%26%26The%20Lord%20of%20the%20Rings%26%26");
 		
@@ -168,7 +175,7 @@ public class ProxyAcceptanceTest {
         initWithDefaultConfig();
 
         targetServiceAdmin.register(post(urlEqualTo("/with/length")).willReturn(aResponse().withStatus(201)));
-        proxyingServiceAdmin.register(post(urlEqualTo("/with/length")).willReturn(aResponse().proxiedFrom(TARGET_SERVICE_BASE_URL)));
+        proxyingServiceAdmin.register(post(urlEqualTo("/with/length")).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
         testClient.postWithBody("/with/length", "TEST", "application/x-www-form-urlencoded", "utf-8");
 
@@ -180,7 +187,7 @@ public class ProxyAcceptanceTest {
         initWithDefaultConfig();
 
         targetServiceAdmin.register(post(urlEqualTo("/chunked")).willReturn(aResponse().withStatus(201)));
-        proxyingServiceAdmin.register(post(urlEqualTo("/chunked")).willReturn(aResponse().proxiedFrom(TARGET_SERVICE_BASE_URL)));
+        proxyingServiceAdmin.register(post(urlEqualTo("/chunked")).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
         testClient.postWithChunkedBody("/chunked", "TEST".getBytes());
 
@@ -193,7 +200,7 @@ public class ProxyAcceptanceTest {
         init(wireMockConfig().preserveHostHeader(true));
 
         targetServiceAdmin.register(get(urlEqualTo("/preserve-host-header")).willReturn(aResponse().withStatus(200)));
-        proxyingServiceAdmin.register(get(urlEqualTo("/preserve-host-header")).willReturn(aResponse().proxiedFrom(TARGET_SERVICE_BASE_URL)));
+        proxyingServiceAdmin.register(get(urlEqualTo("/preserve-host-header")).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
         testClient.get("/preserve-host-header", withHeader("Host", "my.host"));
 
@@ -202,11 +209,11 @@ public class ProxyAcceptanceTest {
     }
 
     @Test
-    public void usesProxyUrlBasedHostHeaderWhenPreserveHostHeaderNotSpecified() {
+    public void usesProxyUrlBasedHostHeaderWhenPreserveHostHeaderNotSpecified() throws Exception {
         init(wireMockConfig().preserveHostHeader(false));
 
         targetServiceAdmin.register(get(urlEqualTo("/host-header")).willReturn(aResponse().withStatus(200)));
-        proxyingServiceAdmin.register(get(urlEqualTo("/host-header")).willReturn(aResponse().proxiedFrom(TARGET_SERVICE_BASE_URL)));
+        proxyingServiceAdmin.register(get(urlEqualTo("/host-header")).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
         testClient.get("/host-header", withHeader("Host", "my.host"));
 
@@ -219,7 +226,7 @@ public class ProxyAcceptanceTest {
         initWithDefaultConfig();
 
         targetServiceAdmin.register(patch(urlEqualTo("/patch")).willReturn(aResponse().withStatus(200)));
-        proxyingServiceAdmin.register(patch(urlEqualTo("/patch")).willReturn(aResponse().proxiedFrom(TARGET_SERVICE_BASE_URL)));
+        proxyingServiceAdmin.register(patch(urlEqualTo("/patch")).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
         testClient.patchWithBody("/patch", "Patch body", "text/plain", "utf-8");
 
@@ -239,7 +246,7 @@ public class ProxyAcceptanceTest {
         proxyingServiceAdmin.register(any(urlEqualTo("/extra/headers"))
                 .willReturn(aResponse()
                         .withHeader("X-Additional-Header", "Yep")
-                        .proxiedFrom(TARGET_SERVICE_BASE_URL)));
+                        .proxiedFrom(targetServiceBaseUrl)));
 
         WireMockResponse response = testClient.get("/extra/headers");
 
@@ -255,7 +262,7 @@ public class ProxyAcceptanceTest {
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Set-Cookie", "session=1234")));
-        proxyingServiceAdmin.register(get(urlEqualTo("/duplicate/cookies")).willReturn(aResponse().proxiedFrom(TARGET_SERVICE_BASE_URL)));
+        proxyingServiceAdmin.register(get(urlEqualTo("/duplicate/cookies")).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
 
         testClient.get("/duplicate/cookies");
         testClient.get("/duplicate/cookies", withHeader("Cookie", "session=1234"));
@@ -284,10 +291,13 @@ public class ProxyAcceptanceTest {
     }
 
     @Test
-    public void canProxyViaAForwardProxy() {
-        WireMockServer forwardProxy = new WireMockServer(wireMockConfig().port(8187).enableBrowserProxying(true));
+    public void canProxyViaAForwardProxy() throws Exception {
+        int proxyPort = findFreePort();
+        int wireMockPort = findFreePort();
+
+        WireMockServer forwardProxy = new WireMockServer(wireMockConfig().port(proxyPort).enableBrowserProxying(true));
         forwardProxy.start();
-        init(wireMockConfig().proxyVia(new ProxySettings("localhost", 8187)));
+        init(wireMockConfig().proxyVia(new ProxySettings("localhost", proxyPort)));
 
         register200StubOnProxyAndTarget("/proxy-via");
 
@@ -307,6 +317,6 @@ public class ProxyAcceptanceTest {
 
     private void register200StubOnProxyAndTarget(String url) {
         targetServiceAdmin.register(get(urlEqualTo(url)).willReturn(aResponse().withStatus(200)));
-        proxyingServiceAdmin.register(get(urlEqualTo(url)).willReturn(aResponse().proxiedFrom(TARGET_SERVICE_BASE_URL)));
+        proxyingServiceAdmin.register(get(urlEqualTo(url)).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestDelayAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestDelayAcceptanceTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.base.Stopwatch;
@@ -40,13 +41,10 @@ public class RequestDelayAcceptanceTest {
     private static final int SOCKET_TIMEOUT_MILLISECONDS = 500;
     private static final int LONGER_THAN_SOCKET_TIMEOUT = SOCKET_TIMEOUT_MILLISECONDS * 3;
 
-    private int httpPort = findFreePort();
-    private int httpsPort = findFreePort();
-
     private HttpClient httpClient;
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(httpPort, httpsPort);
+    public WireMockRule wireMockRule = new WireMockRule(Options.DYNAMIC_PORT, Options.DYNAMIC_PORT);
 
     @Before
     public void init() {
@@ -111,7 +109,7 @@ public class RequestDelayAcceptanceTest {
     }
 
     private void executeGetRequest(String protocol) throws IOException {
-        int port = protocol.equals("https") ? httpsPort : httpPort;
+        int port = protocol.equals("https") ? wireMockRule.httpsPort() : wireMockRule.port();
         String url = String.format("%s://localhost:%d/anything", protocol, port);
         HttpGet get = new HttpGet(url);
         httpClient.execute(get);

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestDelayAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestDelayAcceptanceTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
-import java.util.concurrent.TimeUnit;
 
+import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -39,13 +39,14 @@ public class RequestDelayAcceptanceTest {
 
     private static final int SOCKET_TIMEOUT_MILLISECONDS = 500;
     private static final int LONGER_THAN_SOCKET_TIMEOUT = SOCKET_TIMEOUT_MILLISECONDS * 3;
-    private static final int HTTP_PORT = 8080;
-    private static final int HTTPS_PORT = 8443;
+
+    private int httpPort = findFreePort();
+    private int httpsPort = findFreePort();
 
     private HttpClient httpClient;
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(HTTP_PORT, HTTPS_PORT);
+    public WireMockRule wireMockRule = new WireMockRule(httpPort, httpsPort);
 
     @Before
     public void init() {
@@ -110,7 +111,7 @@ public class RequestDelayAcceptanceTest {
     }
 
     private void executeGetRequest(String protocol) throws IOException {
-        int port = protocol.equals("https") ? HTTPS_PORT : HTTP_PORT;
+        int port = protocol.equals("https") ? httpsPort : httpPort;
         String url = String.format("%s://localhost:%d/anything", protocol, port);
         HttpGet get = new HttpGet(url);
         httpClient.execute(get);

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
+import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -240,7 +241,7 @@ public class VerificationAcceptanceTest {
     public static class JournalDisabled {
 
         @Rule
-        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().disableRequestJournal());
+        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(findFreePort()).disableRequestJournal());
 
         @Test(expected=RequestJournalDisabledException.class)
         public void verifyThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
@@ -255,11 +256,11 @@ public class VerificationAcceptanceTest {
 
     public static class JournalMaxEntriesRestricted {
         @Rule
-        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().maxRequestJournalEntries(Optional.of(2)));
+        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(findFreePort()).maxRequestJournalEntries(Optional.of(2)));
 
         @Test
         public void maxLengthIs2() {
-            WireMockTestClient testClient = new WireMockTestClient();
+            WireMockTestClient testClient = new WireMockTestClient(wireMockRule.port());
             testClient.get("/request1");
             testClient.get("/request2");
             testClient.get("/request3");

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -241,7 +241,7 @@ public class VerificationAcceptanceTest {
     public static class JournalDisabled {
 
         @Rule
-        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(findFreePort()).disableRequestJournal());
+        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().disableRequestJournal());
 
         @Test(expected=RequestJournalDisabledException.class)
         public void verifyThrowsExceptionWhenVerificationAttemptedAndRequestJournalDisabled() {
@@ -256,7 +256,7 @@ public class VerificationAcceptanceTest {
 
     public static class JournalMaxEntriesRestricted {
         @Rule
-        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(findFreePort()).maxRequestJournalEntries(Optional.of(2)));
+        public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().maxRequestJournalEntries(Optional.of(2)));
 
         @Test
         public void maxLengthIs2() {

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -38,7 +38,7 @@ public class WireMockServerTests {
 
     @Test
     public void instantiationWithEmptyFileSource() throws IOException {
-        Options options = new WireMockConfiguration().port(findFreePort()).fileSource(new SingleRootFileSource(tempDir.getRoot()));
+        Options options = new WireMockConfiguration().dynamicPort().fileSource(new SingleRootFileSource(tempDir.getRoot()));
 
         WireMockServer wireMockServer = null;
         try {
@@ -54,14 +54,13 @@ public class WireMockServerTests {
     // https://github.com/tomakehurst/wiremock/issues/193
     @Test
     public void supportsRecordingProgrammaticallyWithoutHeaderMatching() {
-        int port = findFreePort();
-        WireMockServer wireMockServer = new WireMockServer(port, new SingleRootFileSource(tempDir.getRoot()), false, new ProxySettings("proxy.company.com", port));
+        WireMockServer wireMockServer = new WireMockServer(Options.DYNAMIC_PORT, new SingleRootFileSource(tempDir.getRoot()), false, new ProxySettings("proxy.company.com", Options.DYNAMIC_PORT));
         wireMockServer.start();
         wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir.getRoot() + "/mappings"), new SingleRootFileSource(tempDir.getRoot() + "/__files"));
         wireMockServer.stubFor(get(urlEqualTo("/something")).willReturn(aResponse().withStatus(200)));
 
-        WireMockTestClient client = new WireMockTestClient(port);
-        assertThat(client.get("http://localhost:" + port + "/something").statusCode(), is(200));
+        WireMockTestClient client = new WireMockTestClient(wireMockServer.port());
+        assertThat(client.get("http://localhost:" + wireMockServer.port() + "/something").statusCode(), is(200));
     }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -27,6 +27,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -37,7 +38,7 @@ public class WireMockServerTests {
 
     @Test
     public void instantiationWithEmptyFileSource() throws IOException {
-        Options options = new WireMockConfiguration().fileSource(new SingleRootFileSource(tempDir.getRoot()));
+        Options options = new WireMockConfiguration().port(findFreePort()).fileSource(new SingleRootFileSource(tempDir.getRoot()));
 
         WireMockServer wireMockServer = null;
         try {
@@ -53,12 +54,14 @@ public class WireMockServerTests {
     // https://github.com/tomakehurst/wiremock/issues/193
     @Test
     public void supportsRecordingProgrammaticallyWithoutHeaderMatching() {
-        WireMockServer wireMockServer = new WireMockServer(8064, new SingleRootFileSource(tempDir.getRoot()), false, new ProxySettings("proxy.company.com", 8064));
+        int port = findFreePort();
+        WireMockServer wireMockServer = new WireMockServer(port, new SingleRootFileSource(tempDir.getRoot()), false, new ProxySettings("proxy.company.com", port));
         wireMockServer.start();
         wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir.getRoot() + "/mappings"), new SingleRootFileSource(tempDir.getRoot() + "/__files"));
         wireMockServer.stubFor(get(urlEqualTo("/something")).willReturn(aResponse().withStatus(200)));
 
-        WireMockTestClient client = new WireMockTestClient(8064);
-        assertThat(client.get("http://localhost:8064/something").statusCode(), is(200));
+        WireMockTestClient client = new WireMockTestClient(port);
+        assertThat(client.get("http://localhost:" + port + "/something").statusCode(), is(200));
     }
+
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.testsupport.Network.findFreePort;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -30,13 +31,16 @@ public class WireMockClientAcceptanceTest {
 	
 	private WireMockServer wireMockServer;
 	private WireMockTestClient testClient;
-	
+
+    private int port;
+
 	@Before
 	public void init() {
-		wireMockServer = new WireMockServer();
+        port = findFreePort();
+		wireMockServer = new WireMockServer(port);
 		wireMockServer.start();
-		WireMock.configure();
-		testClient = new WireMockTestClient();
+		WireMock.configureFor(port);
+		testClient = new WireMockTestClient(port);
 	}
 	
 	@After
@@ -46,7 +50,7 @@ public class WireMockClientAcceptanceTest {
 
 	@Test
 	public void buildsMappingWithUrlOnlyRequestAndStatusOnlyResponse() {
-		WireMock wireMock = new WireMock();
+		WireMock wireMock = new WireMock(port);
 		wireMock.register(
 				get(urlEqualTo("/my/new/resource"))
 				.willReturn(

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
 import org.junit.After;
 import org.junit.Before;
@@ -32,15 +33,12 @@ public class WireMockClientAcceptanceTest {
 	private WireMockServer wireMockServer;
 	private WireMockTestClient testClient;
 
-    private int port;
-
 	@Before
 	public void init() {
-        port = findFreePort();
-		wireMockServer = new WireMockServer(port);
+		wireMockServer = new WireMockServer(Options.DYNAMIC_PORT);
 		wireMockServer.start();
-		WireMock.configureFor(port);
-		testClient = new WireMockTestClient(port);
+		WireMock.configureFor(wireMockServer.port());
+		testClient = new WireMockTestClient(wireMockServer.port());
 	}
 	
 	@After
@@ -50,7 +48,7 @@ public class WireMockClientAcceptanceTest {
 
 	@Test
 	public void buildsMappingWithUrlOnlyRequestAndStatusOnlyResponse() {
-		WireMock wireMock = new WireMock(port);
+		WireMock wireMock = new WireMock(wireMockServer.port());
 		wireMock.register(
 				get(urlEqualTo("/my/new/resource"))
 				.willReturn(

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/Network.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/Network.java
@@ -1,0 +1,19 @@
+package com.github.tomakehurst.wiremock.testsupport;
+
+import java.net.ServerSocket;
+
+public class Network {
+
+    public static int findFreePort() {
+        try {
+            ServerSocket socket = new ServerSocket(0);
+            int result = socket.getLocalPort();
+            socket.close();
+
+            return result;
+        } catch(Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -81,7 +81,7 @@ public class WireMockTestClient {
     }
 
     public WireMockResponse getViaProxy(String url) {
-        return getViaProxy(url, DEFAULT_PORT);
+        return getViaProxy(url, port);
     }
 
     public WireMockResponse getViaProxy(String url, int proxyPort) {


### PR DESCRIPTION
Patch to use dynamically allocated ports during test run rather than using the defaults (8080/8443).