### PR TITLE
refine stubbing and verification acceptance tests for some matchers

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -143,6 +143,13 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 	}
 
 	@Test
+	public void doesNotMatchOnUrlPathWhenPathShorter() {
+	    stubFor(get(urlPathEqualTo("/matching-path")).willReturn(aResponse().withStatus(200)));
+
+	    assertThat(testClient.get("/matching").statusCode(), is(404));
+	}
+
+	@Test
 	public void matchesOnUrlPathPatternAndQueryParameters() {
 		stubFor(get(urlPathMatching("/path(.*)/match"))
 				.withQueryParam("search", containing("WireMock"))
@@ -150,6 +157,20 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 				.willReturn(aResponse().withStatus(200)));
 
 		assertThat(testClient.get("/path-and-query/match?since=2014-10-14&search=WireMock%20stubbing").statusCode(), is(200));
+	}
+
+	@Test
+	public void doesNotMatchOnUrlPathPatternWhenPathShorter() {
+	    stubFor(get(urlPathMatching("/matching-path")).willReturn(aResponse().withStatus(200)));
+
+	    assertThat(testClient.get("/matching").statusCode(), is(404));
+	}
+
+	@Test
+	public void doesNotMatchOnUrlPathPatternWhenExtraPathPresent() {
+	    stubFor(get(urlPathMatching("/matching-path")).willReturn(aResponse().withStatus(200)));
+
+	    assertThat(testClient.get("/matching-path/extra").statusCode(), is(404));
 	}
 
 	@Test

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -50,20 +50,62 @@ public class VerificationAcceptanceTest {
 
         @Test
         public void verifiesRequestBasedOnUrlOnly() {
-            testClient.get("/this/got/requested");
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlEqualTo("/this/got/requested?query")));
+        }
+
+        @Test(expected=VerificationException.class)
+        public void throwsVerificationExceptionOnUrlEqualsWhenQueryMissing() {
+            testClient.get("/this/got/requested?query");
             verify(getRequestedFor(urlEqualTo("/this/got/requested")));
+        }
+
+        @Test(expected=VerificationException.class)
+        public void throwsVerificationExceptionOnUrlEqualsWhenPathShorter() {
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlEqualTo("/this/got/requeste?query")));
+        }
+
+        @Test(expected=VerificationException.class)
+        public void throwsVerificationExceptionOnUrlEqualsWhenExtraPathPresent() {
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlEqualTo("/this/got/requested/?query")));
         }
 
         @Test
         public void verifiesRequestBasedOnUrlPathOnly() {
-            testClient.get("/this/got/requested");
+            testClient.get("/this/got/requested?query");
             verify(getRequestedFor(urlPathEqualTo("/this/got/requested")));
+        }
+
+        @Test(expected=VerificationException.class)
+        public void throwsVerificationExceptionOnUrlPathEqualsWhenPathShorter() {
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlPathEqualTo("/this/got/requeste")));
+        }
+
+        @Test(expected=VerificationException.class)
+        public void throwsVerificationExceptionOnUrlPathEqualsWhenExtraPathPresent() {
+            testClient.get("/this/got/requested?query");
+            verify(getRequestedFor(urlPathEqualTo("/this/got/requested/")));
         }
 
         @Test
         public void verifiesRequestBasedOnUrlPathPatternOnly() {
             testClient.get("/this/got/requested");
             verify(getRequestedFor(urlPathMatching("/(.*?)/got/.*")));
+        }
+
+        @Test(expected=VerificationException.class)
+        public void throwsVerificationExceptionOnUrlPathPatternWhenOnlyPrefixMatching() {
+            testClient.get("/this/got/requested");
+            verify(getRequestedFor(urlPathMatching("/(.*?)/got/")));
+        }
+
+        @Test(expected=VerificationException.class)
+        public void throwsVerificationExceptionOnUrlPathPatternWhenOnlySuffixMatching() {
+            testClient.get("/this/got/requested");
+            verify(getRequestedFor(urlPathMatching("/got/.*")));
         }
 
         @Test(expected=VerificationException.class)


### PR DESCRIPTION
matchers: urlEqualTo, urlPathEqualTo, urlPathMatching

I wanted to fix #408 but it turned out that the issue is already fixed in 2.0-beta.
These are the refined tests which I think should be added as enhanced regression tests anyway.