### PR TITLE
Issue #288 Adds urlPathPattern matching strategy

### DIFF
--- a/docs/source/stubbing.rst
+++ b/docs/source/stubbing.rst
@@ -87,7 +87,7 @@ And in JSON via the ``urlPattern`` attribute:
     }
 
 
-Alternatively, just the path part of the URL can be matched exactly, which is most useful when combined with query parameter
+Alternatively, just the path part of the URL can be matched exactly or using a regular expression, which is most useful when combined with query parameter
 matching (:ref:`stubbing-query-parameter-matching`):
 
 .. code-block:: java
@@ -95,6 +95,10 @@ matching (:ref:`stubbing-query-parameter-matching`):
     stubFor(get(urlPathEqualTo("/query"))
         .willReturn(aResponse().withStatus(200)));
 
+.. code-block:: java
+
+    stubFor(get(urlPathMatching("/qu.*"))
+        .willReturn(aResponse().withStatus(200)));
 
 And in JSON via the ``urlPath`` attribute:
 
@@ -188,6 +192,8 @@ And in JSON:
     	}
     }
 
+Note: you must use ``urlPathEqualTo`` or ``urlPathMatching`` to specify the path, as ``urlEqualTo`` or ``urlMatching`` will
+attempt to match the whole request URL, including the query parameters.
 
 .. _stubbing-request-body-matching:
 

