### PR TITLE
null values in http headers are allowed.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/MultiValue.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/MultiValue.java
@@ -50,7 +50,6 @@ public class MultiValue {
     }
 
     public List<String> values() {
-        checkPresent();
         return values;
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeaderTest.java
@@ -61,11 +61,6 @@ public class HttpHeaderTest {
         HttpHeader.absent("Something").firstValue();
     }
 
-    @Test(expected=IllegalStateException.class)
-    public void throwsExceptionWhenAttemptingToAccessValuesWhenAbsent() {
-        HttpHeader.absent("Something").values();
-    }
-
     @Test
     public void shouldMatchSingleValueToValuePattern() {
         HttpHeader header = new HttpHeader("My-Header", "my-value");


### PR DESCRIPTION
Hi Tom, 
We are using wiremock extensively.  Our tests were working fine till 1.58. After upgrading to 2.1.7 many tests failed. 
I am able to narrow down the root cause.

If I try following URL on 1.58 it works fine. But with 2.1.7 it throws 500 internal server error.

**curl -vv -H"Hello;" http://localhost:8080/__admin/** 

It breaks when http header has a key with null value. 

As per following document null values are allowed in http headers. Key cannot be null, but values can be null.
https://docs.oracle.com/javase/8/docs/jre/api/net/httpserver/spec/com/sun/net/httpserver/Headers.html
"However, null keys will never will be present in HTTP request headers, and will not be output/sent in response headers. Null values can be represented as either a null entry for the key (i.e. the list is null) or where the key has a list, but one (or more) of the list's values is null. Null values are output as a header line containing the key but no associated value."


Here is my pull request with relevant changes.

I've removed null value check and corresponding unit test case.

Thanks,
-Shailesh