### PR TITLE
Isolate jetty dependencies into a single package

### DIFF
--- a/sample-war/src/main/webapp/WEB-INF/web.xml
+++ b/sample-war/src/main/webapp/WEB-INF/web.xml
@@ -23,7 +23,7 @@
 
   <servlet>
   	<servlet-name>wiremock-mock-service-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty6.Jetty6HandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.StubRequestHandler</param-value>
@@ -36,7 +36,7 @@
   
   <servlet>
   	<servlet-name>wiremock-admin-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty6.Jetty6HandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.AdminRequestHandler</param-value>

--- a/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml
+++ b/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml
@@ -26,7 +26,7 @@
 
   <servlet>
   	<servlet-name>wiremock-mock-service-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty6.Jetty6HandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.StubRequestHandler</param-value>
@@ -47,7 +47,7 @@
   
   <servlet>
   	<servlet-name>wiremock-admin-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty6.Jetty6HandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.AdminRequestHandler</param-value>

--- a/sample-war/src/main/webappLimitedRequestJournal/WEB-INF/web.xml
+++ b/sample-war/src/main/webappLimitedRequestJournal/WEB-INF/web.xml
@@ -29,7 +29,7 @@
 
   <servlet>
   	<servlet-name>wiremock-mock-service-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty6.Jetty6HandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.StubRequestHandler</param-value>
@@ -42,7 +42,7 @@
   
   <servlet>
   	<servlet-name>wiremock-admin-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty6.Jetty6HandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.AdminRequestHandler</param-value>

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty6/Jetty6HttpServer.java
@@ -29,6 +29,7 @@ import com.github.tomakehurst.wiremock.http.HttpServer;
 import com.github.tomakehurst.wiremock.http.RequestHandler;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.servlet.ContentTypeSettingFilter;
+import com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet;
 import com.github.tomakehurst.wiremock.servlet.TrailingSlashFilter;
 import org.mortbay.jetty.Handler;
 import org.mortbay.jetty.MimeTypes;
@@ -40,7 +41,7 @@ import org.mortbay.jetty.servlet.ServletHolder;
 import org.mortbay.thread.QueuedThreadPool;
 
 import static com.github.tomakehurst.wiremock.core.WireMockApp.*;
-import static com.github.tomakehurst.wiremock.jetty6.Jetty6HandlerDispatchingServlet.*;
+import static com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet.*;
 import static com.google.common.collect.Maps.*;
 
 class Jetty6HttpServer implements HttpServer {
@@ -203,7 +204,7 @@ class Jetty6HttpServer implements HttpServer {
 
         mockServiceContext.setAttribute(StubRequestHandler.class.getName(), stubRequestHandler);
         mockServiceContext.setAttribute(Notifier.KEY, notifier);
-        ServletHolder servletHolder = mockServiceContext.addServlet(Jetty6HandlerDispatchingServlet.class, "/");
+        ServletHolder servletHolder = mockServiceContext.addServlet(WireMockHandlerDispatchingServlet.class, "/");
         servletHolder.setInitParameter(RequestHandler.HANDLER_CLASS_KEY, StubRequestHandler.class.getName());
         servletHolder.setInitParameter(SHOULD_FORWARD_TO_FILES_CONTEXT, "true");
 
@@ -227,7 +228,7 @@ class Jetty6HttpServer implements HttpServer {
             Notifier notifier
     ) {
         Context adminContext = new Context(jettyServer, ADMIN_CONTEXT_ROOT);
-        ServletHolder servletHolder = adminContext.addServlet(Jetty6HandlerDispatchingServlet.class, "/");
+        ServletHolder servletHolder = adminContext.addServlet(WireMockHandlerDispatchingServlet.class, "/");
         servletHolder.setInitParameter(RequestHandler.HANDLER_CLASS_KEY, AdminRequestHandler.class.getName());
         adminContext.setAttribute(AdminRequestHandler.class.getName(), adminRequestHandler);
         adminContext.setAttribute(Notifier.KEY, notifier);

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.jetty6;
+package com.github.tomakehurst.wiremock.servlet;
 
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
 import com.github.tomakehurst.wiremock.common.Notifier;
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestHandler;
 import com.github.tomakehurst.wiremock.http.Response;
+import com.github.tomakehurst.wiremock.jetty6.Jetty6FaultInjector;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletConfig;
@@ -38,7 +39,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.URLDecoder.decode;
 
-public class Jetty6HandlerDispatchingServlet extends HttpServlet {
+public class WireMockHandlerDispatchingServlet extends HttpServlet {
 
 	public static final String SHOULD_FORWARD_TO_FILES_CONTEXT = "shouldForwardToFilesContext";
 	public static final String MAPPED_UNDER_KEY = "mappedUnder";
@@ -92,7 +93,7 @@ public class Jetty6HandlerDispatchingServlet extends HttpServlet {
 	protected void service(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ServletException, IOException {
 		LocalNotifier.set(notifier);
 		
-		Request request = new Jetty6HttpServletRequestAdapter(httpServletRequest, mappedUnder);
+		Request request = new WireMockHttpServletRequestAdapter(httpServletRequest, mappedUnder);
         notifier.info("Received request: " + httpServletRequest.toString());
 
 		Response response = requestHandler.handle(request);

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.jetty6;
+package com.github.tomakehurst.wiremock.servlet;
 
 import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.base.Optional;
 
 import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang.ClassUtils;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.Enumeration;
@@ -33,17 +36,17 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static java.util.Collections.list;
 
-public class Jetty6HttpServletRequestAdapter implements Request {
+public class WireMockHttpServletRequestAdapter implements Request {
     
     private final HttpServletRequest request;
     private byte[] cachedBody;
     private String urlPrefixToRemove;
 
-    public Jetty6HttpServletRequestAdapter(HttpServletRequest request) {
+    public WireMockHttpServletRequestAdapter(HttpServletRequest request) {
         this.request = request;
     }
 
-    public Jetty6HttpServletRequestAdapter(HttpServletRequest request, String urlPrefixToRemove) {
+    public WireMockHttpServletRequestAdapter(HttpServletRequest request, String urlPrefixToRemove) {
         this.request = request;
         this.urlPrefixToRemove = urlPrefixToRemove;
     }
@@ -163,13 +166,32 @@ public class Jetty6HttpServletRequestAdapter implements Request {
 
     @Override
     public boolean isBrowserProxyRequest() {
-        if (request instanceof org.mortbay.jetty.Request) {
+        if (isJettyRequest()) {
             org.mortbay.jetty.Request jettyRequest = (org.mortbay.jetty.Request) request;
             URI uri = URI.create(jettyRequest.getUri().toString());
             return uri.isAbsolute();
         }
 
         return false;
+    }
+
+    private boolean isJettyRequest() {
+        if (!isPresent("org.mortbay.jetty.Request")) {
+            return false;
+        }
+        if (request instanceof org.mortbay.jetty.Request) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isPresent(String className) {
+        try {
+            ClassUtils.getClass(className);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
The servlet and request adapters have moved to the "servlet" package.
The only dependency they had on jetty was conditional anyway, so
the condition was also modified to not even require jetty on the
classpath.

See gh-407. Not a complete modularization yet, but splits up the
servlet-only stuff from the jetty server.