### PR TITLE
CLI flag to set Jetty's request header buffer size

### DIFF
--- a/docs/source/running-standalone.rst
+++ b/docs/source/running-standalone.rst
@@ -87,6 +87,9 @@ The number of threads Jetty uses for accepting requests.
 ``--jetty-accept-queue-size``:
 The Jetty queue size for accepted requests.
 
+``--jetty-header-buffer-size``:
+The Jetty buffer size for request headers, e.g. ``--jetty-header-buffer-size 16384``, defaults to 8192K.
+
 ``--extensions``:
 Extension class names e.g. com.mycorp.HeaderTransformer,com.mycorp.BodyTransformer. See :ref:`extending-wiremock`.
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
@@ -8,10 +8,14 @@ import com.google.common.base.Optional;
 public class JettySettings {
     private final Optional<Integer> acceptors;
     private final Optional<Integer> acceptQueueSize;
+    private final Optional<Integer> requestHeaderSize;
 
-    private JettySettings(Optional<Integer> acceptors, Optional<Integer> acceptQueueSize) {
+    private JettySettings(Optional<Integer> acceptors,
+                          Optional<Integer> acceptQueueSize,
+                          Optional<Integer> requestHeaderSize) {
         this.acceptors = acceptors;
         this.acceptQueueSize = acceptQueueSize;
+        this.requestHeaderSize = requestHeaderSize;
     }
 
     public Optional<Integer> getAcceptors() {
@@ -22,17 +26,23 @@ public class JettySettings {
         return acceptQueueSize;
     }
 
+    public Optional<Integer> getRequestHeaderSize() {
+        return requestHeaderSize;
+    }
+
     @Override
     public String toString() {
         return "JettySettings{" +
                 "acceptors=" + acceptors +
                 ", acceptQueueSize=" + acceptQueueSize +
+                ", requestHeaderSize=" + requestHeaderSize +
                 '}';
     }
 
     public static class Builder {
         private Integer acceptors;
         private Integer acceptQueueSize;
+        private Integer requestHeaderSize;
 
         private Builder() {
         }
@@ -51,9 +61,15 @@ public class JettySettings {
             return this;
         }
 
+        public Builder withRequestHeaderSize(Integer requestHeaderSize) {
+            this.requestHeaderSize = requestHeaderSize;
+            return this;
+        }
+
         public JettySettings build() {
-            JettySettings jettySettings = new JettySettings(Optional.fromNullable(acceptors), Optional.fromNullable(acceptQueueSize));
-            return jettySettings;
+            return new JettySettings(Optional.fromNullable(acceptors),
+                    Optional.fromNullable(acceptQueueSize),
+                    Optional.fromNullable(requestHeaderSize));
         }
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -58,6 +58,7 @@ public class WireMockConfiguration implements Options {
     private String proxyHostHeader;
     private Integer jettyAcceptors;
     private Integer jettyAcceptQueueSize;
+    private Integer jettyHeaderBufferSize;
 
     private Map<String, Extension> extensions = newLinkedHashMap();
 
@@ -97,6 +98,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration jettyAcceptQueueSize(Integer jettyAcceptQueueSize) {
         this.jettyAcceptQueueSize = jettyAcceptQueueSize;
+        return this;
+    }
+
+    public WireMockConfiguration jettyHeaderBufferSize(Integer jettyHeaderBufferSize) {
+        this.jettyHeaderBufferSize = jettyHeaderBufferSize;
         return this;
     }
 
@@ -236,6 +242,7 @@ public class WireMockConfiguration implements Options {
         return JettySettings.Builder.aJettySettings()
                 .withAcceptors(jettyAcceptors)
                 .withAcceptQueueSize(jettyAcceptQueueSize)
+                .withRequestHeaderSize(jettyHeaderBufferSize)
                 .build();
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HttpServer.java
@@ -58,7 +58,7 @@ class Jetty6HttpServer implements HttpServer {
             RequestDelayControl requestDelayControl
     ) {
 
-    	jettyServer = new Server();
+        jettyServer = new Server();
 
         QueuedThreadPool threadPool = new QueuedThreadPool(options.containerThreads());
         jettyServer.setThreadPool(threadPool);
@@ -146,7 +146,6 @@ class Jetty6HttpServer implements HttpServer {
         DelayableSocketConnector connector = new DelayableSocketConnector(requestDelayControl);
         connector.setHost(bindAddress);
         connector.setPort(port);
-        connector.setHeaderBufferSize(8192);
         setJettySettings(jettySettings, connector);
         return connector;
     }
@@ -157,7 +156,6 @@ class Jetty6HttpServer implements HttpServer {
             JettySettings jettySettings) {
         DelayableSslSocketConnector connector = new DelayableSslSocketConnector(requestDelayControl);
         connector.setPort(httpsSettings.port());
-        connector.setHeaderBufferSize(8192);
         connector.setKeystore(httpsSettings.keyStorePath());
         connector.setKeyPassword(httpsSettings.keyStorePassword());
 
@@ -179,6 +177,12 @@ class Jetty6HttpServer implements HttpServer {
         if (jettySettings.getAcceptQueueSize().isPresent()) {
             connector.setAcceptQueueSize(jettySettings.getAcceptQueueSize().get());
         }
+
+        int headerBufferSize = 8192;
+        if (jettySettings.getRequestHeaderSize().isPresent()) {
+            headerBufferSize = jettySettings.getRequestHeaderSize().get();
+        }
+        connector.setHeaderBufferSize(headerBufferSize);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked" })

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -64,6 +64,7 @@ public class CommandLineOptions implements Options {
     private static final String MAX_ENTRIES_REQUEST_JOURNAL = "max-request-journal-entries";
     private static final String JETTY_ACCEPTOR_THREAD_COUNT = "jetty-acceptor-threads";
     private static final String JETTY_ACCEPT_QUEUE_SIZE = "jetty-accept-queue-size";
+    private static final String JETTY_HEADER_BUFFER_SIZE = "jetty-header-buffer-size";
     private static final String ROOT_DIR = "root-dir";
     private static final String CONTAINER_THREADS = "container-threads";
 
@@ -94,7 +95,8 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(MAX_ENTRIES_REQUEST_JOURNAL, "Set maximum number of entries in request journal (if enabled) to discard old entries if the log becomes too large. Default: no discard").withRequiredArg();
         optionParser.accepts(JETTY_ACCEPTOR_THREAD_COUNT, "Number of Jetty acceptor threads").withRequiredArg();
         optionParser.accepts(JETTY_ACCEPT_QUEUE_SIZE, "The size of Jetty's accept queue size").withRequiredArg();
-		optionParser.accepts(HELP, "Print this message");
+        optionParser.accepts(JETTY_HEADER_BUFFER_SIZE, "The size of Jetty's buffer for request headers").withRequiredArg();
+        optionParser.accepts(HELP, "Print this message");
 		
 		optionSet = optionParser.parse(args);
         validate();
@@ -178,6 +180,7 @@ public class CommandLineOptions implements Options {
 
     @Override
     public JettySettings jettySettings() {
+
         JettySettings.Builder builder = JettySettings.Builder.aJettySettings();
 
         if (optionSet.hasArgument(JETTY_ACCEPTOR_THREAD_COUNT)) {
@@ -186,6 +189,10 @@ public class CommandLineOptions implements Options {
 
         if (optionSet.hasArgument(JETTY_ACCEPT_QUEUE_SIZE)) {
             builder = builder.withAcceptQueueSize(Integer.parseInt((String) optionSet.valueOf(JETTY_ACCEPT_QUEUE_SIZE)));
+        }
+
+        if (optionSet.hasArgument(JETTY_HEADER_BUFFER_SIZE)) {
+            builder = builder.withRequestHeaderSize(Integer.parseInt((String) optionSet.valueOf(JETTY_HEADER_BUFFER_SIZE)));
         }
 
         return builder.build();
@@ -312,6 +319,17 @@ public class CommandLineOptions implements Options {
         builder.put(DISABLE_REQUEST_JOURNAL, requestJournalDisabled())
                .put(VERBOSE, verboseLoggingEnabled());
 
+        if (jettySettings().getAcceptQueueSize().isPresent()) {
+            builder.put(JETTY_ACCEPT_QUEUE_SIZE, jettySettings().getAcceptQueueSize().get());
+        }
+
+        if (jettySettings().getAcceptors().isPresent()) {
+            builder.put(JETTY_ACCEPTOR_THREAD_COUNT, jettySettings().getAcceptors().get());
+        }
+
+        if (jettySettings().getRequestHeaderSize().isPresent()) {
+            builder.put(JETTY_HEADER_BUFFER_SIZE, jettySettings().getRequestHeaderSize().get());
+        }
 
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Object> param: builder.build().entrySet()) {

--- a/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
@@ -1,0 +1,45 @@
+package com.github.tomakehurst.wiremock.common;
+
+import com.google.common.base.Optional;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JettySettingsTest {
+
+    private static final int number = 1234;
+
+    @Test
+    public void testBuilderWithValues() {
+
+
+        JettySettings.Builder builder = JettySettings.Builder.aJettySettings();
+        builder.withAcceptors(number)
+                .withAcceptQueueSize(number)
+                .withRequestHeaderSize(number);
+        JettySettings jettySettings = builder.build();
+
+        ensurePresent(jettySettings.getAcceptors());
+        ensurePresent(jettySettings.getAcceptQueueSize());
+        ensurePresent(jettySettings.getRequestHeaderSize());
+    }
+
+    @Test
+    public void testBuilderWithNoValues() {
+
+
+        JettySettings.Builder builder = JettySettings.Builder.aJettySettings();
+        JettySettings jettySettings = builder.build();
+
+        assertFalse(jettySettings.getAcceptors().isPresent());
+        assertFalse(jettySettings.getAcceptQueueSize().isPresent());
+        assertFalse(jettySettings.getRequestHeaderSize().isPresent());
+    }
+
+    private void ensurePresent(Optional<Integer> optional) {
+        assertTrue(optional.isPresent());
+        assertEquals(new Integer(number), optional.get());
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -222,6 +222,12 @@ public class CommandLineOptionsTest {
     }
 
     @Test
+    public void returnsCorrectlyParsedJettyHeaderBufferSize() {
+        CommandLineOptions options = new CommandLineOptions("--jetty-header-buffer-size", "16384");
+        assertThat(options.jettySettings().getRequestHeaderSize().get(), is(16384));
+    }
+
+    @Test
     public void returnsAbsentIfJettyAcceptQueueSizeNotSet() {
         CommandLineOptions options = new CommandLineOptions();
         assertThat(options.jettySettings().getAcceptQueueSize().isPresent(), is(false));
@@ -231,6 +237,12 @@ public class CommandLineOptionsTest {
     public void returnsAbsentIfJettyAcceptorsNotSet() {
         CommandLineOptions options = new CommandLineOptions();
         assertThat(options.jettySettings().getAcceptors().isPresent(), is(false));
+    }
+
+    @Test
+    public void returnsAbsentIfJettyHeaderBufferSizeNotSet() {
+        CommandLineOptions options = new CommandLineOptions();
+        assertThat(options.jettySettings().getRequestHeaderSize().isPresent(), is(false));
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
My apps have very large Headers which were overflowing Jetty's
Request Header Buffer,  this resulted in response: 413 FULL head

To recreate the problem do any GET with a single header larger
than 9k or so.

Also added console output confirmation when Jetty related command
line flags are specified (there are 3 now total).  They previously
weren't output even when applied which leads to confusion.