### PR TITLE
Unit test fixes for pretty print

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -423,9 +423,9 @@ public class VerificationAcceptanceTest {
             } catch (VerificationException e) {
                 assertThat(e.getMessage(), is(
                         "Expected exactly 3 requests matching the following pattern but received only 2:\n" +
-                        "{\n" +
-                        "  \"url\" : \"/hit\",\n" +
-                        "  \"method\" : \"GET\"\n" +
+                        "{" + System.lineSeparator() +
+                        "  \"url\" : \"/hit\"," + System.lineSeparator() +
+                        "  \"method\" : \"GET\"" + System.lineSeparator() +
                         "}"
                     )
                 );
@@ -463,9 +463,9 @@ public class VerificationAcceptanceTest {
             } catch (VerificationException e) {
                 assertThat(e.getMessage(), is(
                     "Expected less than 2 requests matching the following pattern but received 4:\n" +
-                    "{\n" +
-                    "  \"url\" : \"/hit\",\n" +
-                    "  \"method\" : \"GET\"\n" +
+                    "{" + System.lineSeparator() +
+                    "  \"url\" : \"/hit\"," + System.lineSeparator() +
+                    "  \"method\" : \"GET\"" + System.lineSeparator() +
                     "}"
                     )
                 );

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/DiffTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/DiffTest.java
@@ -171,18 +171,18 @@ public class DiffTest {
             junitStyleDiffMessage(
                 "ANY\n" +
                 "/thing\n" +
-                "{\n" +
-                "  \"outer\" : {\n" +
-                "    \"inner\" : {\n" +
-                "      \"thing\" : 1\n" +
-                "    }\n" +
-                "  }\n" +
+                "{" + System.lineSeparator() +
+                "  \"outer\" : {" + System.lineSeparator() +
+                "    \"inner\" : {" + System.lineSeparator() +
+                "      \"thing\" : 1" + System.lineSeparator() +
+                "    }" + System.lineSeparator() +
+                "  }" + System.lineSeparator() +
                 "}",
 
                 "ANY\n" +
                 "/thing\n" +
-                "{\n" +
-                "  \"outer\" : { }\n" +
+                "{" + System.lineSeparator() +
+                "  \"outer\" : { }" + System.lineSeparator() +
                 "}")
         ));
     }
@@ -203,18 +203,18 @@ public class DiffTest {
             junitStyleDiffMessage(
                 "ANY\n" +
                 "/thing\n" +
-                "{\n" +
-                "  \"outer\" : {\n" +
-                "    \"inner:\" : {\n" +
-                "      \"thing\" : 1\n" +
-                "    }\n" +
-                "  }\n" +
+                "{" + System.lineSeparator() +
+                "  \"outer\" : {" + System.lineSeparator() +
+                "    \"inner:\" : {" + System.lineSeparator() +
+                "      \"thing\" : 1" + System.lineSeparator() +
+                "    }" + System.lineSeparator() +
+                "  }" + System.lineSeparator() +
                 "}",
 
                 "ANY\n" +
                 "/thing\n" +
-                "{\n" +
-                "  \"outer\" : { }\n" +
+                "{" + System.lineSeparator() +
+                "  \"outer\" : { }" + System.lineSeparator() +
                 "}")
         ));
     }
@@ -279,19 +279,19 @@ public class DiffTest {
             junitStyleDiffMessage(
                 "ANY\n" +
                 "/thing\n" +
-                "<my-elements>\n" +
-                "  <one attr-one=\"1111\"/>\n" +
-                "  <two/>\n" +
-                "  <three/>\n" +
-                "</my-elements>\n",
+                "<my-elements>" + System.lineSeparator() +
+                "  <one attr-one=\"1111\"/>" + System.lineSeparator() +
+                "  <two/>" + System.lineSeparator() +
+                "  <three/>" + System.lineSeparator() +
+                "</my-elements>" + System.lineSeparator(),
 
                 "ANY\n" +
                 "/thing\n" +
-                "<my-elements>\n" +
-                "  <one attr-one=\"2222\"/>\n" +
-                "  <two/>\n" +
-                "  <three/>\n" +
-                "</my-elements>\n")
+                "<my-elements>" + System.lineSeparator() +
+                "  <one attr-one=\"2222\"/>" + System.lineSeparator() +
+                "  <two/>" + System.lineSeparator() +
+                "  <three/>" + System.lineSeparator() +
+                "</my-elements>" + System.lineSeparator())
         ));
     }
 


### PR DESCRIPTION
The pretty print library used appears to create system specific
new line characters. Now the non-ignored unit tests pass on
Windows.

I suppose an alternative to this approach could be to change the 
configuration of the library to always use unix line endings.