### PR TITLE
Reverts to WireMock 1 behaviour - Date header only returned if stubbed

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -145,8 +145,7 @@ class JettyHttpServer implements HttpServer {
             int port,
             JettySettings jettySettings) {
 
-        HttpConfiguration httpConfig = new HttpConfiguration();
-        setHeaderBufferSize(jettySettings, httpConfig);
+        HttpConfiguration httpConfig = createHttpConfig(jettySettings);
 
         ServerConnector connector = createServerConnector(
                 jettySettings,
@@ -170,8 +169,7 @@ class JettyHttpServer implements HttpServer {
         }
         sslContextFactory.setNeedClientAuth(httpsSettings.needClientAuth());
 
-        HttpConfiguration httpConfig = new HttpConfiguration();
-        setHeaderBufferSize(jettySettings, httpConfig);
+        HttpConfiguration httpConfig = createHttpConfig(jettySettings);
         httpConfig.addCustomizer(new SecureRequestCustomizer());
 
         final int port = httpsSettings.port();
@@ -186,6 +184,15 @@ class JettyHttpServer implements HttpServer {
                 ),
                 new HttpConnectionFactory(httpConfig)
         );
+    }
+
+    private HttpConfiguration createHttpConfig(JettySettings jettySettings) {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setRequestHeaderSize(
+                jettySettings.getRequestHeaderSize().or(8192)
+        );
+        httpConfig.setSendDateHeader(false);
+        return httpConfig;
     }
 
     private ServerConnector createServerConnector(JettySettings jettySettings, int port, ConnectionFactory... connectionFactories) {
@@ -213,14 +220,6 @@ class JettyHttpServer implements HttpServer {
         if (jettySettings.getAcceptQueueSize().isPresent()) {
             connector.setAcceptQueueSize(jettySettings.getAcceptQueueSize().get());
         }
-    }
-
-    private void setHeaderBufferSize(JettySettings jettySettings, HttpConfiguration configuration) {
-        int headerBufferSize = 8192;
-        if (jettySettings.getRequestHeaderSize().isPresent()) {
-            headerBufferSize = jettySettings.getRequestHeaderSize().get();
-        }
-        configuration.setRequestHeaderSize(headerBufferSize);
     }
 
     @SuppressWarnings({"rawtypes", "unchecked" })

--- a/src/test/java/com/github/tomakehurst/wiremock/DateHeaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DateHeaderAcceptanceTest.java
@@ -1,0 +1,34 @@
+package com.github.tomakehurst.wiremock;
+
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class DateHeaderAcceptanceTest extends AcceptanceTestBase {
+
+    @Test
+    public void returnsStubbedDateHeader() {
+
+        stubFor(get(urlEqualTo("/stubbed/dateheader"))
+            .willReturn(aResponse().withStatus(200).withHeader("Date", "Sun, 06 Nov 1994 08:49:37 GMT")));
+
+        WireMockResponse response = testClient.get("/stubbed/dateheader");
+
+        assertThat(response.firstHeader("Date"), is("Sun, 06 Nov 1994 08:49:37 GMT"));
+    }
+
+    @Test
+    public void returnsNullDateHeaderIfNotStubbed() {
+
+        stubFor(get(urlEqualTo("/nodateheader")).willReturn(aResponse().withStatus(200)));
+
+        WireMockResponse response = testClient.get("/nodateheader");
+
+        assertThat(response.firstHeader("Date"), is(nullValue()));
+    }
+
+}


### PR DESCRIPTION
In WireMock v1 no Date header is returned unless explicitly stubbed.

This PR returns WireMock v2 to that behaviour; previously it generated a Date header field regardless of stubbing, meaning that if you stubbed the Date header field you got two, with the stubbed one later in the header field order so ignored by most clients.