### PR TITLE
Allow responses to contain request parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     compile("junit:junit:4.12") {
         exclude group: "org.hamcrest", module: "hamcrest-core"
     }
+    compile "org.antlr:ST4:4.0.8"
 
     testCompile "org.hamcrest:hamcrest-all:1.3"
     testCompile("org.jmock:jmock:2.5.1") {
@@ -131,6 +132,7 @@ shadowJar {
     relocate "com.jayway", 'wiremock.com.jayway'
     relocate "org.objectweb", 'wiremock.org.objectweb'
     relocate "org.custommonkey", "wiremock.org.custommonkey"
+    relocate "org.antlr", "wiremock.org.antlr"
 
     dependencies {
         exclude(dependency('junit:junit'))

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateRequestAdapter.java
@@ -1,0 +1,66 @@
+package com.github.tomakehurst.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.http.HttpHeader;
+import com.github.tomakehurst.wiremock.http.QueryParameter;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.google.common.collect.Maps;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
+import static com.google.common.collect.Maps.newHashMap;
+
+public class TemplateRequestAdapter {
+
+    private final Request request;
+    private final Map<String, String> headers;
+    private final Map<String, String> query;
+
+    public TemplateRequestAdapter(final Request request) {
+        this.request = request;
+        headers = newHashMap();
+        for (HttpHeader header : request.getHeaders().all()) {
+            headers.put(header.key().replace('-', '_'), header.firstValue());
+        }
+
+        query = getQueryParameters(request);
+    }
+
+    private Map<String, String> getQueryParameters(Request request) {
+        try {
+            URI requestUri = new URI(request.getAbsoluteUrl());
+            Map<String, QueryParameter> queryParameters = splitQuery(requestUri.getQuery());
+            return Maps.transformEntries(queryParameters, new Maps.EntryTransformer<String, QueryParameter, String>() {
+                @Override
+                public String transformEntry(String key, QueryParameter value) {
+                    return value.firstValue();
+                }
+            });
+        } catch (URISyntaxException e) {
+            return newHashMap();
+        }
+    }
+
+    public String getBody() {
+        return request.getBodyAsString();
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public RequestMethod getMethod() {
+        return request.getMethod();
+    }
+
+    public String getUrl() {
+        return request.getUrl();
+    }
+
+    public Map<String, String> getQuery() {
+        return query;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/TemplateTransformer.java
@@ -1,0 +1,47 @@
+package com.github.tomakehurst.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.http.*;
+import org.stringtemplate.v4.ST;
+
+import java.util.Collection;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+public class TemplateTransformer extends ResponseTransformer {
+
+    @Override
+    public Response transform(Request request, Response originalResponse, FileSource files, Parameters parameters) {
+        Response.Builder responseBuilder = Response.Builder.like(originalResponse);
+        TemplateRequestAdapter requestForTemplate = new TemplateRequestAdapter(request);
+
+        if (originalResponse.getBody() != null) {
+            responseBuilder.body(substitute(originalResponse.getBodyAsString(), requestForTemplate));
+        }
+
+        if (originalResponse.getHeaders() != null) {
+            responseBuilder.headers(transformHeaders(originalResponse.getHeaders(), requestForTemplate));
+        }
+        
+        return responseBuilder.build();
+    }
+
+    private HttpHeaders transformHeaders(HttpHeaders originalHeaders, TemplateRequestAdapter request) {
+        Collection<HttpHeader> newHeaders = newArrayList();
+        for (HttpHeader oldHeader : originalHeaders.all()) {
+            newHeaders.add(new HttpHeader(oldHeader.key(), substitute(oldHeader.firstValue(), request)));
+        }
+        return new HttpHeaders(newHeaders);
+    }
+
+    private String substitute(String input, TemplateRequestAdapter request) {
+        ST template = new ST(input, '$', '$');
+        template.add("request", request);
+        return template.render();
+    }
+
+    @Override
+    public String name() {
+        return "TemplateTransformer";
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/TemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/TemplateTransformerTest.java
@@ -1,0 +1,90 @@
+package com.github.tomakehurst.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(JMock.class)
+public class TemplateTransformerTest {
+
+    private Mockery context;
+    private TemplateTransformer transformer;
+
+    @Before
+    public void init() {
+        context = new Mockery();
+        transformer = new TemplateTransformer();
+    }
+
+    @Test
+    public void readsRequestBody() {
+        Request request = new MockRequestBuilder(context).withBody("request body").build();
+        Response response = Response.response().status(200).body("$request.body$").build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getBodyAsString(), is("request body"));
+    }
+
+    @Test
+    public void ignoresEscapedDelimiter() {
+        Request request = new MockRequestBuilder(context).build();
+        Response response = Response.response().status(200).body("\\$request.body\\$").build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getBodyAsString(), is("$request.body$"));
+    }
+
+    @Test
+    public void readsRequestHeaders() {
+        Request request = new MockRequestBuilder(context).withHeader("Accept", "text/plain").build();
+        Response response = Response.response().status(200).body("$request.headers.Accept$").build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getBodyAsString(), is("text/plain"));
+    }
+
+    @Test
+    public void readsRequestQueryParams() {
+        Request request = new MockRequestBuilder(context).withUrl("/widgets?id=5").build();
+        Response response = Response.response().status(200).body("$request.query.id$").build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getBodyAsString(), is("5"));
+    }
+
+    @Test
+    public void readsRequestMethod() {
+        Request request = new MockRequestBuilder(context).withMethod(RequestMethod.POST).build();
+        Response response = Response.response().status(200).body("$request.method$").build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getBodyAsString(), is("POST"));
+    }
+
+    @Test
+    public void convertsHyphensToUnderscoreInHeaderNames() {
+        Request request = new MockRequestBuilder(context).withHeader("Content-Type", "text/plain").build();
+        Response response = Response.response().status(200).body("$request.headers.Content_Type$").build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getBodyAsString(), is("text/plain"));
+    }
+
+    @Test
+    public void readsRequestUrl() {
+        Request request = new MockRequestBuilder(context).withUrl("/widgets?id=5").build();
+        Response response = Response.response().status(200).body("$request.url$").build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getBodyAsString(), is("/widgets?id=5"));
+    }
+
+    @Test
+    public void substitutesInResponseHeaders() {
+        Request request = new MockRequestBuilder(context).withHeader("Accept", "text/plain").build();
+        Response response = Response.response().status(200)
+                .headers(new HttpHeaders(new HttpHeader("Content-Type", "$request.headers.Accept$"))).build();
+        Response transformedResponse = transformer.transform(request, response, null, null);
+        assertThat(transformedResponse.getHeaders().getContentTypeHeader().mimeTypePart(), is("text/plain"));
+    }
+}


### PR DESCRIPTION
Fixes #405 

A couple of things to note:
- This only takes the first query param or header value corresponding to the given key
- Headers have to be referred to with '-' replaced by '_' - this is because StringTemplate needs the keys to be valid Java identifiers. I don't think there's any other templating library that's suitable for this and doesn't have that restriction, so I think this is the best workaround.
