### PR TITLE
add content-length to response header

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -16,13 +16,12 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.google.common.base.Optional;
+import com.sun.deploy.net.HttpRequest;
 
 import java.nio.charset.Charset;
-import java.util.Arrays;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeaders.noHeaders;
 import static com.google.common.base.Charsets.UTF_8;
-import static com.google.common.collect.Iterables.transform;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 
@@ -58,7 +57,7 @@ public class Response {
 		this.status = status;
         this.statusMessage = statusMessage;
         this.body = body;
-        this.headers = headers;
+        this.headers = addContentLength(headers,body==null?0:body.length);
         this.configured = configured;
         this.fault = fault;
         this.fromProxy = fromProxy;
@@ -68,7 +67,7 @@ public class Response {
     public Response(int status, String statusMessage, String body, HttpHeaders headers, boolean configured, Fault fault, boolean fromProxy, Optional<ResponseDefinition> renderedFromDefinition) {
         this.status = status;
         this.statusMessage = statusMessage;
-        this.headers = headers;
+        this.headers = addContentLength(headers, body==null?0:body.length());
         this.renderedFromDefinition = renderedFromDefinition;
         this.body = body == null ? null : body.getBytes(encodingFromContentTypeHeaderOrUtf8());
         this.configured = configured;
@@ -76,6 +75,13 @@ public class Response {
         this.fromProxy = fromProxy;
     }
 
+    private HttpHeaders addContentLength(HttpHeaders headers, int bodyLength)
+    {
+        if(!headers.getHeader(HttpRequest.CONTENT_LENGTH).isPresent()){
+            return headers.plus(HttpHeader.httpHeader(CaseInsensitiveKey.from(HttpRequest.CONTENT_LENGTH), String.valueOf(bodyLength)));
+        }
+        return headers;
+    }
 	public int getStatus() {
 		return status;
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubRequestHandlerTest.java
@@ -16,7 +16,6 @@
 package com.github.tomakehurst.wiremock.stubbing;
 
 import com.github.tomakehurst.wiremock.core.StubServer;
-import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.http.*;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -25,7 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Collections;
 
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
 import static com.github.tomakehurst.wiremock.http.Response.response;
@@ -58,15 +56,16 @@ public class StubRequestHandlerTest {
             Response response = response().status(200).body("Body content").build();
 			allowing(responseRenderer).render(with(any(ResponseDefinition.class))); will(returnValue(response));
 		}});
-		
+
 		Request request = aRequest(context)
 			.withUrl("/the/required/resource")
 			.withMethod(GET)
 			.build();
 		Response response = requestHandler.handle(request);
-		
+
 		assertThat(response.getStatus(), is(200));
 		assertThat(response.getBodyAsString(), is("Body content"));
+		assertThat(response.getHeaders().getHeader("Content-Length").firstValue(), is("12"));
 	}
 	
 	@Test


### PR DESCRIPTION
Some HTTP clients read or validate the response according to the content-length header.
Although there are ways to workaround this by pre-calculating the content-length and adding it to a stubbed response or maybe customizing a ResponseTransformer - it's nicer to have it supported transparently