### PR TITLE
Change JsonFileMappingsLoader.java to not exit wiremock due to bad json in mapping

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsLoader.java
@@ -23,6 +23,8 @@ import com.google.common.base.Predicate;
 
 import static com.google.common.collect.Iterables.filter;
 
+import static java.lang.System.out;
+
 public class JsonFileMappingsLoader implements MappingsLoader {
 
 	private final FileSource mappingsFileSource;
@@ -35,8 +37,16 @@ public class JsonFileMappingsLoader implements MappingsLoader {
 	public void loadMappingsInto(StubMappings stubMappings) {
 		JsonStubMappingCreator jsonStubMappingCreator = new JsonStubMappingCreator(stubMappings);
 		Iterable<TextFile> mappingFiles = filter(mappingsFileSource.listFilesRecursively(), byFileExtension("json"));
+		
+		//***Custom Changes here tedleman 1/7/15****
 		for (TextFile mappingFile: mappingFiles) {
-			jsonStubMappingCreator.addMappingFrom(mappingFile.readContentsAsString());
+			try{
+				jsonStubMappingCreator.addMappingFrom(mappingFile.readContentsAsString());
+			}catch(Exception e){
+				out.println("ERROR READING [skipped]: "+mappingFile.name());
+				out.println(e.getMessage());
+			}
+			
 		}
 	}
 	


### PR DESCRIPTION
Hi Tom,

I made a very simple change in JsonFileMappingsLoader.java to not exit wiremock if an exception is thrown due to bad json in a single mapping, instead printing the name of the mapping and error message to standard output. Wiremock would then launch without that mapping. Instead of uploading this small change to my company's internal repo, I was wondering if you would be willing to pull this change so that we can easily keep up with your updates in the future.

Thanks,
Troy