### PR TITLE
Added ability to match requests relationally (e.g. more than/less than 5 requests)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingMode.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingMode.java
@@ -1,0 +1,12 @@
+package com.github.tomakehurst.wiremock.client;
+
+import java.util.function.BiPredicate;
+
+/**
+ *
+ */
+public interface CountMatchingMode extends BiPredicate<Integer, Integer> {
+
+    String getFriendlyName();
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingMode.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingMode.java
@@ -1,6 +1,6 @@
 package com.github.tomakehurst.wiremock.client;
 
-import java.util.function.BiPredicate;
+import com.github.tomakehurst.wiremock.common.BiPredicate;
 
 /**
  *

--- a/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategy.java
@@ -1,0 +1,90 @@
+package com.github.tomakehurst.wiremock.client;
+
+/**
+ * Matches the number of requests made using relational predicates.
+ */
+public class CountMatchingStrategy {
+
+    public static final CountMatchingMode LESS_THAN =
+            new CountMatchingMode() {
+                @Override
+                public String getFriendlyName() {
+                    return "Less than";
+                }
+
+                @Override
+                public boolean test(Integer actual, Integer expected) {
+                    return actual < expected;
+                }
+            };
+
+    public static final CountMatchingMode LESS_THAN_OR_EQUAL =
+            new CountMatchingMode() {
+                @Override
+                public String getFriendlyName() {
+                    return "Less than or exactly";
+                }
+
+                @Override
+                public boolean test(Integer actual, Integer expected) {
+                    return actual <= expected;
+                }
+            };
+
+    public static final CountMatchingMode EQUAL_TO =
+            new CountMatchingMode() {
+                @Override
+                public String getFriendlyName() {
+                    return "Exactly";
+                }
+
+                @Override
+                public boolean test(Integer actual, Integer expected) {
+                    return actual.equals(expected);
+                }
+            };
+
+    public static final CountMatchingMode GREATER_THAN_OR_EQUAL =
+            new CountMatchingMode() {
+                @Override
+                public String getFriendlyName() {
+                    return "More than or exactly";
+                }
+
+                @Override
+                public boolean test(Integer actual, Integer expected) {
+                    return actual >= expected;
+                }
+            };
+
+    public static final CountMatchingMode GREATER_THAN =
+            new CountMatchingMode() {
+                @Override
+                public String getFriendlyName() {
+                    return "More than";
+                }
+
+                @Override
+                public boolean test(Integer actual, Integer expected) {
+                    return actual > expected;
+                }
+            };
+
+    private CountMatchingMode mode;
+    private int expected;
+
+    public CountMatchingStrategy(CountMatchingMode mode, int expected) {
+        this.mode = mode;
+        this.expected = expected;
+    }
+
+    public boolean match(int actual) {
+        return mode.test(actual, expected);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s %d", mode.getFriendlyName(), expected);
+    }
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
@@ -38,4 +38,9 @@ public class VerificationException extends AssertionError {
         super(String.format("Expected exactly %d requests matching: %s\nRequests received: %s",
                 expectedCount, expected.toString(), Json.write(requests)));
     }
+
+    public VerificationException(RequestPattern expected, CountMatchingStrategy count, List<LoggedRequest> requests) {
+        super(String.format("Expected %s requests matching: %s\nRequests received: %s",
+                count.toString().toLowerCase(), expected.toString(), Json.write(requests)));
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -226,6 +226,26 @@ public class WireMock {
         return matchingStrategy;
     }
 
+	public static CountMatchingStrategy lessThan(int expected) {
+		return new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN, expected);
+	}
+
+	public static CountMatchingStrategy lessThanOrExactly(int expected) {
+		return new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN_OR_EQUAL, expected);
+	}
+
+	public static CountMatchingStrategy exactly(int expected) {
+		return new CountMatchingStrategy(CountMatchingStrategy.EQUAL_TO, expected);
+	}
+
+	public static CountMatchingStrategy moreThanOrExactly(int expected) {
+		return new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN_OR_EQUAL, expected);
+	}
+
+	public static CountMatchingStrategy moreThan(int expected) {
+		return new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN, expected);
+	}
+
 	public static MappingBuilder get(UrlMatchingStrategy urlMatchingStrategy) {
 		return new MappingBuilder(RequestMethod.GET, urlMatchingStrategy);
 	}
@@ -290,12 +310,26 @@ public class WireMock {
 		}
 	}
 
+	public void verifyThat(CountMatchingStrategy count, RequestPatternBuilder requestPatternBuilder) {
+		RequestPattern requestPattern = requestPatternBuilder.build();
+		VerificationResult result = admin.countRequestsMatching(requestPattern);
+		result.assertRequestJournalEnabled();
+
+		if (!count.match(result.getCount())) {
+			throw new VerificationException(requestPattern, count, find(allRequests()));
+		}
+	}
+
 	public static void verify(RequestPatternBuilder requestPatternBuilder) {
 		defaultInstance.get().verifyThat(requestPatternBuilder);
 	}
 
 	public static void verify(int count, RequestPatternBuilder requestPatternBuilder) {
 		defaultInstance.get().verifyThat(count, requestPatternBuilder);
+	}
+
+	public static void verify(CountMatchingStrategy countMatchingStrategy, RequestPatternBuilder requestPatternBuilder) {
+		defaultInstance.get().verifyThat(countMatchingStrategy, requestPatternBuilder);
 	}
 
     public List<LoggedRequest> find(RequestPatternBuilder requestPatternBuilder) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/BiPredicate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/BiPredicate.java
