### PR TITLE
Graceful shutdown when Jetty is stopped during a fixed response delay sleep

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -76,7 +76,7 @@ public class StubResponseRenderer implements ResponseRenderer {
 	        try {
 	            Thread.sleep(optionalDelay.get());
 	        } catch (InterruptedException e) {
-	            throw new RuntimeException(e);
+	            Thread.currentThread().interrupt();
 	        }
 	    }
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HandlerDispatchingServlet.java
@@ -96,6 +96,9 @@ public class Jetty6HandlerDispatchingServlet extends HttpServlet {
         notifier.info("Received request: " + httpServletRequest.toString());
 
 		Response response = requestHandler.handle(request);
+        if (Thread.currentThread().isInterrupted()) {
+            return;
+        }
 		if (response.wasConfigured()) {
 		    applyResponse(response, httpServletResponse);
 		} else if (request.getMethod() == GET && shouldForwardToFilesContext) {

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDelayAcceptanceTest.java
@@ -1,0 +1,60 @@
+package com.github.tomakehurst.wiremock;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.net.SocketTimeoutException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ResponseDelayAcceptanceTest {
+
+    private static final int SOCKET_TIMEOUT_MILLISECONDS = 500;
+    private static final int LONGER_THAN_SOCKET_TIMEOUT = SOCKET_TIMEOUT_MILLISECONDS * 2;
+    private static final int SHORTER_THAN_SOCKET_TIMEOUT = SOCKET_TIMEOUT_MILLISECONDS / 2;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(Options.DYNAMIC_PORT, Options.DYNAMIC_PORT);
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private HttpClient httpClient;
+
+    @Before
+    public void init() {
+        httpClient = HttpClientFactory.createClient(SOCKET_TIMEOUT_MILLISECONDS);
+    }
+
+    @Test
+    public void requestTimesOutWhenDelayIsLongerThanSocketTimeout() throws Exception {
+        stubFor(get(urlEqualTo("/delayed")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(LONGER_THAN_SOCKET_TIMEOUT)));
+
+        exception.expect(SocketTimeoutException.class);
+        httpClient.execute(new HttpGet(String.format("http://localhost:%d/delayed", wireMockRule.port())));
+    }
+
+    @Test
+    public void requestIsSuccessfulWhenDelayIsShorterThanSocketTimeout() throws Exception {
+        stubFor(get(urlEqualTo("/delayed")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(SHORTER_THAN_SOCKET_TIMEOUT)));
+
+        final HttpResponse execute = httpClient.execute(new HttpGet(String.format("http://localhost:%d/delayed", wireMockRule.port())));
+        assertThat(execute.getStatusLine().getStatusCode(), is(200));
+    }
+}


### PR DESCRIPTION
Hi Tom, 

when a fixed response delay is configured and Jetty shuts down while the Thread is sleeping, a RuntimeException is thrown. This happens in every unit test where the test finishes execution before the fixed delay is over. Although this behaviour is ok, it clutters the log with stacktraces. 

My suggestion provides a graceful shutdown without throwing exceptions as well as a basic acceptance test for configuring response delays. 