### PR TITLE
Fix ClassCastException in CommandLineOptions.extensionOfType

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 group = 'com.github.tomakehurst'
-version = '2.0.8-beta'
+version = '2.0.9-beta'
 
 def shouldPublishLocally = System.getProperty('LOCAL_PUBLISH')
 

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -256,14 +256,14 @@ public class CommandLineOptions implements Options {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends Extension> Map<String, T> extensionsOfType(Class<T> extensionType) {
+    public <T extends Extension> Map<String, T> extensionsOfType(final Class<T> extensionType) {
         if (optionSet.has(EXTENSIONS)) {
             String classNames = (String) optionSet.valueOf(EXTENSIONS);
             return (Map<String, T>) Maps.filterEntries(ExtensionLoader.load(classNames.split(",")), 
                             new Predicate<Map.Entry<String, Extension>>() {
                                 @Override
                                 public boolean apply(Map.Entry<String, Extension> input) {
-                                    return input.getValue().getClass().isAssignableFrom(input.getValue().getClass());
+                                    return extensionType.isAssignableFrom(input.getValue().getClass());
                                 }
             });
         }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -259,10 +259,10 @@ public class CommandLineOptions implements Options {
     public <T extends Extension> Map<String, T> extensionsOfType(Class<T> extensionType) {
         if (optionSet.has(EXTENSIONS)) {
             String classNames = (String) optionSet.valueOf(EXTENSIONS);
-            return (Map<String, T>) Maps.filterEntries(ExtensionLoader.loadExtension(classNames.split(",")), 
-                            new Predicate<Map.Entry<String, Object>>() {
+            return (Map<String, T>) Maps.filterEntries(ExtensionLoader.load(classNames.split(",")), 
+                            new Predicate<Map.Entry<String, Extension>>() {
                                 @Override
-                                public boolean apply(Map.Entry<String, Object> input) {
+                                public boolean apply(Map.Entry<String, Extension> input) {
                                     return input.getValue().getClass().isAssignableFrom(input.getValue().getClass());
                                 }
             });

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -15,7 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.standalone;
 
-import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
+import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URI;
@@ -24,27 +27,30 @@ import java.util.List;
 import java.util.Map;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.common.*;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.HttpsSettings;
+import com.github.tomakehurst.wiremock.common.JettySettings;
+import com.github.tomakehurst.wiremock.common.Notifier;
+import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionLoader;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
+import com.github.tomakehurst.wiremock.http.HttpServerFactory;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
 import com.google.common.collect.UnmodifiableIterator;
 import com.google.common.io.Resources;
+
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
-
-import static com.github.tomakehurst.wiremock.common.ProxySettings.*;
-import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.*;
-
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
-import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS;
 
 public class CommandLineOptions implements Options {
 	
@@ -249,10 +255,17 @@ public class CommandLineOptions implements Options {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T extends Extension> Map<String, T> extensionsOfType(Class<T> extensionType) {
         if (optionSet.has(EXTENSIONS)) {
             String classNames = (String) optionSet.valueOf(EXTENSIONS);
-            return ExtensionLoader.loadExtension(classNames.split(","));
+            return (Map<String, T>) Maps.filterEntries(ExtensionLoader.loadExtension(classNames.split(",")), 
+                            new Predicate<Map.Entry<String, Object>>() {
+                                @Override
+                                public boolean apply(Map.Entry<String, Object> input) {
+                                    return input.getValue().getClass().isAssignableFrom(input.getValue().getClass());
+                                }
+            });
         }
 
         return Collections.emptyMap();

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
 import com.google.common.base.Optional;
 import org.junit.Test;
 
@@ -261,25 +262,52 @@ public class CommandLineOptionsTest {
     public void returnsExtensionsSpecifiedAsClassNames() {
         CommandLineOptions options = new CommandLineOptions(
                 "--extensions",
-                "com.github.tomakehurst.wiremock.standalone.CommandLineOptionsTest$Ext1,com.github.tomakehurst.wiremock.standalone.CommandLineOptionsTest$Ext2");
+                "com.github.tomakehurst.wiremock.standalone.CommandLineOptionsTest$ResponseDefinitionTransformerExt1,com.github.tomakehurst.wiremock.standalone.CommandLineOptionsTest$ResponseDefinitionTransformerExt2,com.github.tomakehurst.wiremock.standalone.CommandLineOptionsTest$RequestExt1");
         Map<String, ResponseDefinitionTransformer> extensions = options.extensionsOfType(ResponseDefinitionTransformer.class);
-        assertThat(extensions.get("one"), instanceOf(Ext1.class));
-        assertThat(extensions.get("two"), instanceOf(Ext2.class));
+        assertThat(extensions.entrySet(), hasSize(2));
+        assertThat(extensions.get("ResponseDefinitionTransformer_One"), instanceOf(ResponseDefinitionTransformerExt1.class));
+        assertThat(extensions.get("ResponseDefinitionTransformer_Two"), instanceOf(ResponseDefinitionTransformerExt2.class));
     }
     
-    public static class Ext1 extends ResponseDefinitionTransformer {
-        @Override
-        public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource files, Parameters parameters) { return null; }
-
-        @Override
-        public String name() { return "one"; }
+    @Test
+    public void returnsRequestMatcherExtensionsSpecifiedAsClassNames() {
+        CommandLineOptions options = new CommandLineOptions(
+                        "--extensions",
+                        "com.github.tomakehurst.wiremock.standalone.CommandLineOptionsTest$RequestExt1,com.github.tomakehurst.wiremock.standalone.CommandLineOptionsTest$ResponseDefinitionTransformerExt1");
+        Map<String, RequestMatcherExtension> extensions = options.extensionsOfType(RequestMatcherExtension.class);
+        assertThat(extensions.entrySet(), hasSize(1));
+        assertThat(extensions.get("RequestMatcherExtension_One"), instanceOf(RequestExt1.class));
     }
-
-    public static class Ext2 extends ResponseDefinitionTransformer {
+    
+    @Test
+    public void returnsEmptySetForNoExtensionsSpecifiedAsClassNames() {
+        CommandLineOptions options = new CommandLineOptions();
+        Map<String, RequestMatcherExtension> extensions = options.extensionsOfType(RequestMatcherExtension.class);
+        assertThat(extensions.entrySet(), hasSize(0));
+    }
+    
+    public static class ResponseDefinitionTransformerExt1 extends ResponseDefinitionTransformer {
         @Override
         public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource files, Parameters parameters) { return null; }
+        
+        @Override
+        public String name() { return "ResponseDefinitionTransformer_One"; }
+    }
+    
+    public static class ResponseDefinitionTransformerExt2 extends ResponseDefinitionTransformer {
+        @Override
+        public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource files, Parameters parameters) { return null; }
+        
+        @Override
+        public String name() { return "ResponseDefinitionTransformer_Two"; }
+    }
+    
+    public static class RequestExt1 extends RequestMatcherExtension {
+        
+        @Override
+        public String name() { return "RequestMatcherExtension_One"; }
 
         @Override
-        public String name() { return "two"; }
+        public boolean isMatchedBy(Request request, Parameters parameters) { return false; }
     }
 }


### PR DESCRIPTION
Prevent ClassCastException when adding custom RequestMatcher or
ResponseDefinitionTransformer via command line option.