--- a/src/main/java/com/github/tomakehurst/wiremock/client/UrlMatchingStrategy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/UrlMatchingStrategy.java
@@ -44,6 +44,6 @@ public class UrlMatchingStrategy {
     }
 
 	public void setUrlPathPattern(String urlPathPattern) {
-		this.urlPathPattern = urlPath;
+		this.urlPathPattern = urlPathPattern;
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/UrlMatchingStrategy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/UrlMatchingStrategy.java
@@ -22,23 +22,28 @@ public class UrlMatchingStrategy {
 	private String url;
 	private String urlPattern;
     private String urlPath;
+	private String urlPathPattern;
 
-    public void contributeTo(RequestPattern requestPattern) {
+	public void contributeTo(RequestPattern requestPattern) {
 		requestPattern.setUrl(url);
 		requestPattern.setUrlPattern(urlPattern);
         requestPattern.setUrlPath(urlPath);
+		requestPattern.setUrlPathPattern(urlPathPattern);
 	}
-	
+
 	public void setUrl(String url) {
 		this.url = url;
 	}
-	
+
 	public void setUrlPattern(String urlPattern) {
 		this.urlPattern = urlPattern;
 	}
 
-
     public void setUrlPath(String urlPath) {
         this.urlPath = urlPath;
     }
+
+	public void setUrlPathPattern(String urlPathPattern) {
+		this.urlPathPattern = urlPath;
+	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -33,12 +33,12 @@ import static com.github.tomakehurst.wiremock.client.RequestPatternBuilder.allRe
 
 
 public class WireMock {
-	
+
 	private static final int DEFAULT_PORT = 8080;
 	private static final String DEFAULT_HOST = "localhost";
 
 	private final Admin admin;
-	
+
 	private static WireMock defaultInstance = new WireMock();
 
     public WireMock(Admin admin) {
@@ -52,19 +52,19 @@ public class WireMock {
     public WireMock(String host, int port) {
 		admin = new HttpAdminClient(host, port);
 	}
-	
+
 	public WireMock(String host, int port, String urlPathPrefix) {
 		admin = new HttpAdminClient(host, port, urlPathPrefix);
 	}
-	
+
 	public WireMock() {
 		admin = new HttpAdminClient(DEFAULT_HOST, DEFAULT_PORT);
 	}
-	
+
 	public static void givenThat(MappingBuilder mappingBuilder) {
 		defaultInstance.register(mappingBuilder);
 	}
-	
+
 	public static void stubFor(MappingBuilder mappingBuilder) {
 		givenThat(mappingBuilder);
 	}
@@ -80,11 +80,11 @@ public class WireMock {
 	public static void configureFor(String host, int port) {
 		defaultInstance = new WireMock(host, port);
 	}
-	
+
 	public static void configureFor(String host, int port, String urlPathPrefix) {
 		defaultInstance = new WireMock(host, port, urlPathPrefix);
 	}
-	
+
 	public static void configure() {
 		defaultInstance = new WireMock();
 	}
@@ -96,11 +96,11 @@ public class WireMock {
     public static void saveAllMappings() {
         defaultInstance.saveMappings();
     }
-	
+
 	public void resetMappings() {
 		admin.resetMappings();
 	}
-	
+
 	public static void reset() {
 		defaultInstance.resetMappings();
 	}
@@ -116,7 +116,7 @@ public class WireMock {
 	public void resetScenarios() {
 		admin.resetScenarios();
 	}
-	
+
 	public static void resetAllScenarios() {
 		defaultInstance.resetScenarios();
 	}
@@ -141,13 +141,13 @@ public class WireMock {
     public ListStubMappingsResult allStubMappings() {
         return admin.listAllStubMappings();
     }
-	
+
 	public static UrlMatchingStrategy urlEqualTo(String url) {
 		UrlMatchingStrategy urlStrategy = new UrlMatchingStrategy();
 		urlStrategy.setUrl(url);
 		return urlStrategy;
 	}
-	
+
 	public static UrlMatchingStrategy urlMatching(String url) {
 		UrlMatchingStrategy urlStrategy = new UrlMatchingStrategy();
 		urlStrategy.setUrlPattern(url);
@@ -159,13 +159,19 @@ public class WireMock {
         urlStrategy.setUrlPath(urlPath);
         return urlStrategy;
     }
-	
+
+	public static UrlMatchingStrategy urlPathMatching(String urlPath) {
+		UrlMatchingStrategy urlStrategy = new UrlMatchingStrategy();
+		urlStrategy.setUrlPathPattern(urlPath);
+		return urlStrategy;
+	}
+
 	public static ValueMatchingStrategy equalTo(String value) {
 		ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
 		headerStrategy.setEqualTo(value);
 		return headerStrategy;
 	}
-	
+
     public static ValueMatchingStrategy equalToJson(String value) {
         ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
         headerStrategy.setEqualToJson(value);
@@ -196,13 +202,13 @@ public class WireMock {
 		headerStrategy.setContains(value);
 		return headerStrategy;
 	}
-	
+
 	public static ValueMatchingStrategy matching(String value) {
 		ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
 		headerStrategy.setMatches(value);
 		return headerStrategy;
 	}
-	
+
 	public static ValueMatchingStrategy notMatching(String value) {
 		ValueMatchingStrategy headerStrategy = new ValueMatchingStrategy();
 		headerStrategy.setDoesNotMatch(value);
@@ -214,35 +220,35 @@ public class WireMock {
         matchingStrategy.setJsonMatchesPath(jsonPath);
         return matchingStrategy;
     }
-	
+
 	public static MappingBuilder get(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.GET, urlMatchingStrategy);
 	}
-	
+
 	public static MappingBuilder post(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.POST, urlMatchingStrategy);
 	}
-	
+
 	public static MappingBuilder put(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.PUT, urlMatchingStrategy);
 	}
-	
+
 	public static MappingBuilder delete(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.DELETE, urlMatchingStrategy);
 	}
-	
+
 	public static MappingBuilder patch(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.PATCH, urlMatchingStrategy);
 	}
-	
+
 	public static MappingBuilder head(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.HEAD, urlMatchingStrategy);
 	}
-	
+
 	public static MappingBuilder options(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.OPTIONS, urlMatchingStrategy);
 	}
-	
+
 	public static MappingBuilder trace(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.TRACE, urlMatchingStrategy);
 	}
@@ -258,7 +264,7 @@ public class WireMock {
 	public static ResponseDefinitionBuilder aResponse() {
 		return new ResponseDefinitionBuilder();
 	}
-	
+
 	public void verifyThat(RequestPatternBuilder requestPatternBuilder) {
 		RequestPattern requestPattern = requestPatternBuilder.build();
         VerificationResult result = admin.countRequestsMatching(requestPattern);
@@ -278,11 +284,11 @@ public class WireMock {
             throw new VerificationException(requestPattern, count, find(allRequests()));
 		}
 	}
-	
+
 	public static void verify(RequestPatternBuilder requestPatternBuilder) {
 		defaultInstance.verifyThat(requestPatternBuilder);
 	}
-	
+
 	public static void verify(int count, RequestPatternBuilder requestPatternBuilder) {
 		defaultInstance.verifyThat(count, requestPatternBuilder);
 	}
@@ -296,19 +302,19 @@ public class WireMock {
     public static List<LoggedRequest> findAll(RequestPatternBuilder requestPatternBuilder) {
         return defaultInstance.find(requestPatternBuilder);
     }
-	
+
 	public static RequestPatternBuilder getRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.GET, urlMatchingStrategy);
 	}
-	
+
 	public static RequestPatternBuilder postRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.POST, urlMatchingStrategy);
 	}
-	
+
 	public static RequestPatternBuilder putRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.PUT, urlMatchingStrategy);
 	}
-	
+
 	public static RequestPatternBuilder deleteRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.DELETE, urlMatchingStrategy);
 	}
