### PR TITLE
Added ability to record a particular request/response repeatedly

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -158,9 +158,9 @@ public class WireMockServer implements Container, LocalStubbing, Admin {
 		stubRequestHandler.addRequestListener(listener);
 	}
 	
-	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource) {
+	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource,	boolean recordRepeatsEnabled) {
 	    addMockServiceRequestListener(
-                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, options.matchingHeaders()));
+                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, options.matchingHeaders(), recordRepeatsEnabled));
         notifier.info("Recording mappings to " + mappingsFileSource.getPath());
 	}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -63,9 +63,9 @@ public class WireMockServerRunner {
 
         wireMockServer = new WireMockServer(options);
 
-        if (options.recordMappingsEnabled()) {
-            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource);
-        }
+		if (options.recordMappingsEnabled()) {
+			wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource, options.recordRepeatsEnabled());
+		}
 
 		if (options.specifiesProxyUrl()) {
 			addProxyMapping(options.proxyUrl());

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -53,9 +53,10 @@ public class WireMockServerTests {
     // https://github.com/tomakehurst/wiremock/issues/193
     @Test
     public void supportsRecordingProgrammaticallyWithoutHeaderMatching() {
+        boolean recordRepeats = false;
         WireMockServer wireMockServer = new WireMockServer(Options.DYNAMIC_PORT, new SingleRootFileSource(tempDir.getRoot()), false, new ProxySettings("proxy.company.com", Options.DYNAMIC_PORT));
         wireMockServer.start();
-        wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir.getRoot() + "/mappings"), new SingleRootFileSource(tempDir.getRoot() + "/__files"));
+        wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir.getRoot() + "/mappings"), new SingleRootFileSource(tempDir.getRoot() + "/__files"), recordRepeats);
         wireMockServer.stubFor(get(urlEqualTo("/something")).willReturn(aResponse().withStatus(200)));
 
         WireMockTestClient client = new WireMockTestClient(wireMockServer.port());

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -68,7 +68,8 @@ public class StubMappingJsonRecorderTest {
 	}
 
     private void constructRecordingListener(List<String> headersToRecord) {
-        listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS));
+        boolean recordRepeats = false;
+        listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS), recordRepeats);
         listener.setIdGenerator(fixedIdGenerator("1$2!3"));
     }
 


### PR DESCRIPTION
This is my proposed addition for:

Two ideas for record/playback of repeated requests and response
https://groups.google.com/d/topic/wiremock-user/tcX9TuCLCeE/discussion

It allows for specifying an optional command-line parameter:
    --record-repeats
that can be used as an addition to the:
    --record-mappings 
command-line parameter.

The first request/response recorded matching a particular request is saved with the file ending .1.json.  The second will end in .2.json. The third will end in .3.json, etc.

Playback assumes the requests will be received and played back to the client in the same order as they were recorded.  If you want different behavior, you should modify the scenario values in the corresponding mapping files according.