@@ -1,0 +1,10 @@
+package com.github.tomakehurst.wiremock.common;
+
+/**
+ *
+ */
+public interface BiPredicate<T, U> {
+
+    boolean test(T first, U second);
+
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -80,8 +80,8 @@ public class VerificationAcceptanceTest {
                     withHeader("X-Thing", "Three"));
 
             verify(getRequestedFor(urlEqualTo("/multi/value/header"))
-                .withHeader("X-Thing", equalTo("Two"))
-                .withHeader("X-Thing", matching("Thr.*")));
+                    .withHeader("X-Thing", equalTo("Two"))
+                    .withHeader("X-Thing", matching("Thr.*")));
 
             verify(getRequestedFor(urlEqualTo("/multi/value/header"))
                     .withHeader("X-Thing", equalTo("Three")));
@@ -210,6 +210,102 @@ public class VerificationAcceptanceTest {
             verify(4, getRequestedFor(urlEqualTo("/add/to/count")));
         }
 
+        private void getCountableRequests(int count) {
+            for (int i = 0; i < count; i++) {
+                testClient.get("/add/to/count");
+            }
+        }
+
+        @Test
+        public void verifiesLessThanCountWithLessRequests() {
+            getCountableRequests(4);
+            verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyLessThanCountWithEqualRequests() {
+            getCountableRequests(5);
+            verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyLessThanCountWithMoreRequests() {
+            getCountableRequests(6);
+            verify(lessThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test
+        public void verifiesLessThanOrExactlyCountWithLessRequests() {
+            getCountableRequests(4);
+            verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test
+        public void verifiesLessThanOrExactlyCountWithEqualRequests() {
+            getCountableRequests(5);
+            verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyLessThanOrExactlyCountWithMoreRequests() {
+            getCountableRequests(6);
+            verify(lessThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyExactCountWithLessRequests() {
+            getCountableRequests(4);
+            verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test
+        public void verifiesExactlyThanCountWithExactRequests() {
+            getCountableRequests(5);
+            verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyExactCountWithMoreRequests() {
+            getCountableRequests(6);
+            verify(exactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyMoreThanOrExactlyCountWithLessRequests() {
+            getCountableRequests(4);
+            verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test
+        public void verifiesMoreThanOrExactlyCountWithEqualRequests() {
+            getCountableRequests(5);
+            verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test
+        public void verifiesMoreThanOrExactlyCountWithMoreRequests() {
+            getCountableRequests(6);
+            verify(moreThanOrExactly(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyMoreThanCountWithLessRequests() {
+            getCountableRequests(4);
+            verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test(expected = VerificationException.class)
+        public void doesNotVerifyMoreThanCountWithEqualRequests() {
+            getCountableRequests(5);
+            verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
+        @Test
+        public void verifiesMoreThanCountWithMoreRequests() {
+            getCountableRequests(6);
+            verify(moreThan(5), getRequestedFor(urlEqualTo("/add/to/count")));
+        }
+
         @Test
         public void verifiesHeaderAbsent() {
             testClient.get("/without/header", withHeader("Content-Type", "application/json"));
@@ -253,7 +349,96 @@ public class VerificationAcceptanceTest {
             } catch (VerificationException e) {
                 assertThat(e.getMessage(), allOf(
                         containsString("Expected exactly 14 requests matching: {"),
-                        containsString("/specific/thing"),
+                        containsString("/some/request"),
+                        containsString("Requests received: "),
+                        containsString("/some/request")));
+            }
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void showsExpectedAndReceivedRequestsOnVerificationExceptionForLessThan() {
+            testClient.get("/some/request");
+            testClient.get("/some/request");
+            testClient.get("/some/request");
+
+            try {
+                verify(lessThan(2), getRequestedFor(urlEqualTo("/some/request")));
+                fail();
+            } catch (VerificationException e) {
+                assertThat(e.getMessage(), allOf(
+                        containsString("Expected less than 2 requests matching: {"),
+                        containsString("/some/request"),
+                        containsString("Requests received: "),
+                        containsString("/some/request")));
+            }
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void showsExpectedAndReceivedRequestsOnVerificationExceptionForLessThanOrExactly() {
+            testClient.get("/some/request");
+            testClient.get("/some/request");
+            testClient.get("/some/request");
+
+            try {
+                verify(lessThanOrExactly(2), getRequestedFor(urlEqualTo("/some/request")));
+                fail();
+            } catch (VerificationException e) {
+                assertThat(e.getMessage(), allOf(
+                        containsString("Expected less than or exactly 2 requests matching: {"),
+                        containsString("/some/request"),
+                        containsString("Requests received: "),
+                        containsString("/some/request")));
+            }
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void showsExpectedAndReceivedRequestsOnVerificationExceptionForExactly() {
+            testClient.get("/some/request");
+
+            try {
+                verify(exactly(12), getRequestedFor(urlEqualTo("/some/request")));
+                fail();
+            } catch (VerificationException e) {
+                assertThat(e.getMessage(), allOf(
+                        containsString("Expected exactly 12 requests matching: {"),
+                        containsString("/some/request"),
+                        containsString("Requests received: "),
+                        containsString("/some/request")));
+            }
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void showsExpectedAndReceivedRequestsOnVerificationExceptionForMoreThanOrExactly() {
+            testClient.get("/some/request");
+
+            try {
+                verify(moreThanOrExactly(12), getRequestedFor(urlEqualTo("/some/request")));
+                fail();
+            } catch (VerificationException e) {
+                assertThat(e.getMessage(), allOf(
+                        containsString("Expected more than or exactly 12 requests matching: {"),
+                        containsString("/some/request"),
+                        containsString("Requests received: "),
+                        containsString("/some/request")));
+            }
+        }
+
+        @Test
+        @SuppressWarnings("unchecked")
+        public void showsExpectedAndReceivedRequestsOnVerificationExceptionForMoreThan() {
+            testClient.get("/some/request");
+
+            try {
+                verify(moreThan(12), getRequestedFor(urlEqualTo("/some/request")));
+                fail();
+            } catch (VerificationException e) {
+                assertThat(e.getMessage(), allOf(
+                        containsString("Expected more than 12 requests matching: {"),
+                        containsString("/some/request"),
                         containsString("Requests received: "),
                         containsString("/some/request")));
             }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/CountMatchingStrategyTest.java
@@ -1,0 +1,84 @@
+package com.github.tomakehurst.wiremock.client;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CountMatchingStrategyTest {
+
+    @Test
+    public void shouldMatchLessThanCorrectly() {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN, 5);
+
+        assertThat(countStrategy.match(3), is(true));
+        assertThat(countStrategy.match(5), is(false));
+        assertThat(countStrategy.match(7), is(false));
+    }
+
+    @Test
+    public void shouldMatchLessThanOrEqualCorrectly() {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN_OR_EQUAL, 5);
+
+        assertThat(countStrategy.match(3), is(true));
+        assertThat(countStrategy.match(5), is(true));
+        assertThat(countStrategy.match(7), is(false));
+    }
+
+    @Test
+    public void shouldMatchEqualToCorrectly() {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.EQUAL_TO, 5);
+
+        assertThat(countStrategy.match(3), is(false));
+        assertThat(countStrategy.match(5), is(true));
+        assertThat(countStrategy.match(7), is(false));
+    }
+
+    @Test
+    public void shouldMatchGreaterThanOrEqualCorrectly() {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN_OR_EQUAL, 5);
+
+        assertThat(countStrategy.match(3), is(false));
+        assertThat(countStrategy.match(5), is(true));
+        assertThat(countStrategy.match(7), is(true));
+    }
+
+    @Test
+    public void shouldMatchGreaterThanCorrectly() {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN, 5);
+
+        assertThat(countStrategy.match(3), is(false));
+        assertThat(countStrategy.match(5), is(false));
+        assertThat(countStrategy.match(7), is(true));
+    }
+
+    @Test
+    public void shouldCorrectlyObtainFriendlyNameForLessThanMode() throws Exception {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN, 5);
+        assertThat(countStrategy.toString(), is("Less than 5"));
+    }
+
+    @Test
+    public void shouldCorrectlyObtainFriendlyNameForLessThanOrEqualMode() throws Exception {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN_OR_EQUAL, 5);
+        assertThat(countStrategy.toString(), is("Less than or exactly 5"));
+    }
+
+    @Test
+    public void shouldCorrectlyObtainFriendlyNameForEqualMode() throws Exception {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.EQUAL_TO, 5);
+        assertThat(countStrategy.toString(), is("Exactly 5"));
+    }
+
+    @Test
+    public void shouldCorrectlyObtainFriendlyNameForGreaterThanOrEqualMode() throws Exception {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN_OR_EQUAL, 5);
+        assertThat(countStrategy.toString(), is("More than or exactly 5"));
+    }
+
+    @Test
+    public void shouldCorrectlyObtainFriendlyNameForGreaterThanMode() throws Exception {
+        CountMatchingStrategy countStrategy = new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN, 5);
+        assertThat(countStrategy.toString(), is("More than 5"));
+    }
+}


### PR DESCRIPTION
Added a new overload of verify() that takes a CountMatchingStrategy as it's first argument. This strategy can be obtained via static convenience methods to create the following assertions:

* `verify(moreThan(5), getRequestedFor(...))`
* `verify(moreThanOrExactly(5), getRequestedFor(...))`
* `verify(exactly(5), getRequestedFor(...))`
* `verify(lessThanOrExactly(5), getRequestedFor(...))`
* `verify(lessThan(5), getRequestedFor(...))`