### PR TITLE
Upgrade to Jetty 9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ apply plugin: 'idea'
 apply plugin: 'project-report'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 group = 'com.github.tomakehurst'
 version = '2.0.8-beta'
 
@@ -34,7 +34,7 @@ def shouldPublishLocally = System.getProperty('LOCAL_PUBLISH')
 
 def versions = [
         jackson: '2.6.1',
-        jetty  : '9.2.13.v20150730'
+        jetty  : '9.3.6.v20151106'
 ]
 
 repositories {

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -30,10 +30,10 @@ import com.github.tomakehurst.wiremock.servlet.TrailingSlashFilter;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.servlets.GzipFilter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
@@ -89,7 +89,9 @@ class JettyHttpServer implements HttpServer {
         );
 
         HandlerCollection handlers = new HandlerCollection();
-        handlers.setHandlers(new Handler[]{adminContext, mockServiceContext});
+        GzipHandler gzipHandler = new GzipHandler();
+        gzipHandler.setHandler(mockServiceContext);
+        handlers.setHandlers(new Handler[]{adminContext, gzipHandler});
         jettyServer.setHandler(handlers);
 
         jettyServer.setStopTimeout(0);
@@ -252,7 +254,6 @@ class JettyHttpServer implements HttpServer {
 
         mockServiceContext.setWelcomeFiles(new String[]{"index.json", "index.html", "index.xml", "index.txt"});
 
-        mockServiceContext.addFilter(GzipFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD));
         mockServiceContext.addFilter(ContentTypeSettingFilter.class, FILES_URL_MATCH, EnumSet.of(DispatcherType.FORWARD));
         mockServiceContext.addFilter(TrailingSlashFilter.class, FILES_URL_MATCH, EnumSet.allOf(DispatcherType.class));
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
@@ -164,7 +164,7 @@ public class JettyHttpServletRequestAdapter implements Request {
     public boolean isBrowserProxyRequest() {
         if (request instanceof org.eclipse.jetty.server.Request) {
             org.eclipse.jetty.server.Request jettyRequest = (org.eclipse.jetty.server.Request) request;
-            return URI.create(jettyRequest.getUri().toString()).isAbsolute();
+            return URI.create(jettyRequest.getHttpURI().toString()).isAbsolute();
         }
 
         return false;


### PR DESCRIPTION
Latest Jetty is 9.3.

Changes:
- Upgrade to JDK8. Jetty 9.3 is now built against JDK8, as cyphers used for HTTP/2.0 are not available in JDK7.
- `org.eclipse.jetty.server.Request#getUri` was renamed into `getHttpURI`
- `GzipFilter` no longer works. `GzipHandler` must be used instead.
