### PR TITLE
Made HttpClient respect system properties

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -50,6 +50,7 @@ public class HttpClientFactory {
                 .disableContentCompression()
                 .setMaxConnTotal(maxConnections)
                 .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutMilliseconds).build())
+                .useSystemProperties()
                 .setHostnameVerifier(new AllowAllHostnameVerifier());
 
         if (proxySettings != NO_PROXY) {
@@ -95,11 +96,11 @@ public class HttpClientFactory {
     public static HttpClient createClient(int maxConnections, int timeoutMilliseconds) {
         return createClient(maxConnections, timeoutMilliseconds, NO_PROXY, NO_STORE);
     }
-	
+
 	public static HttpClient createClient(int timeoutMilliseconds) {
 		return createClient(DEFAULT_MAX_CONNECTIONS, timeoutMilliseconds);
 	}
-	
+
 	public static HttpClient createClient() {
 		return createClient(30000);
 	}


### PR DESCRIPTION
Calling useSystemProperties on the HttpClientBuilder allows the user to configure HttpClient's lower-level workings by setting system properties.

Low-risk alternative resolution to https://github.com/tomakehurst/wiremock/pull/381.