### PR TITLE
allow using single quotes for quoting Strings in JSON files

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -28,6 +28,7 @@ public final class Json {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+			mapper.configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
 			return mapper.readValue(json, clazz);
 		} catch (IOException ioe) {
 			throw new RuntimeException("Unable to bind JSON to object. Reason: " + ioe.getMessage() + "  JSON:" + json, ioe);

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
@@ -29,7 +29,12 @@ public class JsonTest {
 			"{                                          \n" +
                 "\"property\": \"" + TEST_VALUE + "\"   \n" +
             "}";
-	
+
+	private static final String JSON_WITH_SINGLE_QUOTES =
+			"{                                            \n" +
+				"'property': '" + TEST_VALUE + "'         \n" +
+			"}";
+
 	private static final String JSON_WITH_COMMENTS =
 			"// this is the first comment                                                   \n" +
             "{                                                                              \n" +
@@ -37,7 +42,7 @@ public class JsonTest {
                     "\"property\": \"" + TEST_VALUE + "\"// comment on same line as code    \n" +
             "}                                                                              \n" +
              "//this is the last comment";
-	
+
 	@Test
 	public void testReadNoComments() {
 		TestPojo pojo = Json.read(JSON_WITH_NO_COMMENTS, TestPojo.class);
@@ -48,6 +53,13 @@ public class JsonTest {
 	@Test
 	public void testReadWithComments() {
 		TestPojo pojo = Json.read(JSON_WITH_COMMENTS, TestPojo.class);
+		assertNotNull(pojo);
+		assertThat(TEST_VALUE, is(pojo.property));
+	}
+
+	@Test
+	public void testReadWithSingleQuotes() {
+		TestPojo pojo = Json.read(JSON_WITH_SINGLE_QUOTES, TestPojo.class);
 		assertNotNull(pojo);
 		assertThat(TEST_VALUE, is(pojo.property));
 	}


### PR DESCRIPTION
This PR allows you to use single quotes so that you don't have to escape double quotes (e.g. for JSON response body)