### PR TITLE
Support randomly distributed delays for responses

### DIFF
--- a/docs/source/simulating-faults.rst
+++ b/docs/source/simulating-faults.rst
@@ -128,6 +128,25 @@ To use, instantiate a ``new LogNormal(median, sigma)``, or via JSON:
             "sigma": 0.4
     }
 
+Uniform delay
+^^^^^^^^^^^^^
+
+A uniform distribution can be used for simulating a stable latency with a fixed amount of jitter. It takes two parameters:
+
+* lower - Lower bound of the range, inclusive.
+* upper - Upper bound of the range, inclusive.
+
+For instance, to simulate a stable latency of 20ms +/- 5ms, use lower = 15 and upper = 25.
+
+To use, instantiate a ``new UniformDistribution(15, 25)``, or via JSON:
+
+.. code-block:: javascript
+
+    "delayDistribution": {
+            "type": "uniform",
+            "lower": 15,
+            "upper": 25
+    }
 
 .. _simulating-faults-bad-responses:
 

--- a/docs/source/simulating-faults.rst
+++ b/docs/source/simulating-faults.rst
@@ -53,6 +53,63 @@ document of the following form to ``http://<host>:<port>/__admin/settings``:
         "fixedDelay": 500
     }
 
+Random delays
+-------------
+
+In addition to fixed delays, a delay can be sampled from a random distribution. This allows simulation of more specific
+downstream behaviours, such as a long tail for delays.
+
+Use ``#withRandomDelay`` on the stub to pass in the desired distribution:
+
+.. code-block:: java
+
+    stubFor(get(urlEqualTo("/random/delayed")).willReturn(
+            aResponse()
+                    .withStatus(200)
+                    .withRandomDelay(new LogNormal(90, 0.1))));
+
+Or set it on the ``delayDistribution`` field via the JSON api:
+
+.. code-block:: javascript
+
+    {
+        "request": {
+                "method": "GET",
+                "url": "/random/delayed"
+        },
+        "response": {
+                "status": 200,
+                "delayDistribution": {
+                        "type": "lognormal",
+                        "median": 80,
+                        "sigma": 0.4
+                }
+
+        }
+    }
+
+Lognormal delay
+^^^^^^^^^^^^^^^
+
+A lognormal distribution is a pretty good approximation of long tailed latencies centered on the 50th percentile.
+It takes two parameters:
+
+* median - The 50th percentile of latencies.
+* sigma - Standard deviation. The larger the value, the longer the tail.
+
+`Try different values <https://www.wolframalpha.com/input/?i=lognormaldistribution%28log%2890%29%2C+0.4%29>`_ to
+find a good approximation.
+
+To use, instantiate a ``new LogNormal(median, sigma)``, or via JSON:
+
+.. code-block:: javascript
+
+    "delayDistribution": {
+            "type": "lognormal",
+            "median": 80,
+            "sigma": 0.4
+    }
+
 
 .. _simulating-faults-bad-responses:
 

--- a/docs/source/simulating-faults.rst
+++ b/docs/source/simulating-faults.rst
@@ -12,8 +12,8 @@ Simulating Faults
 
 .. _simulating-faults-stub-delays:
 
-Stub delays
-===========
+Stub fixed delays
+=================
 
 A stub response can have a fixed delay attached to it, such that the response will not be returned until after the
 specified number of milliseconds:
@@ -53,11 +53,11 @@ document of the following form to ``http://<host>:<port>/__admin/settings``:
         "fixedDelay": 500
     }
 
-Random delays
--------------
+Stub random delays
+==================
 
 In addition to fixed delays, a delay can be sampled from a random distribution. This allows simulation of more specific
-downstream behaviours, such as a long tail for delays.
+downstream latencies, such as a long tail.
 
 Use ``#withRandomDelay`` on the stub to pass in the desired distribution:
 
@@ -87,6 +87,24 @@ Or set it on the ``delayDistribution`` field via the JSON api:
 
         }
     }
