### PR TITLE
Create new client every time, to work around obscure and I/O-level multi-threading issues

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -51,18 +51,20 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     private static final String CONTENT_LENGTH = "content-length";
     private static final String HOST_HEADER = "host";
 
-    private final HttpClient client;
     private final boolean preserveHostHeader;
     private final String hostHeaderValue;
-	
+	private final ProxySettings proxySettings;
+	private final KeyStoreSettings trustStoreSettings;
+
 	public ProxyResponseRenderer(ProxySettings proxySettings, KeyStoreSettings trustStoreSettings, boolean preserveHostHeader, String hostHeaderValue) {
-		client = HttpClientFactory.createClient(1000, 5 * MINUTES, proxySettings, trustStoreSettings);
+		this.proxySettings = proxySettings;
+		this.trustStoreSettings = trustStoreSettings;
 
         this.preserveHostHeader = preserveHostHeader;
         this.hostHeaderValue = hostHeaderValue;
 	}
 
-    public ProxyResponseRenderer() {
+	public ProxyResponseRenderer() {
         this(ProxySettings.NO_PROXY, KeyStoreSettings.NO_STORE, false, null);
     }
 
@@ -73,7 +75,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
 		try {
 			addBodyIfPostPutOrPatch(httpRequest, responseDefinition);
-			HttpResponse httpResponse = client.execute(httpRequest);
+			HttpResponse httpResponse = client().execute(httpRequest);
 
             return response()
                     .status(httpResponse.getStatusLine().getStatusCode())
@@ -95,15 +97,19 @@ public class ProxyResponseRenderer implements ResponseRenderer {
         if (responseDefinition.getHeaders() != null) {
             httpHeaders.addAll(responseDefinition.getHeaders().all());
         }
-	    
+
 	    return new HttpHeaders(httpHeaders);
     }
+
+	private HttpClient client() {
+		return HttpClientFactory.createClient(1000, 5 * MINUTES, this.proxySettings, this.trustStoreSettings);
+	}
 
     private static HttpUriRequest getHttpRequestFor(ResponseDefinition response) {
 		final RequestMethod method = response.getOriginalRequest().getMethod();
 		final String url = response.getProxyUrl();
 		notifier().info("Proxying: " + method + " " + url);
-		
+
 		if (method.equals(GET))
 			return new HttpGet(url);
 		else if (method.equals(POST))
@@ -123,9 +129,9 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 		else
 			return new GenericHttpUriRequest(method.toString(), url);
 	}
-	
+
 	private void addRequestHeaders(HttpRequest httpRequest, ResponseDefinition response) {
-		Request originalRequest = response.getOriginalRequest(); 
+		Request originalRequest = response.getOriginalRequest();
 		for (String key: originalRequest.getAllHeaderKeys()) {
 			if (headerShouldBeTransferred(key)) {
                 if (!HOST_HEADER.equalsIgnoreCase(key) || preserveHostHeader) {
@@ -142,11 +148,11 @@ public class ProxyResponseRenderer implements ResponseRenderer {
                 }
 			}
 		}
-				
+
 		if (response.getAdditionalProxyRequestHeaders() != null) {
 			for (String key: response.getAdditionalProxyRequestHeaders().keys()) {
 				httpRequest.setHeader(key, response.getAdditionalProxyRequestHeaders().getHeader(key).firstValue());
-			}			
+			}
 		}
 	}
 


### PR DESCRIPTION
Yes, it's true. On OSX, I encountered an obscure bug. 

To uncover it, I added print statements that I implemented by decorating breakpoints in IDEA:

This is all in apache's httpcore version 4.4.1. In org.apache.http.protocol.HttpRequestExecutor, I added non-suspending and logging breakpoints as follows:

Line 122: "REQ:  " + System.identityHashCode(conn) + ": " + conn + " => " + request
Line 126: "OK:   " + System.identityHashCode(conn) + ": " + conn + " => " + request
Line 128: "FAIL: " + System.identityHashCode(conn) + ": " + conn + " => " + request + ": " + ex

A typical output, which shows the bug at the end:

REQ:  120493608: CPoolProxy{148.121.152.75:56553<->10.179.121.244:8084} => [URL]
REQ:  1402900645: CPoolProxy{148.121.152.75:56552<->10.179.121.244:8084} => [URL]
OK:   120493608: CPoolProxy{148.121.152.75:56553<->10.179.121.244:8084} => [URL]
OK:   1402900645: CPoolProxy{148.121.152.75:56552<->10.179.121.244:8084} => [URL]
REQ:  1848886687: CPoolProxy{148.121.152.75:56552<->10.179.121.244:8084} => [URL]
FAIL: 1848886687: CPoolProxy{0:0:0:0:0:0:9479:984b:56552<->10.179.121.244:8084} => [URL]: org.apache.http.NoHttpResponseException: The target server failed to respond

(The [URL]'s are request objects I have edited out, for clarity.)

The System.identityHashCodes ensure I am printing the same object. We see object #1848886687 goes from one state at request time, and to a new state after. The new state is that the local address has mysteriously become 0:0:0:0:0:0:9479:984b!

What is that, you say? It is an IPv6 address format. However, it describes the same IPv4 IP address!  You can work out what 94.79.98.4b is in decimal for yourself ...

When does this change occur? When the socket connection flushes the outgoing data. (I.e. the request.) This happens in org.apache.http.impl.io.SessionOutputBufferImpl, line 126:

       this.outstream.write(b, off, len);

Don't ask me how it happens, but before we call write here, the connection is fine. And SOMETIMES, when the call returns, it is screwed, and unable to receive incoming data. (Manifesting as NoHttpResponseException: The target server failed to respond, as above, and the FAIL breakpoint hitting.) Not every time, but pretty often. This is why I suspect multi-threading issues.

I am serious. Do NOT ask me how this happens. Could be an issue with http-core and/or my network setup. I just know the pull request makes the FAILs go away.

PS: Sorry about the whitespace/formatting diff, that's my opinionated IDEA. The change is only creating a new client every time. I can clean that up, but it'll have to be a little later.

PPS: This is NOT an april fool's!