### PR TITLE
Specify file encoding explicitly in gradlew.bat

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -72,7 +72,7 @@ set CMD_LINE_ARGS=%$
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dfile.encoding=UTF-8" "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
**Fix**
This pull request fixes the issue described below by explicitly passing UTF-8 as file encoding when executing gradle.

**Issue**
Running `gradlew.bat build` on Windows (8.1) yields,
```
[...]
:compileTestJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
E:\Git\wiremock\src\test\java\com\github\tomakehurst\wiremock\verification\LoggedRequestTest.java:47: error: unmappable character for encoding Cp1252
    public static final String REQUEST_BODY = "some text Õ¢óÕú░Õ¡ùÕ¢óÞ?▓Õ¡ù";
                                                                      ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
:processTestResources
:testClasses
:test

com.github.tomakehurst.wiremock.RequestQueryAcceptanceTest > requestBodyEncodingRemainsUtf8 FAILED
    java.lang.AssertionError at RequestQueryAcceptanceTest.java:122

[...]

com.github.tomakehurst.wiremock.verification.LoggedRequestTest > jsonRepresentation FAILED
    java.lang.AssertionError at LoggedRequestTest.java:120

com.github.tomakehurst.wiremock.verification.LoggedRequestTest > bodyEncodedAsUTF8 FAILED
    java.lang.AssertionError at LoggedRequestTest.java:137

[...]
FAILURE: Build failed with an exception.
```