### PR TITLE
Fix android codec dependencies

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServletRequestAdapter.java
@@ -24,7 +24,8 @@ import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.codec.binary.Base64;
+import com.google.common.io.BaseEncoding;
+import com.google.common.base.Charsets;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -125,7 +126,7 @@ public class JettyHttpServletRequestAdapter implements Request {
 
     @Override
     public String getBodyAsBase64() {
-        return Base64.encodeBase64String(getBody());
+        return BaseEncoding.base64().encode(getBody().toString().getBytes(Charsets.US_ASCII));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -158,7 +158,7 @@ public class LoggedRequest implements Request {
     @Override
     @JsonProperty("bodyAsBase64")
     public String getBodyAsBase64() {
-        return   BaseEncoding.base64().encode(getBody().toString().getBytes(Charsets.US_ASCII));
+        return BaseEncoding.base64().encode(getBody().toString().getBytes(Charsets.US_ASCII));
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -29,7 +29,8 @@ import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.codec.binary.Base64;
+import com.google.common.io.BaseEncoding;
+import com.google.common.base.Charsets;
 
 import java.net.URI;
 import java.util.Date;
@@ -84,7 +85,7 @@ public class LoggedRequest implements Request {
         this.absoluteUrl = absoluteUrl;
         this.clientIp = clientIp;
         this.method = method;
-        this.body = Base64.decodeBase64(bodyAsBase64);
+        this.body = BaseEncoding.base64().decode(bodyAsBase64);
         this.headers = headers;
         this.cookies = cookies;
         this.queryParams = splitQuery(URI.create(url));
@@ -157,7 +158,7 @@ public class LoggedRequest implements Request {
     @Override
     @JsonProperty("bodyAsBase64")
     public String getBodyAsBase64() {
-        return Base64.encodeBase64String(body);
+        return   BaseEncoding.base64().encode(getBody().toString().getBytes(Charsets.US_ASCII));
     }
 
     @Override


### PR DESCRIPTION
@tomakehurst  The Guava libraries work in android. I have made 2 changes that were needed to make encoding and decoding work in Android. I have tested the changes in Android project. Also I tested the changes for Desktop in wiremock standalone by running `wiremock-standalone-2.1.1-beta.jar` and testing a basic stubbing. Both worked. 