@@ -316,23 +322,23 @@ public class WireMock {
 	public static RequestPatternBuilder patchRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.PATCH, urlMatchingStrategy);
 	}
-	
+
 	public static RequestPatternBuilder headRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.HEAD, urlMatchingStrategy);
 	}
-	
+
 	public static RequestPatternBuilder optionsRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.OPTIONS, urlMatchingStrategy);
 	}
-	
+
 	public static RequestPatternBuilder traceRequestedFor(UrlMatchingStrategy urlMatchingStrategy) {
 		return new RequestPatternBuilder(RequestMethod.TRACE, urlMatchingStrategy);
 	}
-	
+
 	public static void setGlobalFixedDelay(int milliseconds) {
 		defaultInstance.setGlobalFixedDelayVariable(milliseconds);
 	}
-	
+
 	public void setGlobalFixedDelayVariable(int milliseconds) {
 		GlobalSettings settings = new GlobalSettings();
 		settings.setFixedDelay(milliseconds);

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -46,6 +46,7 @@ public class RequestPattern {
     private String urlPattern;
 	private String url;
     private String urlPath;
+	private String urlPathPattern;
     private RequestMethod method;
     private Map<String, ValuePattern> headerPatterns;
     private Map<String, ValuePattern> queryParamPatterns;
@@ -63,16 +64,16 @@ public class RequestPattern {
 		this.method = method;
 		this.headerPatterns = headerPatterns;
 	}
-	
+
 	public RequestPattern(RequestMethod method) {
 		this.method = method;
 	}
-	
+
 	public RequestPattern(RequestMethod method, String url) {
 		this.url = url;
 		this.method = method;
 	}
-	
+
 	public RequestPattern() {
 	}
 
@@ -87,8 +88,8 @@ public class RequestPattern {
     }
 
     private void assertIsInValidState() {
-        if (from(asList(url, urlPath, urlPattern)).filter(notNull()).size() > 1) {
-			throw new IllegalStateException("Only one of url, urlPattern or urlPath may be set");
+        if (from(asList(url, urlPath, urlPattern, urlPathPattern)).filter(notNull()).size() > 1) {
+			throw new IllegalStateException("Only one of url, urlPattern, urlPath or urlPathPattern may be set");
 		}
 	}
 
@@ -108,6 +109,8 @@ public class RequestPattern {
             matched = url.equals(candidateUrl);
         } else if (urlPattern != null) {
 			matched = candidateUrl.matches(urlPattern);
+		} else if (urlPathPattern != null) {
+			matched = candidateUrl.matches(urlPathPattern.concat(".*"));
 		} else {
             matched = candidateUrl.startsWith(urlPath);
         }
@@ -242,6 +245,15 @@ public class RequestPattern {
         this.urlPath = urlPath;
         assertIsInValidState();
     }
+
+	public String getUrlPathPattern() {
+		return urlPathPattern;
+	}
+
+	public void setUrlPathPattern(String urlPathPattern) {
+		this.urlPathPattern = urlPathPattern;
+		assertIsInValidState();
+	}
 
 	public List<ValuePattern> getBodyPatterns() {
 		return bodyPatterns;

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class StubbingAcceptanceTest extends AcceptanceTestBase {
-	
+
 	@Test
 	public void mappingWithExactUrlAndMethodMatch() {
 		stubFor(get(urlEqualTo("/a/registered/resource")).willReturn(
@@ -44,26 +44,26 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 				.withStatus(401)
 				.withHeader("Content-Type", "text/plain")
 				.withBody("Not allowed!")));
-		
+
 		WireMockResponse response = testClient.get("/a/registered/resource");
-		
+
 		assertThat(response.statusCode(), is(401));
 		assertThat(response.content(), is("Not allowed!"));
 		assertThat(response.firstHeader("Content-Type"), is("text/plain"));
 	}
-	
+
 	@Test
 	public void mappingWithUrlContainingQueryParameters() {
 		stubFor(get(urlEqualTo("/search?name=John&postcode=N44LL")).willReturn(
 				aResponse()
-				.withHeader("Location", "/nowhere")
-				.withStatus(302)));
-		
+						.withHeader("Location", "/nowhere")
+						.withStatus(302)));
+
 		WireMockResponse response = testClient.get("/search?name=John&postcode=N44LL");
-		
+
 		assertThat(response.statusCode(), is(302));
 	}
-	
+
 	@Test
 	public void mappingWithHeaderMatchers() {
 		stubFor(put(urlEqualTo("/some/url"))
@@ -71,15 +71,15 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 			.withHeader("Two", matching("[a-z]{5}"))
 			.withHeader("Three", notMatching("[A-Z]+"))
 			.willReturn(aResponse().withStatus(204)));
-		
+
 		WireMockResponse response = testClient.put("/some/url",
 				withHeader("One", "abcd1234"),
 				withHeader("Two", "thing"),
 				withHeader("Three", "something"));
-		
+
 		assertThat(response.statusCode(), is(204));
 	}
-	
+
 	@Test
 	public void mappingWithCaseInsensitiveHeaderMatchers() {
 		stubFor(put(urlEqualTo("/case/insensitive"))
@@ -87,12 +87,12 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 			.withHeader("two", matching("[a-z]{5}"))
 			.withHeader("Three", notMatching("[A-Z]+"))
 			.willReturn(aResponse().withStatus(204)));
-		
+
 		WireMockResponse response = testClient.put("/case/insensitive",
 				withHeader("one", "abcd1234"),
 				withHeader("TWO", "thing"),
 				withHeader("tHrEe", "something"));
-		
+
 		assertThat(response.statusCode(), is(204));
 	}
 
@@ -130,6 +130,16 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
     }
 
 	@Test
+	public void matchesOnUrlPathPatternAndQueryParameters() {
+		stubFor(get(urlPathMatching("/path(.*)/match"))
+				.withQueryParam("search", containing("WireMock"))
+				.withQueryParam("since", equalTo("2014-10-14"))
+				.willReturn(aResponse().withStatus(200)));
+
+		assertThat(testClient.get("/path-and-query/match?since=2014-10-14&search=WireMock%20stubbing").statusCode(), is(200));
+	}
+
+	@Test
 	public void doesNotMatchIfSpecifiedQueryParameterNotInRequest() {
 		stubFor(get(urlPathEqualTo("/path-and-query/match"))
 				.withQueryParam("search", containing("WireMock"))
@@ -144,12 +154,12 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 				aResponse()
 				.withStatus(200)
 				.withBodyFile("plain-example.txt")));
-		
+
 		WireMockResponse response = testClient.get("/my/file");
-		
+
 		assertThat(response.content(), is("Some example test from a file"));
 	}
-	
+
 	@Test
 	public void matchingOnRequestBodyWithTwoRegexes() {
 		stubFor(put(urlEqualTo("/match/this/body"))
@@ -158,16 +168,16 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 	            .willReturn(aResponse()
                 .withStatus(HTTP_OK)
                 .withBodyFile("plain-example.txt")));
-        
+
         WireMockResponse response = testClient.putWithBody("/match/this/body", "Blah...but not the rest", "text/plain");
         assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
         response = testClient.putWithBody("/match/this/body", "@12345@...but not the rest", "text/plain");
         assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
-        
+
         response = testClient.putWithBody("/match/this/body", "BlahBlah@56565@Blah", "text/plain");
         assertThat(response.statusCode(), is(HTTP_OK));
 	}
-	
+
 	@Test
     public void matchingOnRequestBodyWithAContainsAndANegativeRegex() {
 		stubFor(put(urlEqualTo("/match/this/body/too"))
@@ -176,14 +186,14 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
                 .willReturn(aResponse()
                 .withStatus(HTTP_OK)
                 .withBodyFile("plain-example.txt")));
-        
+
         WireMockResponse response = testClient.putWithBody("/match/this/body/too", "Blah12345", "text/plain");
         assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
-        
+
         response = testClient.putWithBody("/match/this/body/too", "BlahBlahBlah", "text/plain");
         assertThat(response.statusCode(), is(HTTP_OK));
     }
-	
+
 	@Test
     public void matchingOnRequestBodyWithEqualTo() {
         stubFor(put(urlEqualTo("/match/this/body/too"))
@@ -191,14 +201,14 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
                 .willReturn(aResponse()
                 .withStatus(HTTP_OK)
                 .withBodyFile("plain-example.txt")));
-        
+
         WireMockResponse response = testClient.putWithBody("/match/this/body/too", "Blah12345", "text/plain");
         assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
-        
+
         response = testClient.putWithBody("/match/this/body/too", "BlahBlahBlah", "text/plain");
         assertThat(response.statusCode(), is(HTTP_OK));
     }
-	
+
 	@Test
 	public void responseWithFixedDelay() {
 	    stubFor(get(urlEqualTo("/delayed/resource")).willReturn(
@@ -206,57 +216,57 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
                 .withStatus(200)
                 .withBody("Content")
                 .withFixedDelay(500)));
-        
+
 	    long start = System.currentTimeMillis();
         testClient.get("/delayed/resource");
         int duration = (int) (System.currentTimeMillis() - start);
-        
+
         assertThat(duration, greaterThanOrEqualTo(500));
 	}
-	
+
 	@Test
 	public void highPriorityMappingMatchedFirst() {
 		stubFor(get(urlMatching("/priority/.*")).atPriority(10)
 				.willReturn(aResponse()
                 .withStatus(500)));
 		stubFor(get(urlEqualTo("/priority/resource")).atPriority(2).willReturn(aResponse().withStatus(200)));
-		
+
 		assertThat(testClient.get("/priority/resource").statusCode(), is(200));
 	}
-	
+
 	@Test
 	public void emptyResponseFault() {
 		stubFor(get(urlEqualTo("/empty/response")).willReturn(
                 aResponse()
                 .withFault(Fault.EMPTY_RESPONSE)));
-		
+
 		getAndAssertUnderlyingExceptionInstanceClass("/empty/response", NoHttpResponseException.class);
 	}
-	
+
 	@Test
 	public void malformedResponseChunkFault() {
 		stubFor(get(urlEqualTo("/malformed/response")).willReturn(
                 aResponse()
                 .withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
-		
+
 		getAndAssertUnderlyingExceptionInstanceClass("/malformed/response", MalformedChunkCodingException.class);
 	}
-	
+
 	@Test
 	public void randomDataOnSocketFault() {
 		stubFor(get(urlEqualTo("/random/data")).willReturn(
                 aResponse()
                 .withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
-		
+
 		getAndAssertUnderlyingExceptionInstanceClass("/random/data", ClientProtocolException.class);
 	}
-	
+
 	@Test
 	public void matchingUrlsWithEscapeCharacters() {
 		stubFor(get(urlEqualTo("/%26%26The%20Lord%20of%20the%20Rings%26%26")).willReturn(aResponse().withStatus(HTTP_OK)));
 		assertThat(testClient.get("/%26%26The%20Lord%20of%20the%20Rings%26%26").statusCode(), is(HTTP_OK));
 	}
-	
+
 	@Test
 	public void default200ResponseWhenStatusCodeNotSpecified() {
 		stubFor(get(urlEqualTo("/default/two-hundred")).willReturn(aResponse()));
@@ -318,7 +328,7 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 			assertThat(e.getCause(), instanceOf(expectedClass));
 			thrown = true;
 		}
-		
+
 		assertTrue("No exception was thrown", thrown);
 	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -46,6 +46,18 @@ public class VerificationAcceptanceTest {
             verify(getRequestedFor(urlEqualTo("/this/got/requested")));
         }
 
+        @Test
+        public void verifiesRequestBasedOnUrlPathOnly() {
+            testClient.get("/this/got/requested");
+            verify(getRequestedFor(urlPathEqualTo("/this/got")));
+        }
+
+        @Test
+        public void verifiesRequestBasedOnUrlPathPatternOnly() {
+            testClient.get("/this/got/requested");
+            verify(getRequestedFor(urlPathMatching("/(.*?)/got")));
+        }
+
         @Test(expected=VerificationException.class)
         public void throwsVerificationExceptionWhenNoMatch() {
             testClient.get("/this/got/requested");


### PR DESCRIPTION
Adds a URL path matching strategy so regular expression matches on the path are possible in conjunction with query parameters to fix Issue #288.