### PR TITLE
for 2.0 release -fixing documentation -  for remove api

### DIFF
--- a/docs/source/stubbing.rst
+++ b/docs/source/stubbing.rst
@@ -620,6 +620,7 @@ Note that this feature is not available when running WireMock from a servlet con
 Removing stubs
 ============
 
+
 Stub mappings which have been created can be removed via ``mappings`` directory via a call to ``WireMock.removeStubMapping``
 in Java or posting a request with body that has the stub to ``http://<host>:<port>/__admin/mappings/remove``.
 

--- a/docs/source/stubbing.rst
+++ b/docs/source/stubbing.rst
@@ -640,7 +640,8 @@ request that matches url="/v8/asd/26", and method "method": "GET".
             "status": 202,
             "body": "response for test",
             "headers": {
-            "Content-Type": "text/plain"
+                "Content-Type": "text/plain"
+            }
         }
     }
 

--- a/docs/source/stubbing.rst
+++ b/docs/source/stubbing.rst
@@ -620,14 +620,14 @@ Note that this feature is not available when running WireMock from a servlet con
 Removing stubs
 ============
 
-
-Stub mappings which have been created can be removed via ``mappings`` directory via a call to ``WireMock.removeStubMapping``
+Stub mappings which have been created can be removed via a call to ``WireMock.removeStubMapping``
 in Java or posting a request with body that has the stub to ``http://<host>:<port>/__admin/mappings/remove``.
 
-WireMock tries to match UUID is it is passed in the body of the stup to a post request and if it finds the stub it removes it.
-if match is not found, then it tries to match the request object found in the stub with existing mappings and removes the first one that it finds.
+WireMock tries to match UUID in the a post request and if it finds the stub with that UUID it removes it.
+it then tries to match the request object with the one in post request and if it finds a match it removes it. Basically this api removes
+all the matching stubs where either UUID or request object match is found.
 
-For Example - posting following stub as body to http://<host>:<port>/__admin/mappings/remove will find first mapping with
+For Example - posting following stub as body to http://<host>:<port>/__admin/mappings/remove will find all mapping with
 request that matches url="/v8/asd/26", and method "method": "GET".
 
 .. code-block:: javascript
@@ -645,13 +645,9 @@ request that matches url="/v8/asd/26", and method "method": "GET".
       }
     }
 
-This is because body does not have UUID. if it had an element like
-"uuid": "aa85aed3-66c8-42bb-a79b-38e3264ff2ef",in addition to "request" and "response" then wiremock will remove the one that matches the uuid provided.
-removing via uuid has precedence over removing via request match.
+If it had an element like "uuid": "aa85aed3-66c8-42bb-a79b-38e3264ff2ef",in addition to "request" and "response" then wiremock will remove the one that matches the uuid provided.
 
-Note that this api only removes one mapping and not multiple ones if they exist
-Note that this feature is not available when running WireMock from a servlet container.
-
+Note: remove api uses UUID to find match and also uses request object to find a match and removes all maps that match the request.
 
 .. _stubbing-reset:
 

--- a/docs/source/stubbing.rst
+++ b/docs/source/stubbing.rst
@@ -647,7 +647,7 @@ request that matches url="/v8/asd/26", and method "method": "GET".
 
 If it had an element like "uuid": "aa85aed3-66c8-42bb-a79b-38e3264ff2ef",in addition to "request" and "response" then wiremock will remove the one that matches the uuid provided.
 
-Note: remove api uses UUID to find match and also uses request object to find a match and removes all maps that match the request.
+Note: remove api uses UUID to find match and also uses request object to find a match and removes all mappings that match the request.
 
 .. _stubbing-reset:
 

--- a/docs/source/stubbing.rst
+++ b/docs/source/stubbing.rst
@@ -631,18 +631,17 @@ For Example - posting following stub as body to http://<host>:<port>/__admin/map
 request that matches url="/v8/asd/26", and method "method": "GET".
 
 .. code-block:: javascript
-{
-      "request": {
-        "url": "/v8/asd/26",
-        "method": "GET"
-      },
-      "response": {
-        "status": 202,
-        "body": "response for test",
-        "headers": {
-          "Content-Type": "text/plain"
+    {
+        "request": {
+            "url": "/v8/asd/26",
+            "method": "GET"
+        },
+        "response": {
+            "status": 202,
+            "body": "response for test",
+            "headers": {
+            "Content-Type": "text/plain"
         }
-      }
     }
 
 If it had an element like "uuid": "aa85aed3-66c8-42bb-a79b-38e3264ff2ef",in addition to "request" and "response" then wiremock will remove the one that matches the uuid provided.

--- a/docs/source/stubbing.rst
+++ b/docs/source/stubbing.rst
@@ -620,6 +620,7 @@ Note that this feature is not available when running WireMock from a servlet con
 Removing stubs
 ============
 
+
 Stub mappings which have been created can be removed via a call to ``WireMock.removeStubMapping``
 in Java or posting a request with body that has the stub to ``http://<host>:<port>/__admin/mappings/remove``.
 
@@ -631,23 +632,22 @@ For Example - posting following stub as body to http://<host>:<port>/__admin/map
 request that matches url="/v8/asd/26", and method "method": "GET".
 
 .. code-block:: javascript
+
     {
         "request": {
-            "url": "/v8/asd/26",
-            "method": "GET"
+            "method": "GET",
+            "url": "/v8/asd/26"
         },
         "response": {
-            "status": 202,
-            "body": "response for test",
-            "headers": {
-                "Content-Type": "text/plain"
-            }
+            "status": 200,
+            "body" : "response for test"
         }
     }
 
 If it had an element like "uuid": "aa85aed3-66c8-42bb-a79b-38e3264ff2ef",in addition to "request" and "response" then wiremock will remove the one that matches the uuid provided.
 
 Note: remove api uses UUID to find match and also uses request object to find a match and removes all mappings that match the request.
+
 
 .. _stubbing-reset:
 


### PR DESCRIPTION
changed the documentation to suggest api removes all the matches with uuid and request object both and not unique matches.