### PR TITLE
Enable HttpAdminClient to be used for standalone process wiremock server

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -40,18 +40,18 @@ import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 
 public class HttpAdminClient implements Admin {
 
-    private static final String ADMIN_URL_PREFIX = "%s://%s:%d%s/__admin";
+	private static final String ADMIN_URL_PREFIX = "%s://%s:%d%s/__admin";
 
-    private final String scheme;
-    private final String host;
-    private final int port;
-    private final String urlPathPrefix;
+	private final String scheme;
+	private final String host;
+	private final int port;
+	private final String urlPathPrefix;
 
-    private final HttpClient httpClient;
+	private final HttpClient httpClient;
 
-    protected String getScheme() {
+	protected String getScheme() {
         return scheme;
-    }
+	}
 
     protected String getHost() {
         return host;
@@ -94,13 +94,13 @@ public class HttpAdminClient implements Admin {
         this(host, port, "");
     }
 
-    @Override
-    public void addStubMapping(StubMapping stubMapping) {
+	@Override
+	public void addStubMapping(StubMapping stubMapping) {
         postJsonAssertOkAndReturnBody(
                 urlFor(NewStubMappingTask.class),
                 Json.write(stubMapping),
                 HTTP_CREATED);
-    }
+	}
 
     public void addStubMapping( MappingBuilder mappingBuilder) {
         addStubMapping(mappingBuilder.build());
@@ -120,9 +120,9 @@ public class HttpAdminClient implements Admin {
     }
 
     @Override
-    public void resetMappings() {
-        postJsonAssertOkAndReturnBody(urlFor(ResetTask.class), null, HTTP_OK);
-    }
+	public void resetMappings() {
+		postJsonAssertOkAndReturnBody(urlFor(ResetTask.class), null, HTTP_OK);
+	}
 
     @Override
     public void resetRequests() {
@@ -130,23 +130,23 @@ public class HttpAdminClient implements Admin {
     }
 
     @Override
-    public void resetScenarios() {
+	public void resetScenarios() {
         postJsonAssertOkAndReturnBody(urlFor(ResetScenariosTask.class), null, HTTP_OK);
-    }
+	}
 
     @Override
     public void resetToDefaultMappings() {
         postJsonAssertOkAndReturnBody(urlFor(ResetToDefaultMappingsTask.class), null, HTTP_OK);
     }
 
-    @Override
-    public VerificationResult countRequestsMatching(RequestPattern requestPattern) {
-        String body = postJsonAssertOkAndReturnBody(
+	@Override
+	public VerificationResult countRequestsMatching(RequestPattern requestPattern) {
+		String body = postJsonAssertOkAndReturnBody(
                 urlFor(GetRequestCountTask.class),
                 Json.write(requestPattern),
                 HTTP_OK);
-        return VerificationResult.from(body);
-    }
+		return VerificationResult.from(body);
+	}
 
     public VerificationResult countRequestsMatching(RequestPatternBuilder requestPatternBuilder) {
         return countRequestsMatching(requestPatternBuilder.build());
@@ -162,12 +162,12 @@ public class HttpAdminClient implements Admin {
     }
 
     @Override
-    public void updateGlobalSettings(GlobalSettings settings) {
+	public void updateGlobalSettings(GlobalSettings settings) {
         postJsonAssertOkAndReturnBody(
                 urlFor(GlobalSettingsUpdateTask.class),
                 Json.write(settings),
                 HTTP_OK);
-    }
+	}
 
     @Override
     public void addSocketAcceptDelay(RequestDelaySpec spec) {
@@ -187,17 +187,17 @@ public class HttpAdminClient implements Admin {
     }
 
     private String postJsonAssertOkAndReturnBody(String url, String json, int expectedStatus) {
-        HttpPost post = new HttpPost(url);
-        try {
-            if (json != null) {
-                post.setEntity(new StringEntity(json, APPLICATION_JSON));
-            }
-            HttpResponse response = httpClient.execute(post);
+		HttpPost post = new HttpPost(url);
+		try {
+			if (json != null) {
+				post.setEntity(new StringEntity(json, APPLICATION_JSON));
+			}
+			HttpResponse response = httpClient.execute(post);
             int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode != expectedStatus) {
-                throw new VerificationException(
+			if (statusCode != expectedStatus) {
+				throw new VerificationException(
                         "Expected status " + expectedStatus + " for " + url + " but was " + statusCode);
-            }
+			}
 
             return getEntityAsStringAndCloseStream(response);
         } catch (Exception e) {

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -1,0 +1,139 @@
+package com.github.tomakehurst.wiremock.client;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.ListStubMappingsResult;
+import com.github.tomakehurst.wiremock.verification.VerificationResult;
+import org.junit.*;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+public class HttpAdminClientTest extends HttpAdminClient {
+    private WireMockServer wireMockServer;
+
+    final static int httpPort = 8080;
+    final static int httpsPort = 8443;
+
+    public HttpAdminClientTest() {
+        super(new HttpAdminClientBuilder("localhost", httpsPort).setScheme("https"));
+    }
+
+
+    @Before
+    public void init() {
+        wireMockServer = new WireMockServer(httpPort, httpsPort);
+        wireMockServer.start();
+    }
+
+    @After
+    public void stopServer() {
+        wireMockServer.stop();
+    }
+
+
+    @Test
+    public void httpAdminClientBuilderTest() {
+
+        HttpAdminClient.HttpAdminClientBuilder builder;
+        {//validate constructor
+            final String host1 = "host1";
+            final int port1 = 123;
+            builder = new HttpAdminClient.HttpAdminClientBuilder(host1, port1);
+
+
+            Assert.assertEquals(builder.getHost(), host1);
+            Assert.assertEquals(builder.getPort(), port1);
+        }
+
+        final String host2 = "host2";
+        final int port2 = 234;
+
+        {//validate setters and getters
+
+            builder.setHost(host2)
+                    .setHttpClient(null)
+                    .setPort(port2)
+                    .setScheme("scheme")
+                    .setUrlPathPrefix("prefix");
+            Assert.assertEquals(builder.getHost(), host2);
+            Assert.assertEquals(builder.getPort(), port2);
+            Assert.assertEquals(builder.getScheme(), "scheme");
+            Assert.assertEquals(builder.getUrlPathPrefix(), "prefix");
+            Assert.assertNull(builder.getHttpClient());
+        }
+
+        {//validate build
+            HttpAdminClient client = builder.build();
+
+            Assert.assertEquals(client.getHost(), host2);
+            Assert.assertEquals(client.getPort(), port2);
+            Assert.assertEquals(client.getScheme(), "scheme");
+            Assert.assertEquals(client.getUrlPathPrefix(), "prefix");
+            Assert.assertNotNull(client.getHttpClient());
+        }
+
+    }
+
+    @Test
+    public void stubTest() {
+        Assert.assertNotNull(this.getHttpClient());
+        final String relativePath = "/some/thing";
+        final String url = "https://localhost:8443/some/thing";
+        this.resetMappings();
+
+        {//no mappings at start
+            ListStubMappingsResult result = this.listAllStubMappings();
+            Assert.assertEquals(0, result.getMappings()
+                    .size());
+        }
+
+        {//add one mapping
+            this.addStubMapping(get(urlEqualTo(relativePath))
+                    .willReturn(aResponse()
+                            .withStatus(300)));
+            getJsonAssertOkAndReturnBody(url, 300);
+
+            ListStubMappingsResult result = this.listAllStubMappings();
+            Assert.assertEquals(1, result.getMappings()
+                    .size());
+        }
+
+        { //clear mappings
+            this.resetMappings();
+            ListStubMappingsResult result = this.listAllStubMappings();
+            Assert.assertEquals(0, result.getMappings()
+                    .size());
+        }
+    }
+
+
+    @Test
+    public void countTest() {
+        this.resetRequests();
+
+        Assert.assertNotNull(this.getHttpClient());
+        final String relativePath = "/some/thing";
+        final String url = "https://localhost:8443/some/thing";
+
+        this.addStubMapping(get(urlEqualTo(relativePath))
+                .willReturn(aResponse()
+                        .withStatus(300)));
+        getJsonAssertOkAndReturnBody(url, 300);
+
+
+        {
+            VerificationResult result = this.countRequestsMatching(getRequestedFor(urlEqualTo(relativePath)));
+            Assert.assertEquals(result.getCount(), 1);
+
+        }
+
+        this.resetRequests();
+        {
+            VerificationResult result = this.countRequestsMatching(getRequestedFor(urlEqualTo(relativePath)));
+            Assert.assertEquals(result.getCount(), 0);
+        }
+    }
+
+}


### PR DESCRIPTION
Need: ability to write tests for standalone wiremock using same syntax as for in-process wiremock.
Changes:
* Add support for https
* overload addStubMapping to also accept MappingBuilder
* overload countRequestsMatching to also accept MappingBuilder.

After these changes, or functionally similar ones have been merged to master, I will update the documentation to show how to use HttpAdminClient for remote testing.