### PR TITLE
Added form parameter interaction identical to query parameters

### DIFF
--- a/docs-v2/_docs/request-matching.md
+++ b/docs-v2/_docs/request-matching.md
@@ -10,6 +10,7 @@ WireMock supports matching of requests to stubs and verification queries using t
 * URL
 * HTTP Method
 * Query parameters
+* Form parameters
 * Headers
 * Basic authentication (a special case of header matching)
 * Cookies
@@ -25,6 +26,7 @@ stubFor(any(urlPathEqualTo("/everything"))
   .withHeader("Accept", containing("xml"))
   .withCookie("session", matching(".*12345.*"))
   .withQueryParam("search_term", equalTo("WireMock"))
+  .withFormParam("key", equalTo("value"))
   .withBasicAuth("jeff@example.com", "jeffteenjefftyjeff")
   .withRequestBody(equalToXml("<search-results />"))
   .withRequestBody(matchingXPath("//search-results"))
@@ -46,6 +48,11 @@ JSON:
     "queryParameters" : {
       "search_term" : {
         "equalTo" : "WireMock"
+      }
+    },
+    "formParameters" : {
+      "key" : {
+        "equalTo" : "value"
       }
     },
     "cookies" : {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/LocalMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/LocalMappingBuilder.java
@@ -24,6 +24,7 @@ public interface LocalMappingBuilder<M extends LocalMappingBuilder, S extends Sc
     M atPriority(Integer priority);
     M withHeader(String key, StringValuePattern headerPattern);
     M withQueryParam(String key, StringValuePattern queryParamPattern);
+	M withFormParam(String key, StringValuePattern formParamPattern);
     M withRequestBody(StringValuePattern bodyPattern);
     S inScenario(String scenarioName);
     M withId(UUID id);

--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -82,6 +82,12 @@ class MappingBuilder implements LocalMappingBuilder, ScenarioMappingBuilder {
     }
 
 	@Override
+	public MappingBuilder withFormParam(String key, StringValuePattern formParamPattern) {
+		requestPatternBuilder.withFormParam(key, formParamPattern);
+		return this;
+	}
+
+	@Override
 	public MappingBuilder withRequestBody(StringValuePattern bodyPattern) {
         requestPatternBuilder.withRequestBody(bodyPattern);
 		return this;

--- a/src/main/java/com/github/tomakehurst/wiremock/client/RemoteMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/RemoteMappingBuilder.java
@@ -24,6 +24,7 @@ public interface RemoteMappingBuilder<M extends RemoteMappingBuilder, S extends 
     M atPriority(Integer priority);
     M withHeader(String key, StringValuePattern headerPattern);
     M withQueryParam(String key, StringValuePattern queryParamPattern);
+	M withFormParam(String key, StringValuePattern formParamPattern);
     M withRequestBody(StringValuePattern bodyPattern);
     S inScenario(String scenarioName);
     M withId(UUID id);

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
@@ -15,25 +15,55 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import com.github.tomakehurst.wiremock.http.FormParameter;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Maps.newHashMap;
 import static java.util.Arrays.asList;
 
+import org.apache.commons.collections4.keyvalue.DefaultMapEntry;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+
 public class Urls {
+
+	public static Map<String, FormParameter> splitForm(String form) {
+		if (form == null || form.length() == 0) {
+			return Collections.emptyMap();
+		}
+
+		final Multimap<String, String> entries = HashMultimap.create();
+		for (final NameValuePair nvp : URLEncodedUtils.parse(form, Charset.forName("UTF-8"))) {
+			entries.put(nvp.getName(), nvp.getValue() == null ? "" : nvp.getValue());
+		}
+
+		final Map<String, FormParameter> params = newHashMap();
+		for (final String key : entries.keySet()) {
+			final Collection<String> values = entries.get(key);
+			params.put(key, FormParameter.formParam(key, values.toArray(new String[values.size()])));
+		}
+		return params;
+	}
 
     public static Map<String, QueryParameter> splitQuery(String query) {
         if (query == null) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/FormParameter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/FormParameter.java
@@ -15,31 +15,22 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.Collections;
+import java.util.List;
 
-public interface Request {
+import static java.util.Arrays.asList;
 
-    String getUrl();
-    String getAbsoluteUrl();
-    RequestMethod getMethod();
-    String getClientIp();
+public class FormParameter extends MultiValue {
 
-    String getHeader(String key);
-    HttpHeader header(String key);
-    ContentTypeHeader contentTypeHeader();
-    HttpHeaders getHeaders();
-    boolean containsHeader(String key);
-    Set<String> getAllHeaderKeys();
+	public FormParameter(String key, List<String> values) {
+		super(key, values);
+	}
 
-    Map<String, Cookie> getCookies();
+	public static FormParameter formParam(String key, String... values) {
+		return new FormParameter(key, asList(values));
+	}
 
-    QueryParameter queryParameter(String key);
-	FormParameter formParameter(String key);
-
-    byte[] getBody();
-    String getBodyAsString();
-    String getBodyAsBase64();
-
-    boolean isBrowserProxyRequest();
+	public static FormParameter absent(String key) {
+		return new FormParameter(key, Collections.<String>emptyList());
+	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -17,6 +17,7 @@ public class RequestPatternBuilder {
     private RequestMethod method;
     private Map<String, MultiValuePattern> headers = newLinkedHashMap();
     private Map<String, MultiValuePattern> queryParams = newLinkedHashMap();
+	private Map<String, MultiValuePattern> formParams = newLinkedHashMap();
     private List<StringValuePattern> bodyPatterns = newArrayList();
     private Map<String, StringValuePattern> cookies = newLinkedHashMap();
     private BasicCredentials basicCredentials;
@@ -81,6 +82,11 @@ public class RequestPatternBuilder {
         return this;
     }
 
+	public RequestPatternBuilder withFormParam(String key, StringValuePattern valuePattern) {
+		formParams.put(key, MultiValuePattern.of(valuePattern));
+		return this;
+	}
+
     public RequestPatternBuilder withCookie(String key, StringValuePattern valuePattern) {
         cookies.put(key, valuePattern);
         return this;
@@ -108,6 +114,7 @@ public class RequestPatternBuilder {
                     method,
                     headers.isEmpty() ? null : headers,
                     queryParams.isEmpty() ? null : queryParams,
+					formParams.isEmpty() ? null : formParams,
                     cookies.isEmpty() ? null : cookies,
                     basicCredentials,
                     bodyPatterns.isEmpty() ? null : bodyPatterns,

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -25,11 +25,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.*;
 
+import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
+import static com.github.tomakehurst.wiremock.common.Urls.splitForm;
 import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Strings.repeat;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.io.ByteStreams.toByteArray;
 import static java.util.Collections.list;
@@ -200,7 +203,13 @@ public class WireMockHttpServletRequestAdapter implements Request {
             QueryParameter.absent(key));
     }
 
-    @Override
+	@Override
+	public FormParameter formParameter(String key) {
+		return firstNonNull(splitForm(getBodyAsString()).get(key),
+				FormParameter.absent(key));
+	}
+
+	@Override
     public boolean isBrowserProxyRequest() {
         if (!isJetty()) {
             return false;

--- a/src/test/java/com/github/tomakehurst/wiremock/NearMissesRuleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NearMissesRuleAcceptanceTest.java
@@ -142,7 +142,7 @@ public class NearMissesRuleAcceptanceTest {
 
             client.get("/");
 
-            assertThat(wm.findNearMissesForAllUnmatchedRequests().size(), is(1));
+			assertThat(wm.findNearMissesForAllUnmatchedRequests().size(), is(1));
         }
 
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import com.github.tomakehurst.wiremock.http.FormParameter;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import org.junit.Test;
 
@@ -27,28 +28,46 @@ import static org.junit.Assert.assertThat;
 
 public class UrlsTest {
 
-    private Map<String, QueryParameter> params;
+    private Map<String, QueryParameter> qParams;
+	private Map<String, FormParameter> fParams;
 
     @Test
-    public void copesWithEqualsInParamValues() {
-        params = Urls.splitQuery(URI.create("/thing?param1=one&param2=one==two=three"));
-        assertThat(params.get("param1").firstValue(), is("one"));
-        assertThat(params.get("param2").firstValue(), is("one==two=three"));
+    public void splitQueryCopesWithEqualsInParamValues() {
+        qParams = Urls.splitQuery(URI.create("/thing?param1=one&param2=one==two=three"));
+        assertThat(qParams.get("param1").firstValue(), is("one"));
+        assertThat(qParams.get("param2").firstValue(), is("one==two=three"));
     }
 
     @Test
-    public void returnsEmptyStringsAsValuesWhenOnlyKeysArePresent() {
-        params = Urls.splitQuery(URI.create("/thing?param1&param2&param3"));
-        assertThat(params.get("param1").firstValue(), is(""));
-        assertThat(params.get("param2").firstValue(), is(""));
-        assertThat(params.get("param3").firstValue(), is(""));
+    public void splitQueryReturnsEmptyStringsAsValuesWhenOnlyKeysArePresent() {
+        qParams = Urls.splitQuery(URI.create("/thing?param1&param2&param3"));
+        assertThat(qParams.get("param1").firstValue(), is(""));
+        assertThat(qParams.get("param2").firstValue(), is(""));
+        assertThat(qParams.get("param3").firstValue(), is(""));
     }
 
     @Test
-    public void supportsMultiValuedParameters() {
-        params = Urls.splitQuery(URI.create("/thing?param1=1&param2=two&param1=2&param1=3"));
-        assertThat(params.size(), is(2));
-        assertThat(params.get("param1").isSingleValued(), is(false));
-        assertThat(params.get("param1").values(), hasItems("1", "2", "3"));
+    public void splitQuerySupportsMultiValuedParameters() {
+        qParams = Urls.splitQuery(URI.create("/thing?param1=1&param2=two&param1=2&param1=3"));
+        assertThat(qParams.size(), is(2));
+        assertThat(qParams.get("param1").isSingleValued(), is(false));
+        assertThat(qParams.get("param1").values(), hasItems("1", "2", "3"));
     }
+
+	@Test
+	public void splitFormSupportsMultiValuesParameters() {
+		fParams = Urls.splitForm("param1=1&param1=2");
+		assertThat(fParams.size(), is(1));
+		assertThat(fParams.get("param1").isSingleValued(), is(false));
+		assertThat(fParams.get("param1").values(), hasItems("1", "2"));
+	}
+
+	@Test
+	public void splitFormReturnsEmptyStringsAsValuesWhenOnlyKeysArePresent() {
+		fParams = Urls.splitForm("param1&param2&param3");
+		assertThat(fParams.size(), is(3));
+		assertThat(fParams.get("param1").firstValue(), is(""));
+		assertThat(fParams.get("param2").firstValue(), is(""));
+		assertThat(fParams.get("param3").firstValue(), is(""));
+	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -3,6 +3,7 @@ package com.github.tomakehurst.wiremock.matching;
 import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.http.ContentTypeHeader;
 import com.github.tomakehurst.wiremock.http.Cookie;
+import com.github.tomakehurst.wiremock.http.FormParameter;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
@@ -128,7 +129,13 @@ public class MockRequest implements Request {
         return queryParams.get(key);
     }
 
-    @Override
+	@Override
+	public FormParameter formParameter(String key) {
+		Map<String, FormParameter> formParams = Urls.splitForm(getBodyAsString());
+		return formParams.get(key);
+	}
+
+	@Override
     public byte[] getBody() {
         return body;
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -39,6 +39,7 @@ public class MockRequestBuilder {
 	private List<HttpHeader> individualHeaders = newArrayList();
 	private Map<String, Cookie> cookies = newHashMap();
 	private List<QueryParameter> queryParameters = newArrayList();
+	private List<FormParameter> formParameters = newArrayList();
 	private String body = "";
 	private String bodyAsBase64 = "";
 
@@ -69,6 +70,11 @@ public class MockRequestBuilder {
 
 	public MockRequestBuilder withQueryParameter(String key, String... values) {
 		queryParameters.add(new QueryParameter(key, Arrays.asList(values)));
+		return this;
+	}
+
+	public MockRequestBuilder withFormParameter(String key, String... values) {
+		formParameters.add(new FormParameter(key, Arrays.asList(values)));
 		return this;
 	}
 
@@ -129,6 +135,9 @@ public class MockRequestBuilder {
 
 			for (QueryParameter queryParameter: queryParameters) {
 				allowing(request).queryParameter(queryParameter.key()); will(returnValue(queryParameter));
+			}
+			for (FormParameter formParameter : formParameters) {
+				allowing(request).formParameter(formParameter.key()); will(returnValue(queryParameters));
 			}
 
 			allowing(request).header(with(any(String.class))); will(returnValue(httpHeader("key", "value")));


### PR DESCRIPTION
This change introduces the ability to match on form parameters.

There's still 1 failing test at: ```
com.github.tomakehurst.wiremock.NearMissesRuleAcceptanceTest$CustomMatcherWithNearMissesTest > successfullyCalculatesNearMissesWhenACustomMatcherIsRegistered FAILED
    java.lang.AssertionError at NearMissesRuleAcceptanceTest.java:145
```

Any input is appreciated.