### PR TITLE
Isolate jetty dependencies into a single package

### DIFF
--- a/sample-war/src/main/webapp/WEB-INF/web.xml
+++ b/sample-war/src/main/webapp/WEB-INF/web.xml
@@ -23,7 +23,7 @@
 
   <servlet>
   	<servlet-name>wiremock-mock-service-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty9.JettyHandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.StubRequestHandler</param-value>
@@ -36,7 +36,7 @@
   
   <servlet>
   	<servlet-name>wiremock-admin-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty9.JettyHandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.AdminRequestHandler</param-value>

--- a/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml
+++ b/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml
@@ -26,7 +26,7 @@
 
   <servlet>
   	<servlet-name>wiremock-mock-service-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty9.JettyHandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.StubRequestHandler</param-value>
@@ -47,7 +47,7 @@
   
   <servlet>
   	<servlet-name>wiremock-admin-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty9.JettyHandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.AdminRequestHandler</param-value>

--- a/sample-war/src/main/webappLimitedRequestJournal/WEB-INF/web.xml
+++ b/sample-war/src/main/webappLimitedRequestJournal/WEB-INF/web.xml
@@ -29,7 +29,7 @@
 
   <servlet>
   	<servlet-name>wiremock-mock-service-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty9.JettyHandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.StubRequestHandler</param-value>
@@ -42,7 +42,7 @@
   
   <servlet>
   	<servlet-name>wiremock-admin-handler-servlet</servlet-name>
-  	<servlet-class>com.github.tomakehurst.wiremock.jetty9.JettyHandlerDispatchingServlet</servlet-class>
+  	<servlet-class>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet</servlet-class>
   	<init-param>
   		<param-name>RequestHandlerClass</param-name>
   		<param-value>com.github.tomakehurst.wiremock.http.AdminRequestHandler</param-value>

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyFaultInjector.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyFaultInjector.java
@@ -15,24 +15,21 @@
  */
 package com.github.tomakehurst.wiremock.jetty9;
 
-import com.github.tomakehurst.wiremock.core.FaultInjector;
-import com.google.common.base.Charsets;
-import org.eclipse.jetty.io.ChannelEndPoint;
-import org.eclipse.jetty.io.EndPoint;
-import org.eclipse.jetty.io.SelectChannelEndPoint;
-import org.eclipse.jetty.io.ssl.SslConnection;
-import org.eclipse.jetty.server.HttpChannel;
-import org.eclipse.jetty.server.Response;
-import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.Callback;
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.jetty9.JettyUtils.unwrapResponse;
 
