### PR TITLE
Add CORS header to Admin requests

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/BasicResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/BasicResponseRenderer.java
@@ -15,16 +15,34 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.github.tomakehurst.wiremock.http.Response.response;
 
 public class BasicResponseRenderer implements ResponseRenderer {
 
-	@Override
-	public Response render(ResponseDefinition responseDefinition) {
+    @Override
+    public Response render(ResponseDefinition responseDefinition) {
+
+        // Allows JavaScript Client access to Wiremock admin endpoints
+        // See: http://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+        HttpHeader corsHeader = new HttpHeader("Access-Control-Allow-Origin", "*");
+
+        List<HttpHeader> headersList;
+        HttpHeaders httpHeaders = responseDefinition.getHeaders();
+
+        if (httpHeaders != null) {
+            headersList = (ArrayList<HttpHeader>) responseDefinition.getHeaders().all();
+        } else {
+            headersList = new ArrayList<HttpHeader>();
+        }
+        headersList.add(corsHeader);
+
         return response()
                 .status(responseDefinition.getStatus())
-                .headers(responseDefinition.getHeaders())
+                .headers(new HttpHeaders(headersList))
                 .body(responseDefinition.getBody())
                 .build();
-	}
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
@@ -121,6 +121,20 @@ public class HttpHeaders {
         return result;
     }
 
+    @Override
+    public String toString() {
+        String outString = "HttpHeaders: ";
+
+        if (headers.isEmpty()) {
+            return outString += "[]";
+        }
+
+        for (CaseInsensitiveKey key : headers.keySet()) {
+            outString += key.toString() + ": " + headers.get(key).toString() + "\n";
+        }
+        return outString;
+    }
+
     private CaseInsensitiveKey caseInsensitive(String key) {
         return new CaseInsensitiveKey(key);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
@@ -135,4 +135,15 @@ public class HttpHeadersTest {
         assertThat(headers.getHeader("header-one").firstValue(), is("value 1"));
     }
 
+    @Test
+    public void toStringWhenHeadersPresent() {
+        HttpHeaders httpHeaders = new HttpHeaders(httpHeader("Test-Header", "value1", "value2"));
+        assertThat(httpHeaders.toString().contains("Test-Header"), is(true));
+    }
+
+    @Test
+    public void toStringWhenHeadersEmpty() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        assertThat(httpHeaders.toString().equals("HttpHeaders: []"), is(true));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(JMock.class)
 public class AdminRequestHandlerTest {
-	
 	private Mockery context;
 	private Admin admin;
 
@@ -77,7 +76,8 @@ public class AdminRequestHandlerTest {
 		Response response = handler.handle(request);
 		
 		assertThat(response.getStatus(), is(HTTP_CREATED));
-	}
+        verifyCorsHeader(response);
+    }
 
     @Test
     public void shouldSaveMappingsWhenSaveCalled() {
@@ -93,6 +93,7 @@ public class AdminRequestHandlerTest {
         Response response = handler.handle(request);
 
         assertThat(response.getStatus(), is(HTTP_OK));
+        verifyCorsHeader(response);
     }
 	
 	@Test
@@ -109,6 +110,7 @@ public class AdminRequestHandlerTest {
 		Response response = handler.handle(request);
 		
 		assertThat(response.getStatus(), is(HTTP_OK));
+        verifyCorsHeader(response);
 	}
 	
 	private static final String REQUEST_PATTERN_SAMPLE = 
@@ -132,7 +134,8 @@ public class AdminRequestHandlerTest {
 		
 		assertThat(response.getStatus(), is(HTTP_OK));
 		assertThat(response.getBodyAsString(), equalToJson("{ \"count\": 5, \"requestJournalDisabled\" : false}"));
-	}
+        verifyCorsHeader(response);
+    }
 	
 	private static final String GLOBAL_SETTINGS_JSON =
 		"{												\n" +
@@ -154,5 +157,9 @@ public class AdminRequestHandlerTest {
 				.build());
 		
 	}
-	
+
+    private void verifyCorsHeader(Response response) {
+        HttpHeader header = response.getHeaders().getHeader("Access-Control-Allow-Origin");
+        assertThat(header.values().get(0), is("*"));
+    }
 }


### PR DESCRIPTION
Allows JavaScript clients to stage, reset, etc. without getting
Cross Site Scripting Errors.

See: http://en.wikipedia.org/wiki/Cross-origin_resource_sharing