+
+Global stub delays
+------------------
+
+You can set a random delay globally with ``WireMock.setGlobalRandomDelay()`` or the JSON api at ``http://<host>:<port>/__admin/settings``:
+
+.. code-block:: javascript
+
+    {
+        "delayDistribution": {
+                "type": "lognormal",
+                "median": 90,
+                "sigma": 0.1
+        }
+    }
+
+Available distributions
+-----------------------
 
 Lognormal delay
 ^^^^^^^^^^^^^^^

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.DelayDistribution;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
@@ -27,7 +28,6 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -43,6 +43,7 @@ public class ResponseDefinitionBuilder {
 	protected String bodyFileName;
 	protected List<HttpHeader> headers = newArrayList();
 	protected Integer fixedDelayMilliseconds;
+	protected DelayDistribution delayDistribution;
 	protected String proxyBaseUrl;
 	protected Fault fault;
 	protected List<String> responseTransformerNames;
@@ -104,6 +105,11 @@ public class ResponseDefinitionBuilder {
 
 	public ResponseDefinitionBuilder withFixedDelay(Integer milliseconds) {
 		this.fixedDelayMilliseconds = milliseconds;
+		return this;
+	}
+
+	public ResponseDefinitionBuilder withRandomDelay(DelayDistribution distribution) {
+		this.delayDistribution = distribution;
 		return this;
 	}
 
@@ -204,6 +210,7 @@ public class ResponseDefinitionBuilder {
 						httpHeaders,
 						additionalProxyRequestHeaders,
 						fixedDelayMilliseconds,
+						delayDistribution,
 						proxyBaseUrl,
 						fault,
 						responseTransformerNames,
@@ -218,6 +225,7 @@ public class ResponseDefinitionBuilder {
 						httpHeaders,
 						additionalProxyRequestHeaders,
 						fixedDelayMilliseconds,
+						delayDistribution,
 						proxyBaseUrl,
 						fault,
 						responseTransformerNames,

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -18,10 +18,10 @@ package com.github.tomakehurst.wiremock.client;
 import com.github.tomakehurst.wiremock.core.Admin;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
-import com.github.tomakehurst.wiremock.global.RequestDelaySpec;
+import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
+import com.github.tomakehurst.wiremock.http.DelayDistribution;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.matching.RequestMatcher;
-import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
 import com.github.tomakehurst.wiremock.stubbing.ListStubMappingsResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
@@ -41,6 +41,7 @@ public class WireMock {
 	private static final String DEFAULT_HOST = "localhost";
 
 	private final Admin admin;
+	private final GlobalSettingsHolder globalSettingsHolder = new GlobalSettingsHolder();
 
 	private static ThreadLocal<WireMock> defaultInstance = new ThreadLocal<WireMock>(){
             @Override 
@@ -418,8 +419,23 @@ public class WireMock {
 	}
 
 	public void setGlobalFixedDelayVariable(int milliseconds) {
-		GlobalSettings settings = new GlobalSettings();
+		GlobalSettings settings = globalSettingsHolder.get().copy();
 		settings.setFixedDelay(milliseconds);
+		updateGlobalSettings(settings);
+	}
+
+	public static void setGlobalRandomDelay(DelayDistribution distribution) {
+		defaultInstance.get().setGlobalRandomDelayVariable(distribution);
+	}
+
+	public void setGlobalRandomDelayVariable(DelayDistribution distribution) {
+		GlobalSettings settings = globalSettingsHolder.get().copy();
+		settings.setDelayDistribution(distribution);
+		updateGlobalSettings(settings);
+	}
+
+	private void updateGlobalSettings(GlobalSettings settings) {
+		globalSettingsHolder.replaceWith(settings);
 		admin.updateGlobalSettings(settings);
 	}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/global/GlobalSettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/global/GlobalSettings.java
@@ -17,11 +17,15 @@ package com.github.tomakehurst.wiremock.global;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
+import com.github.tomakehurst.wiremock.http.DelayDistribution;
+
+import java.util.Objects;
 
 @JsonSerialize(include=Inclusion.NON_NULL)
 public class GlobalSettings {
 
 	private Integer fixedDelay;
+    private DelayDistribution delayDistribution;
 
 	public Integer getFixedDelay() {
 		return fixedDelay;
@@ -31,6 +35,21 @@ public class GlobalSettings {
         this.fixedDelay = fixedDelay;
     }
 
+    public DelayDistribution getDelayDistribution() {
+        return delayDistribution;
+    }
+
+    public void setDelayDistribution(DelayDistribution distribution) {
+        delayDistribution = distribution;
+    }
+
+    public GlobalSettings copy() {
+        GlobalSettings newSettings = new GlobalSettings();
+        newSettings.setFixedDelay(fixedDelay);
+        newSettings.setDelayDistribution(delayDistribution);
+        return newSettings;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -38,13 +57,12 @@ public class GlobalSettings {
 
         GlobalSettings that = (GlobalSettings) o;
 
-        if (fixedDelay != null ? !fixedDelay.equals(that.fixedDelay) : that.fixedDelay != null) return false;
-
-        return true;
+        return Objects.equals(fixedDelay, that.fixedDelay)
+                && Objects.equals(delayDistribution, that.delayDistribution);
     }
 
     @Override
     public int hashCode() {
-        return fixedDelay != null ? fixedDelay.hashCode() : 0;
+        return Objects.hash(fixedDelay, delayDistribution);
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/DelayDistribution.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/DelayDistribution.java
@@ -1,0 +1,26 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Distribution that models delays.
+ *
+ * Implementations should be thread safe.
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = LogNormal.class, name = "lognormal")
+})
+public interface DelayDistribution {
+    /**
+     * Samples a delay in milliseconds from the distribution.
+     *
+     * @return next delay in millis
+     */
+    long sampleMillis();
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/DelayDistribution.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/DelayDistribution.java
@@ -14,7 +14,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         property = "type"
 )
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = LogNormal.class, name = "lognormal")
+        @JsonSubTypes.Type(value = LogNormal.class, name = "lognormal"),
+        @JsonSubTypes.Type(value = UniformDistribution.class, name = "uniform")
 })
 public interface DelayDistribution {
     /**

--- a/src/main/java/com/github/tomakehurst/wiremock/http/LogNormal.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/LogNormal.java
@@ -1,0 +1,37 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Returns log normally distributed values. Takes two parameters, the median (50th percentile) of the lognormal
+ * and the standard deviation of the underlying normal distribution.
+ *
+ * The larger the standard deviation the longer the tails.
+ *
+ * @see <a href="https://www.wolframalpha.com/input/?i=lognormaldistribution%28log%2890%29%2C+0.1%29">lognormal example</a>
+ */
+public final class LogNormal implements DelayDistribution {
+
+    @JsonProperty("median")
+    private final double median;
+    @JsonProperty("sigma")
+    private final double sigma;
+
+    /**
+     * @param median 50th percentile of the distribution in millis
+     * @param sigma standard deviation of the distribution, a larger value produces a longer tail
+     */
+    @JsonCreator
+    public LogNormal(@JsonProperty("median") double median, @JsonProperty("sigma") double sigma) {
+        this.median = median;
+        this.sigma = sigma;
+    }
+
+    @Override
+    public long sampleMillis() {
+        return Math.round(Math.exp(ThreadLocalRandom.current().nextGaussian() * sigma) * median);
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -42,6 +42,7 @@ public class ResponseDefinition {
 	private final HttpHeaders headers;
 	private final HttpHeaders additionalProxyRequestHeaders;
 	private final Integer fixedDelayMilliseconds;
+	private final DelayDistribution delayDistribution;
 	private final String proxyBaseUrl;
 	private final Fault fault;
 	private final List<String> transformers;
@@ -61,11 +62,12 @@ public class ResponseDefinition {
 							  @JsonProperty("headers") HttpHeaders headers,
 							  @JsonProperty("additionalProxyRequestHeaders") HttpHeaders additionalProxyRequestHeaders,
 							  @JsonProperty("fixedDelayMilliseconds") Integer fixedDelayMilliseconds,
+							  @JsonProperty("delayDistribution") DelayDistribution delayDistribution,
 							  @JsonProperty("proxyBaseUrl") String proxyBaseUrl,
 							  @JsonProperty("fault") Fault fault,
 							  @JsonProperty("transformers") List<String> transformers,
 							  @JsonProperty("extensionParameters") Parameters transformerParameters) {
-		this(status, statusMessage, Body.fromOneOf(null, body, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, proxyBaseUrl, fault, transformers, transformerParameters);
+		this(status, statusMessage, Body.fromOneOf(null, body, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, proxyBaseUrl, fault, transformers, transformerParameters);
 	}
 
 	public ResponseDefinition(int status,
@@ -77,11 +79,12 @@ public class ResponseDefinition {
 							  HttpHeaders headers,
 							  HttpHeaders additionalProxyRequestHeaders,
 							  Integer fixedDelayMilliseconds,
+							  DelayDistribution delayDistribution,
 							  String proxyBaseUrl,
 							  Fault fault,
 							  List<String> transformers,
 							  Parameters transformerParameters) {
-		this(status, statusMessage, Body.fromOneOf(body, null, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, proxyBaseUrl, fault, transformers, transformerParameters);
+		this(status, statusMessage, Body.fromOneOf(body, null, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, proxyBaseUrl, fault, transformers, transformerParameters);
 	}
 
 	private ResponseDefinition(int status,
@@ -91,6 +94,7 @@ public class ResponseDefinition {
 							   HttpHeaders headers,
 							   HttpHeaders additionalProxyRequestHeaders,
 							   Integer fixedDelayMilliseconds,
+							   DelayDistribution delayDistribution,
 							   String proxyBaseUrl,
 							   Fault fault,
 							   List<String> transformers,
@@ -104,6 +108,7 @@ public class ResponseDefinition {
 		this.headers = headers;
 		this.additionalProxyRequestHeaders = additionalProxyRequestHeaders;
 		this.fixedDelayMilliseconds = fixedDelayMilliseconds;
+		this.delayDistribution = delayDistribution;
 		this.proxyBaseUrl = proxyBaseUrl;
 		this.fault = fault;
 		this.transformers = transformers;
@@ -111,15 +116,15 @@ public class ResponseDefinition {
 	}
 
 	public ResponseDefinition(final int statusCode, final String bodyContent) {
-		this(statusCode, null, Body.fromString(bodyContent), null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty());
+		this(statusCode, null, Body.fromString(bodyContent), null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty());
 	}
 
 	public ResponseDefinition(final int statusCode, final byte[] bodyContent) {
-		this(statusCode, null, Body.fromBytes(bodyContent), null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty());
+		this(statusCode, null, Body.fromBytes(bodyContent), null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty());
 	}
 
 	public ResponseDefinition() {
-		this(HTTP_OK, null, Body.none(), null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty());
+		this(HTTP_OK, null, Body.none(), null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty());
 	}
 
 	public static ResponseDefinition notFound() {
@@ -162,6 +167,7 @@ public class ResponseDefinition {
 				original.headers,
 				original.additionalProxyRequestHeaders,
 				original.fixedDelayMilliseconds,
+				original.delayDistribution,
 				original.proxyBaseUrl,
 				original.fault,
 				original.transformers,
@@ -215,6 +221,10 @@ public class ResponseDefinition {
 
 	public Integer getFixedDelayMilliseconds() {
 		return fixedDelayMilliseconds;
+	}
+
+	public DelayDistribution getDelayDistribution() {
+		return delayDistribution;
 	}
 
 	@JsonIgnore
@@ -286,6 +296,7 @@ public class ResponseDefinition {
 				Objects.equals(headers, that.headers) &&
 				Objects.equals(additionalProxyRequestHeaders, that.additionalProxyRequestHeaders) &&
 				Objects.equals(fixedDelayMilliseconds, that.fixedDelayMilliseconds) &&
+				Objects.equals(delayDistribution, that.delayDistribution) &&
 				Objects.equals(proxyBaseUrl, that.proxyBaseUrl) &&
 				Objects.equals(browserProxyUrl, that.browserProxyUrl) &&
 				Objects.equals(fault, that.fault) &&
@@ -303,4 +314,5 @@ public class ResponseDefinition {
 	public String toString() {
 		return this.wasConfigured? Json.write(this) : "(no response definition configured)";
 	}
+
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -57,7 +57,7 @@ public class StubResponseRenderer implements ResponseRenderer {
 
 	private Response buildResponse(ResponseDefinition responseDefinition) {
 		addDelayIfSpecifiedGloballyOrIn(responseDefinition);
-		addRandomDelayIn(responseDefinition);
+		addRandomDelayIfSpecifiedGloballyOrIn(responseDefinition);
 
 		if (responseDefinition.isProxyResponse()) {
 			return proxyResponseRenderer.render(responseDefinition);
@@ -123,14 +123,22 @@ public class StubResponseRenderer implements ResponseRenderer {
     	return Optional.fromNullable(delay);
     }
 
-    private void addRandomDelayIn(ResponseDefinition response) {
-        if (response.getDelayDistribution() == null) return;
+    private void addRandomDelayIfSpecifiedGloballyOrIn(ResponseDefinition response) {
+		if (response.getDelayDistribution() != null) {
+			addRandomDelayIn(response.getDelayDistribution());
+		} else {
+			addRandomDelayIn(globalSettingsHolder.get().getDelayDistribution());
+		}
+    }
 
-        long delay = response.getDelayDistribution().sampleMillis();
-        try {
+	private void addRandomDelayIn(DelayDistribution delayDistribution) {
+		if (delayDistribution == null) return;
+
+		long delay = delayDistribution.sampleMillis();
+		try {
            TimeUnit.MILLISECONDS.sleep(delay);
         } catch (InterruptedException e) {
            Thread.currentThread().interrupt();
         }
-    }
+	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -21,9 +21,11 @@ import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
 import com.google.common.base.Optional;
 
+import java.util.concurrent.TimeUnit;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
+
 import static com.github.tomakehurst.wiremock.http.Response.response;
 
 public class StubResponseRenderer implements ResponseRenderer {
@@ -55,6 +57,8 @@ public class StubResponseRenderer implements ResponseRenderer {
 
 	private Response buildResponse(ResponseDefinition responseDefinition) {
 		addDelayIfSpecifiedGloballyOrIn(responseDefinition);
+		addRandomDelayIn(responseDefinition);
+
 		if (responseDefinition.isProxyResponse()) {
 			return proxyResponseRenderer.render(responseDefinition);
 		} else {
@@ -117,5 +121,16 @@ public class StubResponseRenderer implements ResponseRenderer {
     			globalSettingsHolder.get().getFixedDelay();
     	
     	return Optional.fromNullable(delay);
+    }
+
+    private void addRandomDelayIn(ResponseDefinition response) {
+        if (response.getDelayDistribution() == null) return;
+
+        long delay = response.getDelayDistribution().sampleMillis();
+        try {
+           TimeUnit.MILLISECONDS.sleep(delay);
+        } catch (InterruptedException e) {
+           Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/UniformDistribution.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/UniformDistribution.java
@@ -1,0 +1,34 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Distribution that returns values uniformally distributed across a range.
+ *
+ * That is, given a uniform distribution of 50 to 60 ms, there will be an equal
+ * spread of delays between 50 and 60. This would useful for representing an
+ * average delay of 55ms with a +/- 5ms jitter.
+ */
+public final class UniformDistribution implements DelayDistribution {
+
+    @JsonProperty("lower")
+    private final int lower;
+    @JsonProperty("upper")
+    private final int upper;
+
+    /**
+     * @param lower lower bound inclusive
+     * @param upper upper bound inclusive
+     */
+    public UniformDistribution(@JsonProperty("lower") int lower, @JsonProperty("upper") int upper) {
+        this.lower = lower;
+        this.upper = upper;
+    }
+
+    @Override
+    public long sampleMillis() {
+        return ThreadLocalRandom.current().nextLong(lower, upper + 1);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsAcceptanceTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.http.LogNormal;
 import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -35,5 +36,30 @@ public class GlobalSettingsAcceptanceTest extends AcceptanceTestBase {
         
         assertThat(duration, greaterThanOrEqualTo(500));
 	}
-	
+
+	@Test
+	public void settingGlobalRandomDistributionDelayCausesADelay() {
+		WireMock.setGlobalRandomDelay(new LogNormal(90, 0.1));
+		givenThat(get(urlEqualTo("/globally/random/delayed/resource")).willReturn(aResponse().withStatus(200)));
+
+		long start = System.currentTimeMillis();
+		testClient.get("/globally/random/delayed/resource");
+		int duration = (int) (System.currentTimeMillis() - start);
+
+		assertThat(duration, greaterThanOrEqualTo(60));
+	}
+
+	@Test
+	public void canCombineFixedAndRandomDelays() {
+		WireMock.setGlobalRandomDelay(new LogNormal(90, 0.1));
+		WireMock.setGlobalFixedDelay(30);
+		givenThat(get(urlEqualTo("/globally/random/delayed/resource")).willReturn(aResponse().withStatus(200)));
+
+		long start = System.currentTimeMillis();
+		testClient.get("/globally/random/delayed/resource");
+		int duration = (int) (System.currentTimeMillis() - start);
+
+		assertThat(duration, greaterThanOrEqualTo(90));
+	}
+
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.http.LogNormal;
 import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.http.UniformDistribution;
 import com.github.tomakehurst.wiremock.stubbing.ListStubMappingsResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -232,21 +233,35 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(duration, greaterThanOrEqualTo(500));
 	}
 
-	 @Test
-    public void responseWithRandomDistributionDelay() {
-        stubFor(get(urlEqualTo("/random/delayed/resource")).willReturn(
+	@Test
+    public void responseWithLogNormalDistributedDelay() {
+        stubFor(get(urlEqualTo("/lognormal/delayed/resource")).willReturn(
                 aResponse()
                 		.withStatus(200)
                 		.withBody("Content")
                 		.withRandomDelay(new LogNormal(90, 0.1))));
 
         long start = System.currentTimeMillis();
-        testClient.get("/random/delayed/resource");
+        testClient.get("/lognormal/delayed/resource");
         int duration = (int) (System.currentTimeMillis() - start);
 
         assertThat(duration, greaterThanOrEqualTo(60));
     }
 
+	@Test
+	public void responseWithUniformDistributedDelay() {
+		stubFor(get(urlEqualTo("/uniform/delayed/resource")).willReturn(
+				aResponse()
+						.withStatus(200)
+						.withBody("Content")
+						.withRandomDelay(new UniformDistribution(50, 60))));
+
+		long start = System.currentTimeMillis();
+		testClient.get("/uniform/delayed/resource");
+		int duration = (int) (System.currentTimeMillis() - start);
+
+		assertThat(duration, greaterThanOrEqualTo(50));
+	}
 
 	@Test
 	public void highPriorityMappingMatchedFirst() {

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock;
 
+import com.github.tomakehurst.wiremock.http.LogNormal;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.stubbing.ListStubMappingsResult;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
@@ -230,6 +231,22 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 
         assertThat(duration, greaterThanOrEqualTo(500));
 	}
+
+	 @Test
+    public void responseWithRandomDistributionDelay() {
+        stubFor(get(urlEqualTo("/random/delayed/resource")).willReturn(
+                aResponse()
+                		.withStatus(200)
+                		.withBody("Content")
+                		.withRandomDelay(new LogNormal(90, 0.1))));
+
+        long start = System.currentTimeMillis();
+        testClient.get("/random/delayed/resource");
+        int duration = (int) (System.currentTimeMillis() - start);
+
+        assertThat(duration, greaterThanOrEqualTo(60));
+    }
+
 
 	@Test
 	public void highPriorityMappingMatchedFirst() {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/LogNormalTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/LogNormalTest.java
@@ -1,0 +1,22 @@
+package com.github.tomakehurst.wiremock.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+public class LogNormalTest {
+
+    // To test properly we would need something like a normality test.
+    // For our purposes, a simple verification is sufficient.
+    @Test
+    public void samplingLogNormalHasExpectedMean() {
+        LogNormal distribution = new LogNormal(90.0, 0.39);
+        int n = 10000;
+
+        long sum = 0;
+        for (int i = 0; i < n; i++) {
+            sum += distribution.sampleMillis();
+        }
+
+        assertEquals(97.1115, sum / (double) n, 5.0);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/UniformDistributionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/UniformDistributionTest.java
@@ -1,0 +1,30 @@
+package com.github.tomakehurst.wiremock.http;
+
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class UniformDistributionTest {
+
+    @Test
+    public void shouldReturnAllValuesInTheRange() {
+        DelayDistribution distribution = new UniformDistribution(3, 4);
+
+        boolean[] found = new boolean[5];
+        Arrays.fill(found, false);
+
+        for (int i = 0; i < 100; i++) {
+           found[(int) distribution.sampleMillis()] = true;
+        }
+
+        assertThat("found 0", found[0], is(false));
+        assertThat("found 1", found[1], is(false));
+        assertThat("found 2", found[2], is(false));
+        assertThat("found 3", found[3], is(true));
+        assertThat("found 4", found[4], is(true));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -49,6 +49,7 @@ public class ResponseDefinitionTest {
                 new HttpHeaders(httpHeader("thing", "thingvalue")),
                 null,
                 1112,
+                null,
                 "http://base.com",
                 Fault.EMPTY_RESPONSE,
                 ImmutableList.of("transformer-1"),


### PR DESCRIPTION
This expands on the existing fixed delay functionality by providing a
more general feature to draw values from a random distribution.

This allows teams to simulate long tails in delays from downstream
systems, a common scenario in load and resiliency tests.

I've provided a log normal implementation out of the box, which gives a
pretty good long tail distribution for modeling delays. It also has the
nice benefit of being able to specify the 50th percentile which is a
commonly tracked metric.

Here is an example priming using the log normal delay:

```json
{
    "request": {
            "method": "GET",
            "url": "/some/thing"
    },
    "response": {
            "status": 200,
            "body": "Hello world!",
            "headers": {
                    "Content-Type": "text/plain"
            },
            "delayDistribution": {
                    "type": "lognormal",
                    "median": 80,
                    "sigma": 0.4
            }

    }
}
```

This example can be viewed visually at wolfram alpha:
https://www.wolframalpha.com/input/?i=lognormaldistribution%28log%2890%29%2C+0.4%29

New distributions can be added by implementing `DelayDistribution` and
adding it to the @JsonTypeInfo in the interface.