### PR TITLE
WireMock 2.0-beta Android Support

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -164,7 +164,9 @@ public class HttpAdminClient implements Admin {
         HttpPost post = new HttpPost(url);
         try {
             if (json != null) {
-                post.setEntity(new StringEntity(json, APPLICATION_JSON));
+                StringEntity stringEntity = new StringEntity(json);
+                stringEntity.setContentType(APPLICATION_JSON.getMimeType());
+                post.setEntity(stringEntity);
             }
             HttpResponse response = httpClient.execute(post);
             int statusCode = response.getStatusLine().getStatusCode();


### PR DESCRIPTION
**With the following change, WireMock 2.0-beta successfully runs on Android**.

I was able to successfully create an ActivityInstrumentationTestCase2 using the @RunWith(AndroidJUnit4.class) class level annotation and the following WireMockRule:
```java
@Rule
public WireMockRule wireMockRule = new WireMockRule();
```
I did a lot of combinations of dependencies as I tried to figure out how to make this work, but when I simplified it down, the modification to make this work on android was VERY simple.  Thanks @tomakehurst for the great work.  

**How**
The only thing that wasn't supported was the StringEntity constructor that was being used in HttpAdminClient.  I reverted back to a constructor that was available on the 4.3.5.1 version of Android version of the Apache HttpClient and then manually set ContentType.

**Notes**
* Android only supports Java 7, and has no support for Java 8 or 9
* Jetty 9.2.x is the last version to support Java 7, so no new versions of Jetty will work on Android.
* On Android, use the following dependency if you are targeting Platform 22 or below. ```org.apache.httpcomponents:httpclient-android:4.3.5.1``` Notes: https://hc.apache.org/httpcomponents-client-4.3.x/android-port.html
* If you are running on 23 or higher, you may need to use the following as noted here http://developer.android.com/about/versions/marshmallow/android-6.0-changes.html#behavior-apache-http-client
```
android {
    useLibrary 'org.apache.http.legacy'
}
```

**Usage In Validation**
I am only using the ```.withBody()``` rule and have not figured out how to implement at ```.withBodyFile()``` rule out of the Android Assets directory, but it worked great by sending the body itself instead.