### PR TITLE
Include trailing port information in host header when proxying.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -135,7 +135,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
                     if (hostHeaderValue != null) {
                         httpRequest.addHeader(key, hostHeaderValue);
                     } else if (response.getProxyBaseUrl() != null) {
-                        httpRequest.addHeader(key, URI.create(response.getProxyBaseUrl()).getHost());
+                        httpRequest.addHeader(key, URI.create(response.getProxyBaseUrl()).getAuthority());
                     }
                 }
 			}

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -227,7 +227,7 @@ public class CommandLineOptions implements Options {
 
     @Override
     public String proxyHostHeader() {
-       return optionSet.hasArgument(PROXY_ALL) ? URI.create((String) optionSet.valueOf(PROXY_ALL)).getHost() : null;
+       return optionSet.hasArgument(PROXY_ALL) ? URI.create((String) optionSet.valueOf(PROXY_ALL)).getAuthority() : null;
     }
 
     @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -261,7 +261,7 @@ public class ProxyAcceptanceTest {
         testClient.get("/host-header", withHeader("Host", "my.host"));
 
         proxyingServiceAdmin.verifyThat(getRequestedFor(urlEqualTo("/host-header")).withHeader("Host", equalTo("my.host")));
-        targetServiceAdmin.verifyThat(getRequestedFor(urlEqualTo("/host-header")).withHeader("Host", equalTo("localhost")));
+        targetServiceAdmin.verifyThat(getRequestedFor(urlEqualTo("/host-header")).withHeader("Host", equalTo("localhost:"+targetService.port())));
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -129,8 +129,14 @@ public class CommandLineOptionsTest {
 		assertThat(options.specifiesProxyUrl(), is(true));
 		assertThat(options.proxyUrl(), is("http://someotherhost.com/site"));
 	}
-	
-	@Test(expected=Exception.class)
+
+    @Test
+    public void setsProxyHostHeaderWithTrailingPortInformation() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-all", "http://someotherhost.com:8080/site");
+        assertThat(options.proxyHostHeader(), is("someotherhost.com:8080"));
+    }
+
+    @Test(expected=Exception.class)
 	public void throwsExceptionWhenProxyAllSpecifiedWithoutUrl() {
 		new CommandLineOptions("--proxy-all");
 	}


### PR DESCRIPTION
According to the HTTP/1.1 standard, the "host" header should include trailing port information. If left out, it implies the default port for the service requested (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23).

The changes in this pull request make WireMock adhere to this by always including trailing port information in the "host" header when proxying.