### PR TITLE
Added bodyAsBase64 element to LoggedRequest JSON in requests find output

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -31,5 +31,6 @@ public interface Request {
     QueryParameter queryParameter(String key);
     byte[] getBody();
     String getBodyAsString();
+    String getBodyAsBase64();
 	boolean isBrowserProxyRequest();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
@@ -15,10 +15,14 @@
  */
 package com.github.tomakehurst.wiremock.jetty9;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.base.Optional;
 
 import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.codec.binary.Base64;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.Enumeration;
@@ -94,6 +98,11 @@ public class JettyHttpServletRequestAdapter implements Request {
     public String getBodyAsString() {
         return stringFromBytes(getBody());
     }
+    
+    @Override
+	public String getBodyAsBase64(){
+		return Base64.encodeBase64String(getBody());
+	}
 
     @SuppressWarnings("unchecked")
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -28,6 +28,8 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.codec.binary.Base64;
+
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
 import static com.github.tomakehurst.wiremock.http.HttpHeaders.copyOf;
@@ -135,6 +137,12 @@ public class LoggedRequest implements Request {
     @JsonProperty("body")
 	public String getBodyAsString() {
         return stringFromBytes(body);
+	}
+	
+	@Override
+	@JsonProperty("bodyAsBase64")
+	public String getBodyAsBase64(){
+		return Base64.encodeBase64String(body);
 	}
 
 	@Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.http.*;
-import com.google.common.base.Charsets;
 
 import java.net.URI;
 import java.text.SimpleDateFormat;
@@ -53,23 +52,23 @@ public class LoggedRequest implements Request {
                 request.getAbsoluteUrl(),
                 request.getMethod(),
                 copyOf(request.getHeaders()),
-                request.getBody(),
                 request.isBrowserProxyRequest(),
-                new Date());
+                new Date(),
+                request.getBodyAsBase64());
 	}
 
     public LoggedRequest(String url,
                          String absoluteUrl,
                          RequestMethod method,
                          HttpHeaders headers,
-                         byte[] body,
                          boolean isBrowserProxyRequest,
-                         Date loggedDate) {
-
+                         Date loggedDate,
+                         String bodyAsBase64)
+    {
         this.url = url;
         this.absoluteUrl = absoluteUrl;
         this.method = method;
-        this.body = body;
+        this.body = Base64.decodeBase64(bodyAsBase64);
         this.headers = headers;
         this.queryParams = splitQuery(URI.create(url));
         this.isBrowserProxyRequest = isBrowserProxyRequest;
@@ -78,15 +77,18 @@ public class LoggedRequest implements Request {
 
     @JsonCreator
     public LoggedRequest(@JsonProperty("url") String url,
-                         @JsonProperty("absoluteUrl") String absoluteUrl,
-                         @JsonProperty("method") RequestMethod method,
-                         @JsonProperty("headers") HttpHeaders headers,
-                         @JsonProperty("body") String body,
-                         @JsonProperty("browserProxyRequest") boolean isBrowserProxyRequest,
-                         @JsonProperty("loggedDate") Date loggedDate) {
-        this(url, absoluteUrl, method, headers, body.getBytes(Charsets.UTF_8), isBrowserProxyRequest, loggedDate);
+    		@JsonProperty("absoluteUrl") String absoluteUrl,
+    		@JsonProperty("method") RequestMethod method,
+    		@JsonProperty("headers") HttpHeaders headers,
+    		@JsonProperty("browserProxyRequest") boolean isBrowserProxyRequest,
+    		@JsonProperty("loggedDate") Date loggedDate,
+    		@JsonProperty("body") String body,
+    		@JsonProperty("loggedDateString") String loggedDateString,
+    		@JsonProperty("bodyAsBase64") String bodyAsBase64)
+    {
+    	this(url, absoluteUrl, method, headers, isBrowserProxyRequest, loggedDate, bodyAsBase64);
     }
-
+    
 	@Override
 	public String getUrl() {
 		return url;

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.testsupport;
 
 import com.github.tomakehurst.wiremock.http.*;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 
@@ -24,7 +25,6 @@ import java.util.List;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
-import static com.google.common.collect.Lists.asList;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Sets.newLinkedHashSet;
 
@@ -36,6 +36,7 @@ public class MockRequestBuilder {
     private List<HttpHeader> individualHeaders = newArrayList();
 	private List<QueryParameter> queryParameters = newArrayList();
 	private String body = "";
+	private String bodyAsBase64 = "";
 
 	private boolean browserProxyRequest = false;
 	private String mockName;
@@ -82,6 +83,11 @@ public class MockRequestBuilder {
 		return this;
 	}
 	
+	public MockRequestBuilder withBodyAsBase64(String bodyAsBase64) {
+		this.bodyAsBase64 = bodyAsBase64;
+		return this;
+	}
+	
 	public MockRequestBuilder asBrowserProxyRequest() {
 		this.browserProxyRequest = true;
 		return this;
@@ -117,6 +123,7 @@ public class MockRequestBuilder {
 			allowing(request).containsHeader(with(any(String.class))); will(returnValue(false));
 			allowing(request).getBody(); will(returnValue(body.getBytes()));
 			allowing(request).getBodyAsString(); will(returnValue(body));
+			allowing(request).getBodyAsBase64(); will(returnValue(bodyAsBase64));
 			allowing(request).getAbsoluteUrl(); will(returnValue("http://localhost:8080" + url));
 			allowing(request).isBrowserProxyRequest(); will(returnValue(browserProxyRequest));
 		}});

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -43,6 +43,7 @@ import static org.junit.Assert.*;
 public class LoggedRequestTest {
 
     public static final String REQUEST_BODY = "some text 形声字形聲字";
+    public static final String REQUEST_BODY_AS_BASE64 = "c29tZSB0ZXh0IOW9ouWjsOWtl+W9ouiBsuWtlw==";
 
     private Mockery context;
 
@@ -69,7 +70,7 @@ public class LoggedRequestTest {
         assertTrue(loggedRequest.containsHeader("Accept"));
         assertNotNull(loggedRequest.getHeader("Accept"));
     }
-
+    
     static  final String DATE = "2012-06-07 16:39:41";
     static final String JSON_EXAMPLE = "{\n" +
             "      \"url\" : \"/my/url\",\n" +
@@ -81,7 +82,8 @@ public class LoggedRequestTest {
             "      \"body\" : \"" + REQUEST_BODY + "\",\n" +
             "      \"browserProxyRequest\" : true,\n" +
             "      \"loggedDate\" : %d,\n" +
-            "      \"loggedDateString\" : \"" + DATE + "\"\n" +
+            "      \"loggedDateString\" : \"" + DATE + "\",\n" +
+            "      \"bodyAsBase64\" : \"" + REQUEST_BODY_AS_BASE64 + "\"\n" +
             "    }";
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.verification;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-import com.google.common.base.Charsets;
 
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
@@ -58,7 +57,8 @@ public class LoggedRequestTest {
         LoggedRequest loggedRequest = createFrom(aRequest(context)
                 .withUrl("/for/logging")
                 .withMethod(POST)
-                .withBody("Actual Content")
+                .withBody(REQUEST_BODY)
+                .withBodyAsBase64(REQUEST_BODY_AS_BASE64)
                 .withHeader("Content-Type", "text/plain")
                 .withHeader("ACCEPT", "application/json")
                 .build());
@@ -79,9 +79,9 @@ public class LoggedRequestTest {
             "      \"headers\" : {\n" +
             "        \"Accept-Language\" : \"en-us,en;q=0.5\"\n" +
             "      },\n" +
-            "      \"body\" : \"" + REQUEST_BODY + "\",\n" +
             "      \"browserProxyRequest\" : true,\n" +
             "      \"loggedDate\" : %d,\n" +
+            "      \"body\" : \"" + REQUEST_BODY + "\",\n" +
             "      \"loggedDateString\" : \"" + DATE + "\",\n" +
             "      \"bodyAsBase64\" : \"" + REQUEST_BODY_AS_BASE64 + "\"\n" +
             "    }";
@@ -97,9 +97,10 @@ public class LoggedRequestTest {
                 "http://mydomain.com/my/url",
                 RequestMethod.GET,
                 headers,
-                REQUEST_BODY,
                 true,
-                loggedDate);
+                loggedDate,
+                REQUEST_BODY_AS_BASE64
+                );
 
         String expectedJson = String.format(JSON_EXAMPLE, loggedDate.getTime());
         assertThat(Json.write(loggedRequest), equalToIgnoringWhiteSpace(expectedJson));
@@ -112,9 +113,10 @@ public class LoggedRequestTest {
             "http://mydomain.com/my/url",
             RequestMethod.GET,
             null,
-            REQUEST_BODY.getBytes(Charsets.UTF_8),
             true,
-            null);
+            null,
+            REQUEST_BODY_AS_BASE64
+            );
 
         assertThat(loggedRequest.getBodyAsString(), is(equalTo(REQUEST_BODY)));
     }


### PR DESCRIPTION
In order to pass back a binary body such as a zip or jpeg exactly as received in the original request for verification, we need a new `bodyAsBase64` element in the `LoggedRequest` JSON. The original string element `body` corrupts the stored byte array so this was needed as there was no way to retrieve it otherwise.
So calling the usual `http://<host>:<port>/__admin/requests/find` will return the same JSON as before but now it will also have something like this example...

`"bodyAsBase64": "TXkgdGV4dAo=",`

... at the same level as `"body": "My text"` element.

For the moment, this is only in the REST API, not the Java API. We tried the Java API after finding that the REST API didn't return binary but that has the same issue.