### PR TITLE
Fix binary data corruption when proxying requests

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -23,7 +23,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.entity.StringEntity;
+import org.apache.http.entity.ByteArrayEntity;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -163,10 +163,10 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
         if (originalRequest.containsHeader(TRANSFER_ENCODING) &&
                 originalRequest.header(TRANSFER_ENCODING).firstValue().equals("chunked")) {
-            return new InputStreamEntity(new ByteArrayInputStream(originalRequest.getBodyAsString().getBytes()), -1, contentType);
+            return new InputStreamEntity(new ByteArrayInputStream(originalRequest.getBody()), -1, contentType);
         }
 
-        return new StringEntity(originalRequest.getBodyAsString(), contentType);
+        return new ByteArrayEntity(originalRequest.getBody());
     }
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -29,6 +29,7 @@ public interface Request {
 	boolean containsHeader(String key);
 	Set<String> getAllHeaderKeys();
     QueryParameter queryParameter(String key);
+    byte[] getBody();
     String getBodyAsString();
 	boolean isBrowserProxyRequest();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HandlerDispatchingServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -122,7 +123,10 @@ public class Jetty6HandlerDispatchingServlet extends HttpServlet {
 
     private static void writeAndTranslateExceptions(HttpServletResponse httpServletResponse, byte[] content) {
         try {
-            httpServletResponse.getOutputStream().write(content);
+            ServletOutputStream out = httpServletResponse.getOutputStream();
+            out.write(content);
+            out.flush();
+            out.close();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HttpServletRequestAdapter.java
@@ -33,74 +33,80 @@ import static com.google.common.io.ByteStreams.toByteArray;
 import static java.util.Collections.list;
 
 public class Jetty6HttpServletRequestAdapter implements Request {
-	
-	private final HttpServletRequest request;
-	private String cachedBody;
-	private String urlPrefixToRemove;
+    
+    private final HttpServletRequest request;
+    private byte[] cachedBody;
+    private String urlPrefixToRemove;
 
-	public Jetty6HttpServletRequestAdapter(HttpServletRequest request) {
-		this.request = request;
-	}
+    public Jetty6HttpServletRequestAdapter(HttpServletRequest request) {
+        this.request = request;
+    }
 
-	public Jetty6HttpServletRequestAdapter(HttpServletRequest request, String urlPrefixToRemove) {
-		this.request = request;
-		this.urlPrefixToRemove = urlPrefixToRemove;
-	}
+    public Jetty6HttpServletRequestAdapter(HttpServletRequest request, String urlPrefixToRemove) {
+        this.request = request;
+        this.urlPrefixToRemove = urlPrefixToRemove;
+    }
 
-	@Override
-	public String getUrl() {
-		String url = request.getRequestURI();
+    @Override
+    public String getUrl() {
+        String url = request.getRequestURI();
 
-		String contextPath = request.getContextPath();
-		if (!isNullOrEmpty(contextPath) && url.startsWith(contextPath)) {
-			url = url.substring(contextPath.length());
-		}
-		if(!isNullOrEmpty(urlPrefixToRemove) && url.startsWith(urlPrefixToRemove)) {
-			url = url.substring(urlPrefixToRemove.length());
-		}
+        String contextPath = request.getContextPath();
+        if (!isNullOrEmpty(contextPath) && url.startsWith(contextPath)) {
+            url = url.substring(contextPath.length());
+        }
+        if(!isNullOrEmpty(urlPrefixToRemove) && url.startsWith(urlPrefixToRemove)) {
+            url = url.substring(urlPrefixToRemove.length());
+        }
 
-		return withQueryStringIfPresent(url);
-	}
-	
-	@Override
-	public String getAbsoluteUrl() {
-		return withQueryStringIfPresent(request.getRequestURL().toString());
-	}
+        return withQueryStringIfPresent(url);
+    }
+    
+    @Override
+    public String getAbsoluteUrl() {
+        return withQueryStringIfPresent(request.getRequestURL().toString());
+    }
 
     private String withQueryStringIfPresent(String url) {
         return url + (isNullOrEmpty(request.getQueryString()) ? "" : "?" + request.getQueryString());
     }
 
-	@Override
-	public RequestMethod getMethod() {
-		return RequestMethod.valueOf(request.getMethod().toUpperCase());
-	}
+    @Override
+    public RequestMethod getMethod() {
+        return RequestMethod.valueOf(request.getMethod().toUpperCase());
+    }
 
-	@Override
-	public String getBodyAsString() {
-		if (cachedBody == null) {
-			try {
-                cachedBody = new String(toByteArray(request.getInputStream()), UTF_8);
-			} catch (IOException ioe) {
-				throw new RuntimeException(ioe);
-			}
-		}
-		
-		return cachedBody;
-	}
+    @Override
+    public byte[] getBody() {
+        if (cachedBody == null) {
+            try {
+                cachedBody = toByteArray(request.getInputStream());
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+        }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public String getHeader(String key) {
-	    List<String> headerNames = list(request.getHeaderNames());
-		for (String currentKey: headerNames) {
-			if (currentKey.toLowerCase().equals(key.toLowerCase())) {
-				return request.getHeader(currentKey);
-			}
-		}
-		
-		return null;
-	}
+        return cachedBody;
+    }
+
+    @Override
+    public String getBodyAsString() {
+        byte[] body = getBody();
+        return new String(body, UTF_8);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public String getHeader(String key) {
+        List<String> headerNames = list(request.getHeaderNames());
+        for (String currentKey: headerNames) {
+            if (currentKey.toLowerCase().equals(key.toLowerCase())) {
+                return request.getHeader(currentKey);
+            }
+        }
+        
+        return null;
+    }
 
     @Override
     @SuppressWarnings("unchecked")
@@ -122,9 +128,9 @@ public class Jetty6HttpServletRequestAdapter implements Request {
     }
 
     @Override
-	public boolean containsHeader(String key) {
-		return header(key).isPresent();
-	}
+    public boolean containsHeader(String key) {
+        return header(key).isPresent();
+    }
 
     @Override
     public HttpHeaders getHeaders() {
@@ -137,15 +143,15 @@ public class Jetty6HttpServletRequestAdapter implements Request {
     }
 
     @SuppressWarnings("unchecked")
-	@Override
-	public Set<String> getAllHeaderKeys() {
-		LinkedHashSet<String> headerKeys = new LinkedHashSet<String>();
-		for (Enumeration<String> headerNames = request.getHeaderNames(); headerNames.hasMoreElements();) {
-			headerKeys.add(headerNames.nextElement());
-		}
-		
-		return headerKeys;
-	}
+    @Override
+    public Set<String> getAllHeaderKeys() {
+        LinkedHashSet<String> headerKeys = new LinkedHashSet<String>();
+        for (Enumeration<String> headerNames = request.getHeaderNames(); headerNames.hasMoreElements();) {
+            headerKeys.add(headerNames.nextElement());
+        }
+        
+        return headerKeys;
+    }
 
     @Override
     public QueryParameter queryParameter(String key) {
@@ -153,7 +159,7 @@ public class Jetty6HttpServletRequestAdapter implements Request {
     }
 
     @Override
-	public boolean isBrowserProxyRequest() {
+    public boolean isBrowserProxyRequest() {
         if (request instanceof org.mortbay.jetty.Request) {
             org.mortbay.jetty.Request jettyRequest = (org.mortbay.jetty.Request) request;
             URI uri = URI.create(jettyRequest.getUri().toString());

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -41,7 +41,7 @@ public class LoggedRequest implements Request {
 	private final RequestMethod method;
 	private final HttpHeaders headers;
     private final Map<String, QueryParameter> queryParams;
-	private final String body;
+	private final byte[] body;
 	private final boolean isBrowserProxyRequest;
     private final Date loggedDate;
 	
@@ -50,19 +50,18 @@ public class LoggedRequest implements Request {
                 request.getAbsoluteUrl(),
                 request.getMethod(),
                 copyOf(request.getHeaders()),
-                request.getBodyAsString(),
+                request.getBody(),
                 request.isBrowserProxyRequest(),
                 new Date());
 	}
 
-    @JsonCreator
-    public LoggedRequest(@JsonProperty("url") String url,
-                         @JsonProperty("absoluteUrl") String absoluteUrl,
-                         @JsonProperty("method") RequestMethod method,
-                         @JsonProperty("headers") HttpHeaders headers,
-                         @JsonProperty("body") String body,
-                         @JsonProperty("browserProxyRequest") boolean isBrowserProxyRequest,
-                         @JsonProperty("loggedDate") Date loggedDate) {
+    public LoggedRequest(String url,
+                         String absoluteUrl,
+                         RequestMethod method,
+                         HttpHeaders headers,
+                         byte[] body,
+                         boolean isBrowserProxyRequest,
+                         Date loggedDate) {
 
         this.url = url;
         this.absoluteUrl = absoluteUrl;
@@ -72,6 +71,17 @@ public class LoggedRequest implements Request {
         this.queryParams = splitQuery(URI.create(url));
         this.isBrowserProxyRequest = isBrowserProxyRequest;
         this.loggedDate = loggedDate;
+    }
+
+    @JsonCreator
+    public LoggedRequest(@JsonProperty("url") String url,
+                         @JsonProperty("absoluteUrl") String absoluteUrl,
+                         @JsonProperty("method") RequestMethod method,
+                         @JsonProperty("headers") HttpHeaders headers,
+                         @JsonProperty("body") String body,
+                         @JsonProperty("browserProxyRequest") boolean isBrowserProxyRequest,
+                         @JsonProperty("loggedDate") Date loggedDate) {
+        this(url, absoluteUrl, method, headers, body.getBytes(), isBrowserProxyRequest, loggedDate);
     }
 
 	@Override
@@ -115,10 +125,15 @@ public class LoggedRequest implements Request {
 		return getHeader(key) != null;
 	}
 
+    @Override
+    public byte[] getBody() {
+        return body;
+    }
+
 	@Override
     @JsonProperty("body")
 	public String getBodyAsString() {
-		return body;
+		return new String(body);
 	}
 
 	@Override

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -102,6 +102,7 @@ public class MockRequestBuilder {
             allowing(request).getHeaders(); will(returnValue(headers));
 			allowing(request).getAllHeaderKeys(); will(returnValue(newLinkedHashSet(headers.keys())));
 			allowing(request).containsHeader(with(any(String.class))); will(returnValue(false));
+			allowing(request).getBody(); will(returnValue(body.getBytes()));
 			allowing(request).getBodyAsString(); will(returnValue(body));
 			allowing(request).getAbsoluteUrl(); will(returnValue("http://localhost:8080" + url));
 			allowing(request).isBrowserProxyRequest(); will(returnValue(browserProxyRequest));


### PR DESCRIPTION
When proxying binary data, for instance Spring Remoting, byte[] to/from String conversion can corrupt data. This PR introduces getBody() method on the Request class and stores the raw bytes instead of bytes converted to String.
Also I found that writeAndTranslateExceptions does not flush/close the ServletOutputStream, so that was added.