### PR TITLE
Fix UTF-8 encoding issue in LoggedRequest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'project-report'
 
 sourceCompatibility = 1.6
 group = 'com.github.tomakehurst'
-version = "1.54-fix-utf8"
+version = 1.54
 
 repositories {
 	mavenCentral()

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.base.Charsets;
-import com.google.common.base.Splitter;
 
 import java.net.URI;
 import java.text.SimpleDateFormat;
@@ -82,7 +81,7 @@ public class LoggedRequest implements Request {
                          @JsonProperty("body") String body,
                          @JsonProperty("browserProxyRequest") boolean isBrowserProxyRequest,
                          @JsonProperty("loggedDate") Date loggedDate) {
-        this(url, absoluteUrl, method, headers, body.getBytes(), isBrowserProxyRequest, loggedDate);
+        this(url, absoluteUrl, method, headers, body.getBytes(Charsets.UTF_8), isBrowserProxyRequest, loggedDate);
     }
 
 	@Override
@@ -134,7 +133,7 @@ public class LoggedRequest implements Request {
 	@Override
     @JsonProperty("body")
 	public String getBodyAsString() {
-		return new String(body, Charsets.UTF_8);
+        return new String(body, Charsets.UTF_8);
 	}
 
 	@Override

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -18,6 +18,8 @@ package com.github.tomakehurst.wiremock.verification;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.google.common.base.Charsets;
+
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
 import org.junit.Before;
@@ -32,11 +34,15 @@ import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static com.github.tomakehurst.wiremock.verification.LoggedRequest.createFrom;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.junit.Assert.*;
 
 @RunWith(JMock.class)
 public class LoggedRequestTest {
+
+    public static final String REQUEST_BODY = "some text 形声字形聲字";
 
     private Mockery context;
 
@@ -72,7 +78,7 @@ public class LoggedRequestTest {
             "      \"headers\" : {\n" +
             "        \"Accept-Language\" : \"en-us,en;q=0.5\"\n" +
             "      },\n" +
-            "      \"body\" : \"some text\",\n" +
+            "      \"body\" : \"" + REQUEST_BODY + "\",\n" +
             "      \"browserProxyRequest\" : true,\n" +
             "      \"loggedDate\" : %d,\n" +
             "      \"loggedDateString\" : \"" + DATE + "\"\n" +
@@ -89,12 +95,26 @@ public class LoggedRequestTest {
                 "http://mydomain.com/my/url",
                 RequestMethod.GET,
                 headers,
-                "some text",
+                REQUEST_BODY,
                 true,
                 loggedDate);
 
         String expectedJson = String.format(JSON_EXAMPLE, loggedDate.getTime());
         assertThat(Json.write(loggedRequest), equalToIgnoringWhiteSpace(expectedJson));
+    }
+
+    @Test
+    public void bodyEncodedAsUTF8() throws Exception {
+        LoggedRequest loggedRequest = new LoggedRequest(
+            "/my/url",
+            "http://mydomain.com/my/url",
+            RequestMethod.GET,
+            null,
+            REQUEST_BODY.getBytes(Charsets.UTF_8),
+            true,
+            null);
+
+        assertThat(loggedRequest.getBodyAsString(), is(equalTo(REQUEST_BODY)));
     }
 
     private Date parse(String dateString) throws Exception {


### PR DESCRIPTION
Setting the UTF-8 encoding for the request body in LoggedRequest. 

The verify method fails when the request contains non-Latin chars if the machine running the tests has a default charset other than UTF-8.

Fixed it by setting encoding of the String returned by getBodyAsString(), just like it is done in Jetty6HttpServletRequestAdapter.

Also removed some exception constructors that were failing compilation on Java 1.6.