### PR TITLE
add multipart support

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
@@ -22,16 +22,20 @@ public class HttpsSettings {
     private final int port;
     private final String keyStorePath;
     private final String keyStorePassword;
+    private final String keyStoreType;
     private final String trustStorePath;
     private final String trustStorePassword;
+    private final String trustStoreType;
     private final boolean needClientAuth;
 
-    public HttpsSettings(int port, String keyStorePath, String keyStorePassword, String trustStorePath, String trustStorePassword, boolean needClientAuth) {
+    public HttpsSettings(int port, String keyStorePath, String keyStorePassword, String keyStoreType, String trustStorePath, String trustStorePassword, String trustStoreType, boolean needClientAuth) {
         this.port = port;
         this.keyStorePath = keyStorePath;
         this.keyStorePassword = keyStorePassword;
+        this.keyStoreType = keyStoreType;
         this.trustStorePath = trustStorePath;
         this.trustStorePassword = trustStorePassword;
+        this.trustStoreType = trustStoreType;
         this.needClientAuth = needClientAuth;
     }
 
@@ -47,6 +51,10 @@ public class HttpsSettings {
         return keyStorePassword;
     }
 
+    public String keyStoreType() {
+        return keyStoreType;
+    }
+
     public boolean enabled() {
         return port > -1;
     }
@@ -57,6 +65,10 @@ public class HttpsSettings {
 
     public String trustStorePassword() {
         return trustStorePassword;
+    }
+
+    public String trustStoreType() {
+        return trustStoreType;
     }
 
     public boolean needClientAuth() {
@@ -88,8 +100,10 @@ public class HttpsSettings {
         private int port;
         private String keyStorePath = Resources.getResource("keystore").toString();
         private String keyStorePassword = "password";
+        private String keyStoreType = "JKS";
         private String trustStorePath = null;
         private String trustStorePassword = "password";
+        private String trustStoreType = "JKS";
         private boolean needClientAuth = false;
 
         public Builder port(int port) {
@@ -107,6 +121,11 @@ public class HttpsSettings {
             return this;
         }
 
+        public Builder keyStoreType(String keyStoreType) {
+            this.keyStoreType = keyStoreType;
+            return this;
+        }
+
         public Builder trustStorePath(String trustStorePath) {
             this.trustStorePath = trustStorePath;
             return this;
@@ -117,13 +136,18 @@ public class HttpsSettings {
             return this;
         }
 
+        public Builder trustStoreType(String trustStoreType) {
+            this.trustStoreType = trustStoreType;
+            return this;
+        }
+
         public Builder needClientAuth(boolean needClientAuth) {
             this.needClientAuth = needClientAuth;
             return this;
         }
 
         public HttpsSettings build() {
-            return new HttpsSettings(port, keyStorePath, keyStorePassword, trustStorePath, trustStorePassword, needClientAuth);
+            return new HttpsSettings(port, keyStorePath, keyStorePassword, keyStoreType, trustStorePath, trustStorePassword, trustStoreType, needClientAuth);
         }
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -125,6 +125,11 @@ public class WireMockConfiguration implements Options {
         return this;
     }
 
+    public WireMockConfiguration keystoreType(String keyStoreType) {
+        this.keyStoreType = keyStoreType;
+        return this;
+    }
+
     public WireMockConfiguration trustStorePath(String truststorePath) {
         this.trustStorePath = truststorePath;
         return this;
@@ -132,6 +137,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration trustStorePassword(String trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
+        return this;
+    }
+
+    public WireMockConfiguration trustStoreType(String trustStoreType) {
+        this.trustStoreType = trustStoreType;
         return this;
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -44,8 +44,10 @@ public class WireMockConfiguration implements Options {
     private int httpsPort = -1;
     private String keyStorePath = Resources.getResource("keystore").toString();
     private String keyStorePassword = "password";
+    private String keyStoreType = "JKS";
     private String trustStorePath;
     private String trustStorePassword = "password";
+    private String trustStoreType = "JKS";
     private boolean needClientAuth;
 
     private boolean browserProxyingEnabled = false;
@@ -238,8 +240,10 @@ public class WireMockConfiguration implements Options {
                 .port(httpsPort)
                 .keyStorePath(keyStorePath)
                 .keyStorePassword(keyStorePassword)
+                .keyStoreType(keyStoreType)
                 .trustStorePath(trustStorePath)
                 .trustStorePassword(trustStorePassword)
+                .trustStoreType(trustStoreType)
                 .needClientAuth(needClientAuth)
                 .build();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -18,6 +18,11 @@ package com.github.tomakehurst.wiremock.http;
 import java.util.Map;
 import java.util.Set;
 
+import java.io.IOException;
+import java.util.Collection;
+
+import javax.servlet.http.Part;
+
 public interface Request {
 
     String getUrl();
@@ -33,6 +38,8 @@ public interface Request {
     Set<String> getAllHeaderKeys();
 
     Map<String, Cookie> getCookies();
+
+	Collection<Part> getParts() throws IOException;
 
     QueryParameter queryParameter(String key);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -164,9 +164,11 @@ class JettyHttpServer implements HttpServer {
         SslContextFactory sslContextFactory = new SslContextFactory();
         sslContextFactory.setKeyStorePath(httpsSettings.keyStorePath());
         sslContextFactory.setKeyManagerPassword(httpsSettings.keyStorePassword());
+        sslContextFactory.setKeyStoreType(httpsSettings.keyStoreType());
         if (httpsSettings.hasTrustStore()) {
             sslContextFactory.setTrustStorePath(httpsSettings.trustStorePath());
             sslContextFactory.setTrustStorePassword(httpsSettings.trustStorePassword());
+            sslContextFactory.setTrustStoreType(httpsSettings.trustStoreType());
         }
         sslContextFactory.setNeedClientAuth(httpsSettings.needClientAuth());
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
@@ -18,11 +18,16 @@ package com.github.tomakehurst.wiremock.jetty9;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.google.common.base.Optional;
+import org.eclipse.jetty.util.MultiPartInputStreamParser;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.codec.binary.Base64;
+
+import javax.servlet.http.Part;
+import java.io.ByteArrayInputStream;
 
 import java.io.IOException;
 import java.net.URI;
@@ -111,6 +116,19 @@ public class JettyHttpServletRequestAdapter implements Request {
     @Override
     public String getBodyAsBase64(){
         return Base64.encodeBase64String(getBody());
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException {
+        getBody();
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(cachedBody);
+        MultiPartInputStreamParser multiPartInputStreamParser = new MultiPartInputStreamParser(byteArrayInputStream, getHeader("Content-Type"), null, null);
+
+        try {
+            return multiPartInputStreamParser.getParts();
+        } catch (ServletException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -66,8 +66,10 @@ public class CommandLineOptions implements Options {
     private static final String HTTPS_PORT = "https-port";
     private static final String HTTPS_KEYSTORE = "https-keystore";
     private static final String HTTPS_KEYSTORE_PASSWORD = "keystore-password";
+    private static final String HTTPS_KEYSTORE_TYPE = "keystore-type";
     private static final String HTTPS_TRUSTSTORE = "https-truststore";
     private static final String HTTPS_TRUSTSTORE_PASSWORD = "truststore-password";
+    private static final String HTTPS_TRUSTSTORE_TYPE = "truststore-type";
     private static final String REQUIRE_CLIENT_CERT = "https-require-client-cert";
     private static final String VERBOSE = "verbose";
     private static final String ENABLE_BROWSER_PROXYING = "enable-browser-proxying";
@@ -92,8 +94,10 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(REQUIRE_CLIENT_CERT, "Make the server require a trusted client certificate to enable a connection");
         optionParser.accepts(HTTPS_TRUSTSTORE_PASSWORD, "Password for the trust store").withRequiredArg();
         optionParser.accepts(HTTPS_TRUSTSTORE, "Path to an alternative truststore for HTTPS client certificates. Must have a password of \"password\".").requiredIf(REQUIRE_CLIENT_CERT).withRequiredArg();
+        optionParser.accepts(HTTPS_TRUSTSTORE_TYPE, "Alternative truststore type then JKS. For example for Android BKS.");
         optionParser.accepts(HTTPS_KEYSTORE_PASSWORD, "Password for the alternative keystore.").withRequiredArg().defaultsTo("password");
         optionParser.accepts(HTTPS_KEYSTORE, "Path to an alternative keystore for HTTPS. Password is assumed to be \"password\" if not specified.").requiredIf(HTTPS_TRUSTSTORE).requiredIf(HTTPS_KEYSTORE_PASSWORD).withRequiredArg().defaultsTo(Resources.getResource("keystore").toString());
+        optionParser.accepts(HTTPS_KEYSTORE_TYPE, "Alternative keystore type then JKS. For example for Android BKS.");
         optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
@@ -198,8 +202,10 @@ public class CommandLineOptions implements Options {
                 .port(httpsPortNumber())
                 .keyStorePath((String) optionSet.valueOf(HTTPS_KEYSTORE))
                 .keyStorePassword((String) optionSet.valueOf(HTTPS_KEYSTORE_PASSWORD))
+                .keyStoreType((String) optionSet.valueOf(HTTPS_KEYSTORE_TYPE))
                 .trustStorePath((String) optionSet.valueOf(HTTPS_TRUSTSTORE))
                 .trustStorePassword((String) optionSet.valueOf(HTTPS_TRUSTSTORE_PASSWORD))
+                .trustStoreType((String) optionSet.valueOf(HTTPS_TRUSTSTORE_TYPE))
                 .needClientAuth(optionSet.has(REQUIRE_CLIENT_CERT)).build();
     }
 
@@ -326,7 +332,8 @@ public class CommandLineOptions implements Options {
 
         if (httpsSettings().enabled()) {
             builder.put(HTTPS_PORT, nullToString(httpsSettings().port()))
-                   .put(HTTPS_KEYSTORE, nullToString(httpsSettings().keyStorePath()));
+                   .put(HTTPS_KEYSTORE, nullToString(httpsSettings().keyStorePath()))
+                   .put(HTTPS_KEYSTORE_TYPE, nullToString(httpsSettings().keyStoreType()));
         }
 
         if (!(proxyVia() == NO_PROXY)) {

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -22,7 +22,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.http.*;
 
+import java.io.IOException;
 import java.net.URI;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +32,8 @@ import java.util.Set;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.codec.binary.Base64;
+
+import javax.servlet.http.Part;
 
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
@@ -135,6 +139,11 @@ public class LoggedRequest implements Request {
     @Override
     public Map<String, Cookie> getCookies() {
         return cookies;
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Hi,

This is a basic multipart support implementation.

Maybe it would be a good idea to have stub the form data in the ReqeustPattern class. Something like withFormData. It should not matter how the form data are received (Url encoded or multi part).

To handle the form data for now, I implemented a wiremock extension. But it would be perfect to have this feature included in Wiremock.

Best regards