### PR TITLE
Added path to remove single mapping

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -294,6 +294,11 @@ public class WireMockServer implements Container, Stubbing, Admin {
     }
 
     @Override
+    public void removeStubMapping(StubMapping stubMapping) {
+        wireMockApp.removeStubMapping(stubMapping);
+    }
+
+    @Override
     public void resetToDefaultMappings() {
         wireMockApp.resetToDefaultMappings();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/AdminTasks.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/AdminTasks.java
@@ -35,6 +35,7 @@ public class AdminTasks {
                 .put(requestSpec(POST, "/scenarios/reset"), ResetScenariosTask.class)
                 .put(requestSpec(POST, "/mappings/save"), SaveMappingsTask.class)
                 .put(requestSpec(POST, "/mappings/reset"), ResetToDefaultMappingsTask.class)
+                .put(requestSpec(POST, "/mappings/remove"), RemoveStubMappingTask.class)
                 .put(requestSpec(POST, "/requests/count"), GetRequestCountTask.class)
                 .put(requestSpec(POST, "/requests/find"), FindRequestsTask.class)
                 .put(requestSpec(POST, "/socket-delay"), SocketDelayTask.class)

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/RemoveStubMappingTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/RemoveStubMappingTask.java
@@ -13,21 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.stubbing;
+package com.github.tomakehurst.wiremock.admin;
 
-
+import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
-import java.util.List;
+public class RemoveStubMappingTask implements AdminTask {
 
-public interface StubMappings {
-
-	ResponseDefinition serveFor(Request request);
-	void addMapping(StubMapping mapping);
-	void removeMapping(StubMapping mapping);
-	void reset();
-	void resetScenarios();
-
-    List<StubMapping> getAll();
+    @Override
+    public ResponseDefinition execute(Admin admin, Request request) {
+        StubMapping mapping = StubMapping.buildFrom(request.getBodyAsString());
+        admin.removeStubMapping(mapping);
+        return ResponseDefinition.ok();
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -69,6 +69,14 @@ public class HttpAdminClient implements Admin {
 	}
 
     @Override
+    public void removeStubMapping(StubMapping stubMapping) {
+        postJsonAssertOkAndReturnBody(
+                urlFor(RemoveStubMappingTask.class),
+                Json.write(stubMapping),
+                HTTP_OK);
+    }
+
+    @Override
     public ListStubMappingsResult listAllStubMappings() {
         String body = getJsonAssertOkAndReturnBody(
                 urlFor(RootTask.class),
@@ -85,8 +93,8 @@ public class HttpAdminClient implements Admin {
 	public void resetMappings() {
 		postJsonAssertOkAndReturnBody(urlFor(ResetTask.class), null, HTTP_OK);
 	}
-	
-	@Override
+
+    @Override
 	public void resetScenarios() {
         postJsonAssertOkAndReturnBody(urlFor(ResetScenariosTask.class), null, HTTP_OK);
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -96,7 +96,7 @@ public class WireMock {
 	public static void reset() {
 		defaultInstance.resetMappings();
 	}
-	
+
 	public void resetScenarios() {
 		admin.resetScenarios();
 	}
@@ -122,7 +122,11 @@ public class WireMock {
         admin.addStubMapping(mapping);
     }
 
-    public ListStubMappingsResult allStubMappings() {
+	public static void removeMapping(MappingBuilder mappingBuilder) {
+		defaultInstance.admin.removeStubMapping(mappingBuilder.build());
+	}
+
+	public ListStubMappingsResult allStubMappings() {
         return admin.listAllStubMappings();
     }
 	

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -15,8 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
-import java.util.List;
-
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.global.RequestDelaySpec;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
@@ -31,6 +29,7 @@ public interface Admin {
     ListStubMappingsResult listAllStubMappings();
     void saveMappings();
 	void resetMappings();
+    void removeStubMapping(StubMapping stubMapping);
 	void resetScenarios();
     void resetToDefaultMappings();
 	VerificationResult countRequestsMatching(RequestPattern requestPattern);

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -142,6 +142,11 @@ public class WireMockApp implements StubServer, Admin {
     }
 
     @Override
+    public void removeStubMapping(StubMapping stubMapping) {
+        stubMappings.removeMapping(stubMapping);
+    }
+
+    @Override
     public void resetToDefaultMappings() {
         resetMappings();
         loadDefaultMappings();

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
@@ -64,6 +64,11 @@ public class InMemoryStubMappings implements StubMappings {
 	}
 
 	@Override
+	public void removeMapping(StubMapping mapping) {
+		mappings.remove(mapping);
+	}
+
+	@Override
 	public void reset() {
 		mappings.clear();
         scenarioMap.clear();

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
@@ -37,7 +37,11 @@ public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
 				if (priorityComparison != 0) {
 					return priorityComparison;
 				}
-				
+
+				if (one.getInsertionIndex() == two.getInsertionIndex()) {
+					return 0;
+				}
+
 				return (two.getInsertionIndex() > one.getInsertionIndex()) ? 1 : -1;
 			}
 		};
@@ -60,5 +64,15 @@ public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
 	@Override
 	public String toString() {
 		return mappingSet.toString();
+	}
+
+	public void remove(StubMapping mappingToDelete) {
+		Iterator<StubMapping> mappings = mappingSet.iterator();
+		while(mappings.hasNext()) {
+			StubMapping mapping = mappings.next();
+			if (mapping.equalsIgnorePriorityAndInsertionCount(mappingToDelete)) {
+				mappingSet.remove(mapping);
+			}
+		}
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -203,6 +203,26 @@ public class StubMapping {
 
 	@Override
 	public boolean equals(Object obj) {
+		if (this.equalsIgnorePriorityAndInsertionCount(obj)) {
+			StubMapping other = (StubMapping) obj;
+			if (insertionIndex != other.insertionIndex) {
+				return false;
+			}
+
+			if (priority == null) {
+				if (other.priority != null) {
+					return false;
+				}
+			} else if (!priority.equals(other.priority)) {
+				return false;
+			}
+		} else {
+			return false;
+		}
+		return true;
+	}
+
+	public boolean equalsIgnorePriorityAndInsertionCount(Object obj) {
 		if (this == obj) {
 			return true;
 		}
@@ -213,21 +233,12 @@ public class StubMapping {
 			return false;
 		}
 		StubMapping other = (StubMapping) obj;
-		if (insertionIndex != other.insertionIndex) {
-			return false;
-		}
+
 		if (newScenarioState == null) {
 			if (other.newScenarioState != null) {
 				return false;
 			}
 		} else if (!newScenarioState.equals(other.newScenarioState)) {
-			return false;
-		}
-		if (priority == null) {
-			if (other.priority != null) {
-				return false;
-			}
-		} else if (!priority.equals(other.priority)) {
 			return false;
 		}
 		if (request == null) {
@@ -260,7 +271,5 @@ public class StubMapping {
 		}
 		return true;
 	}
-
-	
 	
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/Examples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/Examples.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock;
 
+import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -198,4 +199,16 @@ public class Examples extends AcceptanceTestBase {
             .willReturn(aResponse().withStatus(200)));
     }
 
+    @Test
+    public void removeSingleMapping() {
+        String path = "/whatever";
+        MappingBuilder mapping = get(urlEqualTo(path))
+                                .willReturn(aResponse().withStatus(200));
+        stubFor(mapping);
+
+        assertThat(testClient.get(path).statusCode(), is(200));
+
+        removeMapping(mapping);
+        assertThat(testClient.get(path).statusCode(), is(404));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -41,6 +41,7 @@ public class WireMockTestClient {
     private static final String LOCAL_WIREMOCK_NEW_RESPONSE_URL = "http://%s:%d/__admin/mappings/new";
     private static final String LOCAL_WIREMOCK_RESET_URL = "http://%s:%d/__admin/reset";
     private static final String LOCAL_WIREMOCK_RESET_DEFAULT_MAPPINS_URL = "http://%s:%d/__admin/mappings/reset";
+    private static final String LOCAL_WIREMOCK_REMOVE_MAPPING = "http://%s:%d/__admin/mappings/remove";
 
     private int port;
     private String address;
@@ -163,16 +164,12 @@ public class WireMockTestClient {
 
     public void resetMappings() {
         int status = postEmptyBodyAndReturnStatus(resetUrl());
-        if (status != HTTP_OK) {
-            throw new RuntimeException("Returned status code was " + status);
-        }
+        verifyOkStatus(status);
     }
 
     public void resetDefaultMappings() {
         int status = postEmptyBodyAndReturnStatus(resetDefaultMappingsUrl());
-        if (status != HTTP_OK) {
-            throw new RuntimeException("Returned status code was " + status);
-        }
+        verifyOkStatus(status);
     }
 
     private int postJsonAndReturnStatus(String url, String json) {
@@ -214,5 +211,17 @@ public class WireMockTestClient {
                 .disableRedirectHandling()
                 .disableContentCompression()
                 .build();
+    }
+
+    public void removeMapping(String url, String responseTemplate) {
+        String resetUrl = String.format(LOCAL_WIREMOCK_REMOVE_MAPPING, address, port);
+        int status = postJsonAndReturnStatus(resetUrl, String.format(responseTemplate, url));
+        verifyOkStatus(status);
+    }
+
+    private void verifyOkStatus(int status) {
+        if (status != HTTP_OK) {
+            throw new RuntimeException("Returned status code was " + status);
+        }
     }
 }


### PR DESCRIPTION
I have mix feeling about this. On the one hand, I don't think it is a good practice. It is adding state to Wiremock that doesn't need to be. But in my current situation, I need wiremock to act as an external service to write acceptance test for my service. 