### PR TITLE
Android https support for wiremock

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/HttpsSettings.java
@@ -22,16 +22,20 @@ public class HttpsSettings {
     private final int port;
     private final String keyStorePath;
     private final String keyStorePassword;
+    private final String keyStoreType;
     private final String trustStorePath;
     private final String trustStorePassword;
+    private final String trustStoreType;
     private final boolean needClientAuth;
 
-    public HttpsSettings(int port, String keyStorePath, String keyStorePassword, String trustStorePath, String trustStorePassword, boolean needClientAuth) {
+    public HttpsSettings(int port, String keyStorePath, String keyStorePassword, String keyStoreType,  String trustStorePath, String trustStorePassword, String trustStoreType, boolean needClientAuth) {
         this.port = port;
         this.keyStorePath = keyStorePath;
         this.keyStorePassword = keyStorePassword;
+        this.keyStoreType = keyStoreType;
         this.trustStorePath = trustStorePath;
         this.trustStorePassword = trustStorePassword;
+        this.trustStoreType = trustStoreType;
         this.needClientAuth = needClientAuth;
     }
 
@@ -47,6 +51,10 @@ public class HttpsSettings {
         return keyStorePassword;
     }
 
+    public String keyStoreType() {
+        return keyStoreType;
+    }
+
     public boolean enabled() {
         return port > -1;
     }
@@ -57,6 +65,10 @@ public class HttpsSettings {
 
     public String trustStorePassword() {
         return trustStorePassword;
+    }
+
+    public String trustStoreType() {
+        return trustStoreType;
     }
 
     public boolean needClientAuth() {
@@ -78,7 +90,9 @@ public class HttpsSettings {
         return "HttpsSettings{" +
                 "port=" + port +
                 ", keyStorePath='" + keyStorePath + '\'' +
+                ", keyStoreType='" + keyStoreType + '\'' +
                 ", trustStorePath='" + trustStorePath + '\'' +
+                ", trustStoreType='" + trustStoreType + '\'' +
                 ", needClientAuth=" + needClientAuth +
                 '}';
     }
@@ -88,8 +102,10 @@ public class HttpsSettings {
         private int port;
         private String keyStorePath = Resources.getResource("keystore").toString();
         private String keyStorePassword = "password";
+        private String keyStoreType = "JKS";
         private String trustStorePath = null;
         private String trustStorePassword = "password";
+        private String trustStoreType = "JKS";
         private boolean needClientAuth = false;
 
         public Builder port(int port) {
@@ -107,6 +123,11 @@ public class HttpsSettings {
             return this;
         }
 
+        public Builder keyStoreType(String keyStoreType) {
+            this.keyStoreType = keyStoreType;
+            return this;
+        }
+
         public Builder trustStorePath(String trustStorePath) {
             this.trustStorePath = trustStorePath;
             return this;
@@ -117,13 +138,18 @@ public class HttpsSettings {
             return this;
         }
 
+        public Builder trustStoreType(String trustStoreType) {
+            this.trustStoreType = trustStoreType;
+            return this;
+        }
+
         public Builder needClientAuth(boolean needClientAuth) {
             this.needClientAuth = needClientAuth;
             return this;
         }
 
         public HttpsSettings build() {
-            return new HttpsSettings(port, keyStorePath, keyStorePassword, trustStorePath, trustStorePassword, needClientAuth);
+            return new HttpsSettings(port, keyStorePath, keyStorePassword,  keyStoreType,  trustStorePath, trustStorePassword, trustStoreType, needClientAuth);
         }
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -44,8 +44,10 @@ public class WireMockConfiguration implements Options {
     private int httpsPort = -1;
     private String keyStorePath = Resources.getResource("keystore").toString();
     private String keyStorePassword = "password";
+    private String keyStoreType = "JKS";
     private String trustStorePath;
     private String trustStorePassword = "password";
+    private String trustStoreType = "JKS";
     private boolean needClientAuth;
 
     private boolean browserProxyingEnabled = false;
@@ -123,6 +125,11 @@ public class WireMockConfiguration implements Options {
         return this;
     }
 
+    public WireMockConfiguration keystoreType(String keyStoreType) {
+        this.keyStoreType = keyStoreType;
+        return this;
+    }
+
     public WireMockConfiguration trustStorePath(String truststorePath) {
         this.trustStorePath = truststorePath;
         return this;
@@ -130,6 +137,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration trustStorePassword(String trustStorePassword) {
         this.trustStorePassword = trustStorePassword;
+        return this;
+    }
+
+    public WireMockConfiguration trustStoreType(String trustStoreType) {
+        this.trustStoreType = trustStoreType;
         return this;
     }
 
@@ -238,8 +250,10 @@ public class WireMockConfiguration implements Options {
                 .port(httpsPort)
                 .keyStorePath(keyStorePath)
                 .keyStorePassword(keyStorePassword)
+                .keyStoreType(keyStoreType)
                 .trustStorePath(trustStorePath)
                 .trustStorePassword(trustStorePassword)
+                .trustStoreType(trustStoreType)
                 .needClientAuth(needClientAuth)
                 .build();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/CustomizedSslContextFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/CustomizedSslContextFactory.java
@@ -1,0 +1,49 @@
+package com.github.tomakehurst.wiremock.jetty9;
+
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Created by agupt13 on 6/9/16.
+ *
+ * This class is customized because the Android JVM classes do not support the `setEndpointIdentificationAlgorithm` for https communication.
+ */
+public class CustomizedSslContextFactory extends org.eclipse.jetty.util.ssl.SslContextFactory  {
+
+
+
+    public void customize(SSLEngine sslEngine)
+    {
+        SSLParameters sslParams = sslEngine.getSSLParameters();
+        // sslParams.setEndpointIdentificationAlgorithm(_endpointIdentificationAlgorithm);
+        sslEngine.setSSLParameters(sslParams);
+
+        if (super.getWantClientAuth())
+            sslEngine.setWantClientAuth(super.getWantClientAuth());
+        if (super.getNeedClientAuth())
+            sslEngine.setNeedClientAuth(super.getNeedClientAuth());
+
+        sslEngine.setEnabledCipherSuites(super.selectCipherSuites(
+                sslEngine.getEnabledCipherSuites(),
+                sslEngine.getSupportedCipherSuites()));
+
+        sslEngine.setEnabledProtocols(super.selectProtocols(sslEngine.getEnabledProtocols(),sslEngine.getSupportedProtocols()));
+    }
+
+
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -162,7 +162,6 @@ class JettyHttpServer implements HttpServer {
 
         //Added to support Android https communication.
         CustomizedSslContextFactory sslContextFactory = new CustomizedSslContextFactory();
-        System.out.println("HTTPS SETTINGS : " + httpsSettings.toString());
 
         sslContextFactory.setKeyStorePath(httpsSettings.keyStorePath());
         sslContextFactory.setKeyManagerPassword(httpsSettings.keyStorePassword());

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -160,12 +160,17 @@ class JettyHttpServer implements HttpServer {
             HttpsSettings httpsSettings,
             JettySettings jettySettings) {
 
-        SslContextFactory sslContextFactory = new SslContextFactory();
+        //Added to support Android https communication.
+        CustomizedSslContextFactory sslContextFactory = new CustomizedSslContextFactory();
+        System.out.println("HTTPS SETTINGS : " + httpsSettings.toString());
+
         sslContextFactory.setKeyStorePath(httpsSettings.keyStorePath());
         sslContextFactory.setKeyManagerPassword(httpsSettings.keyStorePassword());
+        sslContextFactory.setKeyStoreType(httpsSettings.keyStoreType());
         if (httpsSettings.hasTrustStore()) {
             sslContextFactory.setTrustStorePath(httpsSettings.trustStorePath());
             sslContextFactory.setTrustStorePassword(httpsSettings.trustStorePassword());
+            sslContextFactory.setTrustStoreType(httpsSettings.trustStoreType());
         }
         sslContextFactory.setNeedClientAuth(httpsSettings.needClientAuth());
 


### PR DESCRIPTION
PR contains:
 - patch for Android support for HTTPS communication, which needs the Keystore to be 'BKS' type instead of 'JKS'.  
 - The PR is intended to give users an additional option to send KeyStoreType and TrustStoreType as Wiremock configuration when starting the server. For example,
```
WireMockServer wireMockServer  = new WireMockServer(wireMockConfig().port(9988).httpsPort(9943).keyStoreType("BKS").keystorePath("path/to/keystore")
```

Please note that the acceptance test could not be created for this addition, because the normal JVM only supports JKS keystore type and the acceptance test fails if the test is executed on desktop.  I was trying to forcefully set the  JVM security to support BKS just for the test, but couldn't find how to. The JVM settings have to be set manually by adding Boucy Castle Provider in the Java_Hom>jre>lib>security>java.security file.  @tomakehurst  please let me know if lack of acceptance test is ok in this situation?

I am going to make the change for the standalone process as well so that both standalone and non-standalone versions match. Probably in a seperate PR. (or let me know if that is also  required for acceptance of this one.)  Also, documentation is in progress. Please let me know if any questions.

Thanks for all the help.

