### PR TITLE
Add support for requiring absent query parameters

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/RequestPatternBuilder.java
@@ -39,6 +39,7 @@ public class RequestPatternBuilder {
 	private Map<String, ValueMatchingStrategy> headers = newLinkedHashMap();
     private Map<String, ValueMatchingStrategy> queryParameters = newLinkedHashMap();
     private Set<String> withoutHeaders = newHashSet();
+    private Set<String> withoutQueryParameters = newHashSet();
 	private List<ValueMatchingStrategy> bodyPatterns = newArrayList();
 
 	private RequestMatcher customMatcher;
@@ -83,6 +84,11 @@ public class RequestPatternBuilder {
         return this;
     }
 
+    public RequestPatternBuilder withoutQueryParameter(String key) {
+        withoutQueryParameters.add(key);
+        return this;
+    }
+
 	public RequestPatternBuilder withRequestBody(ValueMatchingStrategy bodyMatchingStrategy) {
 		bodyPatterns.add(bodyMatchingStrategy);
 		return this;
@@ -116,6 +122,10 @@ public class RequestPatternBuilder {
 
         for (Map.Entry<String, ValueMatchingStrategy> queryParam: queryParameters.entrySet()) {
             requestPattern.addQueryParam(queryParam.getKey(), queryParam.getValue().asValuePattern());
+        }
+
+        for (String key: withoutQueryParameters) {
+            requestPattern.addQueryParam(key, ValuePattern.absent());
         }
 
 		if (!bodyPatterns.isEmpty()) {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/RequestPatternBuilder.java
@@ -84,7 +84,7 @@ public class RequestPatternBuilder {
         return this;
     }
 
-    public RequestPatternBuilder withoutQueryParameter(String key) {
+    public RequestPatternBuilder withoutQueryParam(String key) {
         withoutQueryParameters.add(key);
         return this;
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/QueryParameter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/QueryParameter.java
@@ -18,6 +18,8 @@ package com.github.tomakehurst.wiremock.http;
 import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
+
 public class QueryParameter extends MultiValue {
 
     public QueryParameter(String key, List<String> values) {
@@ -26,5 +28,9 @@ public class QueryParameter extends MultiValue {
 
     public static QueryParameter absent(String key) {
         return new QueryParameter(key, Collections.<String>emptyList());
+    }
+
+    public static QueryParameter queryParameter(String key, String... values) {
+        return new QueryParameter(key, asList(values));
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -29,6 +29,7 @@ public interface Request {
 	boolean containsHeader(String key);
 	Set<String> getAllHeaderKeys();
     QueryParameter queryParameter(String key);
+    Set<String> getAllQueryParameterKeys();
     byte[] getBody();
     String getBodyAsString();
 	boolean isBrowserProxyRequest();

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
@@ -161,6 +161,11 @@ public class JettyHttpServletRequestAdapter implements Request {
     }
 
     @Override
+    public Set<String> getAllQueryParameterKeys() {
+        return splitQuery(request.getQueryString()).keySet();
+    }
+
+    @Override
     public boolean isBrowserProxyRequest() {
         if (request instanceof org.eclipse.jetty.server.Request) {
             org.eclipse.jetty.server.Request jettyRequest = (org.eclipse.jetty.server.Request) request;

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -148,6 +148,12 @@ public class LoggedRequest implements Request {
         return queryParams.get(key);
     }
 
+    @Override
+    @JsonIgnore
+    public Set<String> getAllQueryParameterKeys() {
+        return queryParams.keySet();
+    }
+
     public HttpHeaders getHeaders() {
         return headers;
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -194,6 +194,18 @@ public class VerificationAcceptanceTest {
         }
 
         @Test(expected=VerificationException.class)
+        public void verifyIsFalseWhenAbsentQueryParamNotPresent() {
+            testClient.get("/query?param=my-value");
+            verify(getRequestedFor(urlPathEqualTo("/query")).withoutQueryParam("param"));
+        }
+
+        @Test
+        public void verifyAbsentQueryParam() {
+            testClient.get("/query?param=my-value");
+            verify(getRequestedFor(urlPathEqualTo("/query")).withoutQueryParam("otherparam"));
+        }
+
+        @Test(expected=VerificationException.class)
         public void resetErasesCounters() {
             testClient.get("/count/this");
             testClient.get("/count/this");

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/RequestPatternTest.java
@@ -322,6 +322,67 @@ public class RequestPatternTest {
     }
 
     @Test
+    public void shouldFailMatchWhenRequiredAbsentQueryParameterIsPresent() {
+        ignoringNotifier();
+
+        RequestPattern requestPattern = new RequestPattern(GET, "/without/queryparam/fail");
+        requestPattern.addQueryParam("myparam", ValuePattern.absent());
+        Request request = aRequest(context)
+                .withUrl("/without/queryparam/fail")
+                .withMethod(GET)
+                .withQueryParameter("myparam", "value")
+                .build();
+
+        assertFalse("Request is a match for the request pattern and should not be", requestPattern.isMatchedBy(request));
+    }
+
+    @Test
+    public void shouldMatchWhenSpecifiedQueryParametersArePresent() {
+        RequestPattern requestPattern = new RequestPattern(GET, "/queryparam/dependent/resource");
+        requestPattern.addQueryParam("myparam1", equalTo("value1"));
+        requestPattern.addQueryParam("myparam2", equalTo("value2"));
+        Request request = aRequest(context)
+                .withUrl("/queryparam/dependent/resource")
+                .withMethod(GET)
+                .withQueryParameter("myparam1", "value1")
+                .withQueryParameter("myparam2", "value2")
+                .build();
+
+        assertTrue("Request is not a match for the request pattern and should be", requestPattern.isMatchedBy(request));
+    }
+
+    @Test
+    public void shouldNotMatchWhenASpecifiedQueryParameterIsAbsent() {
+        ignoringNotifier();
+
+        RequestPattern requestPattern = new RequestPattern(GET, "/queryparam/dependent/resource");
+        requestPattern.addQueryParam("myparam1", equalTo("value1"));
+        requestPattern.addQueryParam("myparam2", equalTo("value2"));
+        Request request = aRequest(context)
+                .withUrl("/queryparam/dependent/resource")
+                .withMethod(GET)
+                .withQueryParameter("myparam1", "value1")
+                .build();
+
+        assertFalse("Request is a match for the request pattern and should not be", requestPattern.isMatchedBy(request));
+    }
+
+    @Test
+    public void shouldNotMatchWhenASpecifiedQueryParameterHasAnIncorrectValue() {
+        ignoringNotifier();
+
+        RequestPattern requestPattern = new RequestPattern(GET, "/queryparam/dependent/resource");
+        requestPattern.addQueryParam("myparam1", equalTo("value1"));
+        Request request = aRequest(context)
+                .withUrl("/queryparam/dependent/resource")
+                .withMethod(GET)
+                .withQueryParameter("myparam1", "other value")
+                .build();
+
+        assertFalse("Request is a match for the request pattern and should not be", requestPattern.isMatchedBy(request));
+    }
+
+    @Test
 	public void shouldLogMessageIndicatingFailedMethodMatch() {
 		context.checking(new Expectations() {{
 			one(notifier).info("URL /for/logging is match, but method GET is not");

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -16,15 +16,17 @@
 package com.github.tomakehurst.wiremock.testsupport;
 
 import com.github.tomakehurst.wiremock.http.*;
+import com.google.common.collect.Sets;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
+import static com.github.tomakehurst.wiremock.http.QueryParameter.queryParameter;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
-import static com.google.common.collect.Lists.asList;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newLinkedHashSet;
 
@@ -106,9 +108,13 @@ public class MockRequestBuilder {
                 }
             }
 
+            Set<String> queryParameterKeys = Sets.newLinkedHashSet();
 			for (QueryParameter queryParameter: queryParameters) {
 				allowing(request).queryParameter(queryParameter.key()); will(returnValue(queryParameter));
+                queryParameterKeys.add(queryParameter.key());
 			}
+            allowing(request).getAllQueryParameterKeys(); will(returnValue(newLinkedHashSet(queryParameterKeys)));
+            allowing(request).queryParameter(with(any(String.class))); will(returnValue(queryParameter("key", "value")));
 
             allowing(request).header(with(any(String.class))); will(returnValue(httpHeader("key", "value")));
 


### PR DESCRIPTION
There are some use cases when we would like to verify a query parameter is not being sent.
This pull request adds this ability by adding a `withoutQueryParam` method to the `RequestPatternBuilder` (similar to `withoutHeader`).