### PR TITLE
Accept gzipped request bodies

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Gzip.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Gzip.java
@@ -15,7 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 
 import java.io.ByteArrayInputStream;
@@ -52,5 +51,11 @@ public class Gzip {
         } catch (IOException e) {
             return throwUnchecked(e, byte[].class);
         }
+    }
+
+    public static boolean isGzipped(byte[] content) {
+        return content.length >= 2
+                && content[0] == (byte)GZIPInputStream.GZIP_MAGIC
+                && content[1] == (byte)(GZIPInputStream.GZIP_MAGIC >> 8);
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GzipAcceptanceTest.java
@@ -15,8 +15,11 @@
  */
 package com.github.tomakehurst.wiremock;
 
-import com.github.tomakehurst.wiremock.stubbing.StubMappingJsonRecorder;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.entity.GzipCompressingEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.junit.Test;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -40,4 +43,13 @@ public class GzipAcceptanceTest extends AcceptanceTestBase {
         assertThat(plainText, is("body text"));
     }
 
+    @Test
+    public void acceptsGzippedRequest() {
+        wireMockServer.stubFor(any(urlEqualTo("/gzip-request")).withRequestBody(equalTo("request body")).willReturn(aResponse().withBody("response body")));
+
+        HttpEntity compressedBody = new GzipCompressingEntity(new StringEntity("request body", ContentType.TEXT_PLAIN));
+        WireMockResponse response = testClient.post("/gzip-request", compressedBody);
+
+        assertThat(response.content(), is("response body"));
+    }
 }


### PR DESCRIPTION
Fixes #404 

My IDE's done a bit of tidying up in JettyHttpServletRequestAdapter, I can take that out if you'd prefer a cleaner diff.

Also we can maybe just rely on the Content-Encoding header rather than looking at the magic bytes. (That would also mean we can do it without turning the response back and forth between a stream and an array), let me know if you'd prefer it that way.