### PR TITLE
allow specifying response body as JSON

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.common;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public final class Json {
@@ -38,6 +39,15 @@ public final class Json {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(object);
+		} catch (IOException ioe) {
+			throw new RuntimeException("Unable to generate JSON from object. Reason: " + ioe.getMessage(), ioe);
+		}
+	}
+
+	public static byte[] toByteArray(Object object) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			return mapper.writeValueAsBytes(object);
 		} catch (IOException ioe) {
 			throw new RuntimeException("Unable to generate JSON from object. Reason: " + ioe.getMessage(), ioe);
 		}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
@@ -152,6 +153,11 @@ public class ResponseDefinition {
     public void setBase64Body(String base64Body) {
         isBinaryBody = true;
         body = parseBase64Binary(base64Body);
+    }
+
+    public void setJsonBody(JsonNode jsonBody) {
+        isBinaryBody = false;
+        body = Json.toByteArray(jsonBody);
     }
 
     // Needs to be explicitly marked as a property, since an overloaded setter with the same

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
@@ -124,6 +124,13 @@ public class MappingsAcceptanceTest extends AcceptanceTestBase {
         testClient.addResponse(MAPPING_REQUEST_FOR_BINARY_BYTE_BODY);
         assertThat(testClient.get("/bytecompressed/resource/from/file").binaryContent(), is(BINARY_COMPRESSED_CONTENT));
     }
+
+	@Test
+	public void readsJsonMapping() {
+		WireMockResponse response = testClient.get("/testjsonmapping");
+		assertThat(response.statusCode(), is(200));
+		assertThat(response.content(), is("{\"key\":\"value\",\"array\":[1,2,3]}"));
+	}
 	
 	private void getResponseAndAssert200Status(String url) {
 		WireMockResponse response = testClient.get(url);

--- a/src/test/resources/mappings/testjsonmapping.json
+++ b/src/test/resources/mappings/testjsonmapping.json
@@ -1,0 +1,16 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/testjsonmapping"
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "key": "value",
+      "array": [1, 2, 3]
+    },
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
Sometimes, when writing mappings as JSON, you want to mock a JSON response body. Having to escape the JSON inside the JSON can be a bit obnoxious, so this patch lets you specify a JSON object instead.

![270075](https://cloud.githubusercontent.com/assets/1211/8163204/bf6eb582-134f-11e5-8e69-a060763fa050.jpg)