### PR TITLE
Specify file encoding for gradle compile test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ dependencies {
     testRuntime files('src/test/resources/classpathfiles.zip')
 }
 
+compileTestJava {
+    options.encoding = 'UTF-8'
+}
+
 test {
     // Set the timezone for testing somewhere other than my machine to increase the chances of catching timezone bugs
     systemProperty 'user.timezone', 'Australia/Sydney'


### PR DESCRIPTION
**Fix**
This pull request fixes the issue described below by explicitly setting the file encoding to UTF-8 for the compile test task of build.gradle.

**Issue**
Running `gradlew.bat build` on Windows (8.1) yields,
```
[...]
:compileTestJava
warning: [options] bootstrap class path not set in conjunction with -source 1.7
E:\Git\wiremock\src\test\java\com\github\tomakehurst\wiremock\verification\LoggedRequestTest.java:47: error: unmappable character for encoding Cp1252
    public static final String REQUEST_BODY = "some text Õ¢óÕú░Õ¡ùÕ¢óÞ?▓Õ¡ù";
                                                                      ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning
:processTestResources
:testClasses
:test

com.github.tomakehurst.wiremock.RequestQueryAcceptanceTest > requestBodyEncodingRemainsUtf8 FAILED
    java.lang.AssertionError at RequestQueryAcceptanceTest.java:122

[...]

com.github.tomakehurst.wiremock.verification.LoggedRequestTest > jsonRepresentation FAILED
    java.lang.AssertionError at LoggedRequestTest.java:120

com.github.tomakehurst.wiremock.verification.LoggedRequestTest > bodyEncodedAsUTF8 FAILED
    java.lang.AssertionError at LoggedRequestTest.java:137

[...]
FAILURE: Build failed with an exception.
```