### PR TITLE
Fixes NPE when verifying an expected query parameter that is absent from the request

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 
@@ -355,8 +356,8 @@ public class RequestPattern {
             public boolean apply(Map.Entry<String, ValuePattern> entry) {
                 ValuePattern valuePattern = entry.getValue();
                 String key = entry.getKey();
-                QueryParameter queryParam = request.queryParameter(key);
-                boolean match = queryParam.hasValueMatching(valuePattern);
+                Optional<QueryParameter> queryParam = Optional.fromNullable(request.queryParameter(key));
+                boolean match = queryParam.isPresent() && queryParam.get().hasValueMatching(valuePattern);
 
                 if (!match) {
                     notifier().info(String.format(

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -160,6 +160,12 @@ public class VerificationAcceptanceTest {
         }
 
         @Test(expected=VerificationException.class)
+        public void verifyIsFalseWhenExpectedQueryParamMissing() {
+            testClient.get("/query");
+            verify(getRequestedFor(urlPathEqualTo("/query")).withQueryParam("param", equalTo("my-value")));
+        }
+
+        @Test(expected=VerificationException.class)
         public void resetErasesCounters() {
             testClient.get("/count/this");
             testClient.get("/count/this");


### PR DESCRIPTION
Hi Tom,

Similar issue to https://github.com/tomakehurst/wiremock/pull/233 but in the context of verifying. (That PR was not merged but fixed in 026ff48).

Story: 
When the RequestPatternBuilder used for verifying was configured with an expected query parameter that is absent from the request an NPE is thrown. The verification fails as expected but with a strange reason: "com.github.tomakehurst.wiremock.client.VerificationException: Expected status 200 for http://localhost:8080/management/wiremock/__admin/requests/count but was 500".

The PR provides a passing test that shows the NPE in the first commit and a suggested solution in the second commit.