-import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.Socket;
 
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.github.tomakehurst.wiremock.jetty9.JettyUtils.unwrapResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.io.ChannelEndPoint;
+import org.eclipse.jetty.server.HttpChannel;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.BufferUtil;
+
+import com.github.tomakehurst.wiremock.core.FaultInjector;
+import com.google.common.base.Charsets;
 
 public class JettyFaultInjector implements FaultInjector {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyFaultInjectorFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyFaultInjectorFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.tomakehurst.wiremock.jetty9;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.github.tomakehurst.wiremock.core.FaultInjector;
+import com.github.tomakehurst.wiremock.servlet.FaultInjectorFactory;
+
+public class JettyFaultInjectorFactory implements FaultInjectorFactory {
+
+    @Override
+    public FaultInjector buildFaultInjector(HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse) {
+        if (httpServletRequest.getScheme().equals("https")) {
+            return new JettyHttpsFaultInjector(httpServletResponse);
+        }
+
+        return new JettyFaultInjector(httpServletResponse);
+    }
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -50,6 +50,7 @@ import com.github.tomakehurst.wiremock.http.HttpServer;
 import com.github.tomakehurst.wiremock.http.RequestHandler;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.servlet.ContentTypeSettingFilter;
+import com.github.tomakehurst.wiremock.servlet.FaultInjectorFactory;
 import com.github.tomakehurst.wiremock.servlet.TrailingSlashFilter;
 import com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet;
 
@@ -245,10 +246,12 @@ class JettyHttpServer implements HttpServer {
 
         mockServiceContext.addServlet(DefaultServlet.class, FILES_URL_MATCH);
 
+        mockServiceContext.setAttribute(JettyFaultInjectorFactory.class.getName(), new JettyFaultInjectorFactory());
         mockServiceContext.setAttribute(StubRequestHandler.class.getName(), stubRequestHandler);
         mockServiceContext.setAttribute(Notifier.KEY, notifier);
         ServletHolder servletHolder = mockServiceContext.addServlet(WireMockHandlerDispatchingServlet.class, "/");
         servletHolder.setInitParameter(RequestHandler.HANDLER_CLASS_KEY, StubRequestHandler.class.getName());
+        servletHolder.setInitParameter(FaultInjectorFactory.INJECTOR_CLASS_KEY, JettyFaultInjectorFactory.class.getName());
         servletHolder.setInitParameter(WireMockHandlerDispatchingServlet.SHOULD_FORWARD_TO_FILES_CONTEXT, "true");
 
         MimeTypes mimeTypes = new MimeTypes();

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/FaultInjectorFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/FaultInjectorFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.tomakehurst.wiremock.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.github.tomakehurst.wiremock.core.FaultInjector;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public interface FaultInjectorFactory {
+
+    String INJECTOR_CLASS_KEY = "FaultHandlerFactoryClass";
+
+    FaultInjector buildFaultInjector(HttpServletRequest httpServletRequest,
+            HttpServletResponse httpServletResponse);
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.jetty9;
+package com.github.tomakehurst.wiremock.servlet;
 
 import com.github.tomakehurst.wiremock.common.Exceptions;
 import com.github.tomakehurst.wiremock.common.LocalNotifier;
@@ -21,6 +21,8 @@ import com.github.tomakehurst.wiremock.common.Notifier;
 import com.github.tomakehurst.wiremock.core.FaultInjector;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.http.*;
+import com.github.tomakehurst.wiremock.jetty9.JettyFaultInjector;
+import com.github.tomakehurst.wiremock.jetty9.JettyHttpsFaultInjector;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletConfig;
@@ -38,7 +40,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.URLDecoder.decode;
 
-public class JettyHandlerDispatchingServlet extends HttpServlet {
+public class WireMockHandlerDispatchingServlet extends HttpServlet {
 
 	public static final String SHOULD_FORWARD_TO_FILES_CONTEXT = "shouldForwardToFilesContext";
 	public static final String MAPPED_UNDER_KEY = "mappedUnder";
@@ -92,7 +94,7 @@ public class JettyHandlerDispatchingServlet extends HttpServlet {
 	protected void service(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ServletException, IOException {
 		LocalNotifier.set(notifier);
 		
-		Request request = new JettyHttpServletRequestAdapter(httpServletRequest, mappedUnder);
+		Request request = new WireMockHttpServletRequestAdapter(httpServletRequest, mappedUnder);
 
 		Response response = requestHandler.handle(request);
         if (Thread.currentThread().isInterrupted()) {

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.github.tomakehurst.wiremock.jetty9;
+package com.github.tomakehurst.wiremock.servlet;
 
 import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.http.*;
@@ -33,17 +33,17 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static java.util.Collections.list;
 
-public class JettyHttpServletRequestAdapter implements Request {
+public class WireMockHttpServletRequestAdapter implements Request {
 
     private final HttpServletRequest request;
     private byte[] cachedBody;
     private String urlPrefixToRemove;
 
-    public JettyHttpServletRequestAdapter(HttpServletRequest request) {
+    public WireMockHttpServletRequestAdapter(HttpServletRequest request) {
         this.request = request;
     }
 
-    public JettyHttpServletRequestAdapter(HttpServletRequest request, String urlPrefixToRemove) {
+    public WireMockHttpServletRequestAdapter(HttpServletRequest request, String urlPrefixToRemove) {
         this.request = request;
         this.urlPrefixToRemove = urlPrefixToRemove;
     }
@@ -202,12 +202,30 @@ public class JettyHttpServletRequestAdapter implements Request {
 
     @Override
     public boolean isBrowserProxyRequest() {
+        if (!isJetty()) {
+            return false;
+        }
         if (request instanceof org.eclipse.jetty.server.Request) {
             org.eclipse.jetty.server.Request jettyRequest = (org.eclipse.jetty.server.Request) request;
             return URI.create(jettyRequest.getUri().toString()).isAbsolute();
         }
 
         return false;
+    }
+
+    private boolean isJetty() {
+        try {
+            getClass("org.eclipse.jetty.server.Request");
+            return true;
+        } catch (Exception e) {
+        }
+        return false;
+    }
+
+    private void getClass(String type) throws ClassNotFoundException {
+        ClassLoader contextCL = Thread.currentThread().getContextClassLoader();
+        ClassLoader loader = contextCL == null ? WireMockHttpServletRequestAdapter.class.getClassLoader() : contextCL;
+        Class.forName(type, false, loader);
     }
 
     @Override


### PR DESCRIPTION
The servlet and request adapters have moved to the "servlet" package.
The only dependency they had on jetty was conditional anyway, so
the condition was also modified to not even require jetty on the
classpath.

See gh-407. Not a complete modularization yet, but splits up the
servlet-only stuff from the jetty server.