### PR TITLE
NullPointerException when query params provided in actual request are missing when compared with expectations

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -356,7 +356,7 @@ public class RequestPattern {
                 ValuePattern valuePattern = entry.getValue();
                 String key = entry.getKey();
                 QueryParameter queryParam = request.queryParameter(key);
-                boolean match = queryParam.hasValueMatching(valuePattern);
+                boolean match = (queryParam != null ? queryParam.hasValueMatching(valuePattern) : false);
 
                 if (!match) {
                     notifier().info(String.format(

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternMatchesUrlTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternMatchesUrlTest.java
@@ -1,0 +1,65 @@
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.common.Urls;
+import com.github.tomakehurst.wiremock.http.HttpHeaders;
+import com.github.tomakehurst.wiremock.http.QueryParameter;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+public class RequestPatternMatchesUrlTest {
+
+    @Test
+    public void matchesByUrl() {
+        assertTrue(matchesOnUrl("/a/b/c", "/a/b/c"));
+    }
+
+    @Test
+    public void noMatchByUrl() {
+        assertFalse(matchesOnUrl("/a/b/c", "/a/b/d"));
+    }
+
+    @Test
+    public void matchesByQueryParam() {
+        assertTrue(matchesOnUrl("/a/b/c?x=1&y=2", "/a/b/c?x=1&y=2"));
+    }
+
+    @Test
+    public void noMatchByQueryParam() {
+        assertFalse(matchesOnUrl("/a/b/c?x=1&y=2", "/a/b/c?x=2&y=1"));
+    }
+
+    @Test
+    public void matchOnAdditionalQueryParam() {
+        assertTrue(matchesOnUrl("/a/b/c?x=1", "/a/b/c?x=1&y=2"));
+    }
+
+    @Test
+    public void noMatchOnMissingQueryParam() {
+        assertFalse(matchesOnUrl("/a/b/c?x=1&y=2", "/a/b/c?x=1"));
+    }
+
+    private static boolean matchesOnUrl(String expected, String actual) {
+        URI uri = URI.create(expected);
+        String path = uri.getRawPath();
+        Map<String, ValuePattern> params = new HashMap<String, ValuePattern>();
+        for (Map.Entry<String, QueryParameter> e: Urls.splitQuery(uri).entrySet()) {
+            params.put(e.getKey(), equalTo(e.getValue().firstValue()).asValuePattern());
+        }
+        RequestPattern reqPattern = new RequestPattern(RequestMethod.GET, null, new HashMap<String, ValuePattern>(), params);
+        reqPattern.setUrlPath(path);
+        LoggedRequest req = new LoggedRequest(actual, String.format("http://127.0.0.1:80%s", actual), RequestMethod.GET, HttpHeaders.noHeaders(), "", false, new Date());
+        return reqPattern.isMatchedBy(req);
+    }
+
+}


### PR DESCRIPTION
Hi, 

I've come across an issue where if I have a bunch of assertions such as:

            mock.register(
                    get(urlPathEqualTo("/a/b/c"))
                            .withQueryParam("x", equalTo("1"))
                            .withQueryParam("y", equalTo("2"))
                            .willReturn(
                                    aResponse()
                                            .withStatus(200)
                                            .withBody("")
                            )
            );
         
But then go on to put in a request such as :

            /a/b/c?x=1

Then I'd expect the case to not match. But because the query param "y" is missing from the actual request, I'm getting a NullPointerException from the expectations.

See the test RequestPatternMatchesUrlTest#noMatchOnMissingQueryParam for the specific case.

Hope that helps

Cheers