### PR TITLE
Restore scala compat. in MappingBuilder types V2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
 }
 
 apply plugin: 'java'
+apply plugin: 'scala'
 apply plugin: 'eclipse'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
@@ -77,6 +78,7 @@ dependencies {
 
     testCompile "com.googlecode.jarjar:jarjar:1.3"
     testCompile "commons-io:commons-io:2.4"
+    testCompile 'org.scala-lang:scala-library:2.11.8'
 
     testRuntime 'org.slf4j:slf4j-log4j12:1.7.12'
     testRuntime files('src/test/resources/classpathfiles.zip', 'src/test/resources/classpath-filesource.jar')

--- a/src/main/java/com/github/tomakehurst/wiremock/client/LocalMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/LocalMappingBuilder.java
@@ -16,21 +16,18 @@
 package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
-import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
 import java.util.UUID;
 
-public interface LocalMappingBuilder<M extends LocalMappingBuilder, S extends ScenarioMappingBuilder> {
-    M atPriority(Integer priority);
-    M withHeader(String key, StringValuePattern headerPattern);
-    M withQueryParam(String key, StringValuePattern queryParamPattern);
-    M withRequestBody(StringValuePattern bodyPattern);
-    S inScenario(String scenarioName);
-    M withId(UUID id);
-    M withBasicAuth(String username, String password);
-    M withCookie(String name, StringValuePattern value);
+public interface LocalMappingBuilder extends RemoteMappingBuilder {
+    LocalMappingBuilder atPriority(Integer priority);
+    LocalMappingBuilder withHeader(String key, StringValuePattern headerPattern);
+    LocalMappingBuilder withQueryParam(String key, StringValuePattern queryParamPattern);
+    LocalMappingBuilder withRequestBody(StringValuePattern bodyPattern);
+    LocalScenarioMappingBuilder inScenario(String scenarioName);
+    LocalMappingBuilder withId(UUID id);
+    LocalMappingBuilder withBasicAuth(String username, String password);
+    LocalMappingBuilder withCookie(String name, StringValuePattern cookieValuePattern);
 
-    M willReturn(ResponseDefinitionBuilder responseDefBuilder);
-
-    StubMapping build();
+    LocalMappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/LocalScenarioMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/LocalScenarioMappingBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.client;
+
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+
+import java.util.UUID;
+
+public interface LocalScenarioMappingBuilder extends ScenarioMappingBuilder, LocalMappingBuilder {
+
+    LocalScenarioMappingBuilder whenScenarioStateIs(String stateName);
+    LocalScenarioMappingBuilder willSetStateTo(String stateName);
+
+    LocalScenarioMappingBuilder atPriority(Integer priority);
+    LocalScenarioMappingBuilder withHeader(String key, StringValuePattern headerPattern);
+    LocalScenarioMappingBuilder withQueryParam(String key, StringValuePattern queryParamPattern);
+    LocalScenarioMappingBuilder withRequestBody(StringValuePattern bodyPattern);
+    LocalScenarioMappingBuilder inScenario(String scenarioName);
+    LocalScenarioMappingBuilder withId(UUID id);
+    LocalScenarioMappingBuilder withBasicAuth(String username, String password);
+    LocalScenarioMappingBuilder withCookie(String name, StringValuePattern cookieValuePattern);
+
+    LocalScenarioMappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder);
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -29,25 +29,25 @@ import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-class MappingBuilder implements LocalMappingBuilder, ScenarioMappingBuilder {
+class MappingBuilder implements LocalScenarioMappingBuilder {
 
     private RequestPatternBuilder requestPatternBuilder;
 	private ResponseDefinitionBuilder responseDefBuilder;
 	private Integer priority;
 	private String scenarioName;
-	protected String requiredScenarioState;
-	protected String newScenarioState;
+	private String requiredScenarioState;
+	private String newScenarioState;
 	private UUID id;
 
-	public MappingBuilder(RequestMethod method, UrlPattern urlPattern) {
+	MappingBuilder(RequestMethod method, UrlPattern urlPattern) {
         requestPatternBuilder = new RequestPatternBuilder(method, urlPattern);
 	}
 
-	public MappingBuilder(RequestMatcher requestMatcher) {
+	MappingBuilder(RequestMatcher requestMatcher) {
         requestPatternBuilder = new RequestPatternBuilder(requestMatcher);
 	}
 
-	public MappingBuilder(String customRequestMatcherName, Parameters parameters) {
+	MappingBuilder(String customRequestMatcherName, Parameters parameters) {
 		requestPatternBuilder = new RequestPatternBuilder(customRequestMatcherName, parameters);
 	}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/client/RemoteMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/RemoteMappingBuilder.java
@@ -20,17 +20,18 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
 import java.util.UUID;
 
-public interface RemoteMappingBuilder<M extends RemoteMappingBuilder, S extends ScenarioMappingBuilder> {
-    M atPriority(Integer priority);
-    M withHeader(String key, StringValuePattern headerPattern);
-    M withQueryParam(String key, StringValuePattern queryParamPattern);
-    M withRequestBody(StringValuePattern bodyPattern);
-    S inScenario(String scenarioName);
-    M withId(UUID id);
-    M withBasicAuth(String username, String password);
-    M withCookie(String name, StringValuePattern cookieValuePattern);
+public interface RemoteMappingBuilder {
 
-    M willReturn(ResponseDefinitionBuilder responseDefBuilder);
+    RemoteMappingBuilder atPriority(Integer priority);
+    RemoteMappingBuilder withHeader(String key, StringValuePattern headerPattern);
+    RemoteMappingBuilder withQueryParam(String key, StringValuePattern queryParamPattern);
+    RemoteMappingBuilder withRequestBody(StringValuePattern bodyPattern);
+    ScenarioMappingBuilder inScenario(String scenarioName);
+    RemoteMappingBuilder withId(UUID id);
+    RemoteMappingBuilder withBasicAuth(String username, String password);
+    RemoteMappingBuilder withCookie(String name, StringValuePattern cookieValuePattern);
+
+    RemoteMappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder);
 
     StubMapping build();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
@@ -15,7 +15,23 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
-public interface ScenarioMappingBuilder extends RemoteMappingBuilder<ScenarioMappingBuilder, ScenarioMappingBuilder> {
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+
+import java.util.UUID;
+
+public interface ScenarioMappingBuilder extends RemoteMappingBuilder {
+
     ScenarioMappingBuilder whenScenarioStateIs(String stateName);
     ScenarioMappingBuilder willSetStateTo(String stateName);
+
+    ScenarioMappingBuilder atPriority(Integer priority);
+    ScenarioMappingBuilder withHeader(String key, StringValuePattern headerPattern);
+    ScenarioMappingBuilder withQueryParam(String key, StringValuePattern queryParamPattern);
+    ScenarioMappingBuilder withRequestBody(StringValuePattern bodyPattern);
+    ScenarioMappingBuilder inScenario(String scenarioName);
+    ScenarioMappingBuilder withId(UUID id);
+    ScenarioMappingBuilder withBasicAuth(String username, String password);
+    ScenarioMappingBuilder withCookie(String name, StringValuePattern cookieValuePattern);
+
+    ScenarioMappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -104,7 +104,7 @@ public class WireMock {
 		givenThat(mappingBuilder);
 	}
 
-	public static void editStub(MappingBuilder mappingBuilder) {
+	public static void editStub(RemoteMappingBuilder mappingBuilder) {
 		defaultInstance.get().editStubMapping(mappingBuilder);
 	}
 

--- a/src/test/java/com/github/tomakehurst/wiremock/client/LocalMappingBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/LocalMappingBuilderTest.java
@@ -19,8 +19,6 @@ import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -48,23 +46,5 @@ public class LocalMappingBuilderTest {
 
         // No assertions necessary: we're just checking that the compiler agrees with the typing
         ScenarioMappingBuilder resultingBuilder = mockBuilder.inScenario("foo");
-    }
-
-    @Test
-    public void localMappingBuilderSpecifiesSameInterfaceAsRemoteMappingBuilder() {
-        Method[] localMethods = LocalMappingBuilder.class.getDeclaredMethods();
-        Method[] remoteMethods = RemoteMappingBuilder.class.getDeclaredMethods();
-
-        assertThat("LocalMappingBuilder and RemoteMappingBuilder must declare the same methods",
-                localMethods.length, is(remoteMethods.length));
-
-        // Note: the following assumes the methods are in the same order, which isn't strictly necessary
-        for (int i = 0; i < localMethods.length; i++) {
-            Method localMethod = localMethods[i];
-            Method remoteMethod = remoteMethods[i];
-
-            assertThat(localMethod.getName(), is(remoteMethod.getName()));
-            assertThat(localMethod.getParameterTypes(), is(remoteMethod.getParameterTypes()));
-        }
     }
 }

--- a/src/test/scala/com/github/tomakehurst/wiremock/WireMockScalaAcceptanceTest.scala
+++ b/src/test/scala/com/github/tomakehurst/wiremock/WireMockScalaAcceptanceTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.Options
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import com.github.tomakehurst.wiremock.client.WireMock._
+import org.hamcrest.Matchers.is
+import org.junit.Assert.assertThat
+
+
+class WireMockScalaAcceptanceTest {
+	
+	var wireMockServer: WireMockServer = null
+	var testClient: WireMockTestClient = null
+
+	@Before
+	def init() {
+		wireMockServer = new WireMockServer(Options.DYNAMIC_PORT)
+		wireMockServer.start()
+		WireMock.configureFor(wireMockServer.port())
+		testClient = new WireMockTestClient(wireMockServer.port())
+	}
+	
+	@After
+	def stopServer() {
+		wireMockServer.stop()
+	}
+
+	@Test
+	def buildsMappingWithUrlOnlyRequestAndStatusOnlyResponse(): Unit = {
+		val wireMock = new WireMock(wireMockServer.port())
+		wireMock.register(get(urlEqualTo("/my/new/resource"))
+					.willReturn(aResponse()
+						.withStatus(304)))
+		
+		assertThat(testClient.get("/my/new/resource").statusCode(), is(304))
+	}
+	
+	@Test
+	def buildsMappingFromStaticSyntax() {
+		givenThat(get(urlEqualTo("/my/new/resource"))
+					.willReturn(aResponse()
+						.withStatus(304)))
+		
+		assertThat(testClient.get("/my/new/resource").statusCode(), is(304))
+	}
+	
+	@Test
+	def buildsMappingWithUrlOnyRequestAndResponseWithJsonBodyWithDiacriticSigns() {
+		val wireMock = new WireMock(wireMockServer.port());
+		wireMock.register(
+				get(urlEqualTo("/my/new/resource"))
+				.willReturn(
+						aResponse()
+						.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
+						.withStatus(200)))
+
+		assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+	}
+}


### PR DESCRIPTION
Removes broken generics from the MappingBuilder hierarchy, which makes
scalac happy.

Introduces significant repetition in method signatures in order to use
covariant return types, but I don't think that can be got rid of
without breaking backwards compatibility further by splitting the
existing MappingBuilder class up.

Simplifies class hierarchy - local extends from remote, on the basis that
anything that can be done remotely will be possible locally.

Resolves: #457