### PR TITLE
RequestPattern should not match when there is a body pattern but no request body

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -196,7 +196,10 @@ public class RequestPattern implements ValueMatcher<Request> {
     }
 
     private MatchResult allBodyPatternsMatch(final Request request) {
-        if (bodyPatterns != null && !bodyPatterns.isEmpty() && request.getBody() != null) {
+        if (thereAreSomeBodyPatterns() && thereIsNoRequestBody(request)) {
+            return MatchResult.noMatch();
+        }
+        if (thereAreSomeBodyPatterns() && thereIsARequestBody(request)) {
             return MatchResult.aggregate(
                 from(bodyPatterns).transform(new Function<StringValuePattern, MatchResult>() {
                     @Override
@@ -208,6 +211,18 @@ public class RequestPattern implements ValueMatcher<Request> {
         }
 
         return MatchResult.exactMatch();
+    }
+
+    private boolean thereIsARequestBody(Request request) {
+        return request.getBody() != null && request.getBody().length != 0;
+    }
+
+    private boolean thereIsNoRequestBody(Request request) {
+        return request.getBody() == null || request.getBody().length == 0;
+    }
+
+    private boolean thereAreSomeBodyPatterns() {
+        return bodyPatterns != null && !bodyPatterns.isEmpty();
     }
 
     public boolean isMatchedBy(Request request, Map<String, RequestMatcherExtension> customMatchers) {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -285,6 +285,21 @@ public class RequestPatternTest {
     }
 
     @Test
+    public void doesNotMatchExactlyWhenThereIsNoBody() {
+        RequestPattern requestPattern =
+                newRequestPattern(PUT, WireMock.urlPathEqualTo("/my/url"))
+                        .withRequestBody(WireMock.equalToXml("<xml></xml>"))
+                        .build();
+
+        MatchResult matchResult = requestPattern.match(mockRequest()
+                .method(PUT)
+                .url("/my/url")
+                .body(""));
+
+        assertFalse(matchResult.isExactMatch());
+    }
+
+    @Test
     public void matchesExactlyWhenAllCookiesMatch() {
         RequestPattern requestPattern =
             newRequestPattern(POST, WireMock.urlPathEqualTo("/my/url"))


### PR DESCRIPTION
This solves one of the issues I have seen as a result of #445 