### PR TITLE
Add extra information to the mock files : Record request body AS IS to binary file

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -169,9 +169,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
 		stubRequestHandler.addRequestListener(listener);
 	}
 	
-	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource, boolean recordRequestBody) {
+	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource, boolean recordMappingsExtra) {
 	    addMockServiceRequestListener(
-                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, options.matchingHeaders(), recordRequestBody));
+                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, options.matchingHeaders(), recordMappingsExtra));
         notifier.info("Recording mappings to " + mappingsFileSource.getPath());
 	}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -169,9 +169,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
 		stubRequestHandler.addRequestListener(listener);
 	}
 	
-	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource) {
+	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource, boolean recordRequestBody) {
 	    addMockServiceRequestListener(
-                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, options.matchingHeaders()));
+                new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, options.matchingHeaders(), recordRequestBody));
         notifier.info("Recording mappings to " + mappingsFileSource.getPath());
 	}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HTTPBasicMessage.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HTTPBasicMessage.java
@@ -1,0 +1,6 @@
+package com.github.tomakehurst.wiremock.http;
+
+public interface HTTPBasicMessage {
+	HttpHeaders getHeaders();
+	byte[] getBody();
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.http;
 import java.util.Map;
 import java.util.Set;
 
-public interface Request {
+public interface Request extends HTTPBasicMessage {
 
     String getUrl();
     String getAbsoluteUrl();
@@ -28,7 +28,6 @@ public interface Request {
     String getHeader(String key);
     HttpHeader header(String key);
     ContentTypeHeader contentTypeHeader();
-    HttpHeaders getHeaders();
     boolean containsHeader(String key);
     Set<String> getAllHeaderKeys();
 
@@ -36,7 +35,6 @@ public interface Request {
 
     QueryParameter queryParameter(String key);
 
-    byte[] getBody();
     String getBodyAsString();
     String getBodyAsBase64();
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -26,7 +26,7 @@ import static com.google.common.collect.Iterables.transform;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 
-public class Response {
+public class Response implements HTTPBasicMessage {
 
 	private final int status;
     private final String statusMessage;

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.matching;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.tomakehurst.wiremock.client.BasicCredentials;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.Cookie;
@@ -33,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion.NON_NULL;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static com.github.tomakehurst.wiremock.matching.RequestMatcherExtension.NEVER;
 import static com.github.tomakehurst.wiremock.matching.RequestPatternBuilder.newRequestPattern;
@@ -50,7 +48,7 @@ public class RequestPattern implements ValueMatcher<Request> {
     private final Map<String, StringValuePattern> cookies;
     private final BasicCredentials basicAuthCredentials;
     private final List<StringValuePattern> bodyPatterns;
-    private String bodyFileName;
+    private String extraBodyFileName;
 
     private CustomMatcherDefinition customMatcherDefinition;
     private RequestMatcher matcher;
@@ -83,7 +81,7 @@ public class RequestPattern implements ValueMatcher<Request> {
                           BasicCredentials basicAuthCredentials,
                           List<StringValuePattern> bodyPatterns,
                           CustomMatcherDefinition customMatcherDefinition,
-                          String bodyFileName) {
+                          String extraBodyFileName) {
         this.url = url;
         this.method = method;
         this.headers = headers;
@@ -93,7 +91,7 @@ public class RequestPattern implements ValueMatcher<Request> {
         this.bodyPatterns = bodyPatterns;
         this.matcher = defaultMatcher;
         this.customMatcherDefinition = customMatcherDefinition;
-        this.bodyFileName = bodyFileName;
+        this.extraBodyFileName = extraBodyFileName;
     }
 
     @JsonCreator
@@ -108,7 +106,7 @@ public class RequestPattern implements ValueMatcher<Request> {
                           @JsonProperty("basicAuth") BasicCredentials basicAuthCredentials,
                           @JsonProperty("bodyPatterns") List<StringValuePattern> bodyPatterns,
                           @JsonProperty("customMatcher") CustomMatcherDefinition customMatcherDefinition,
-                          @JsonProperty("bodyFileName") String bodyFileName) {
+                          @JsonProperty("extraBodyFileName") String extraBodyFileName) {
 
         this(
             UrlPattern.fromOneOf(url, urlPattern, urlPath, urlPathPattern),
@@ -119,7 +117,7 @@ public class RequestPattern implements ValueMatcher<Request> {
             basicAuthCredentials,
             bodyPatterns,
             customMatcherDefinition,
-            bodyFileName
+            extraBodyFileName
         );
     }
 
@@ -288,12 +286,12 @@ public class RequestPattern implements ValueMatcher<Request> {
         return customMatcherDefinition;
     }
 
-    public String getBodyFileName() {
-        return bodyFileName;
+    public String getExtraBodyFileName() {
+        return extraBodyFileName;
     }
 
-    public void setBodyFileName(String bodyFileName) {
-        this.bodyFileName = bodyFileName;
+    public void setExtraBodyFileName(String extraBodyFileName) {
+        this.extraBodyFileName = extraBodyFileName;
     }
 
     @Override
@@ -323,12 +321,12 @@ public class RequestPattern implements ValueMatcher<Request> {
             Objects.equal(basicAuthCredentials, that.basicAuthCredentials) &&
             Objects.equal(bodyPatterns, that.bodyPatterns) &&
             Objects.equal(customMatcherDefinition, that.customMatcherDefinition) &&
-            Objects.equal(bodyFileName, that.bodyFileName);
+            Objects.equal(extraBodyFileName, that.extraBodyFileName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(url, method, headers, queryParams, cookies, basicAuthCredentials, bodyPatterns, customMatcherDefinition, matcher, defaultMatcher, bodyFileName);
+        return Objects.hashCode(url, method, headers, queryParams, cookies, basicAuthCredentials, bodyPatterns, customMatcherDefinition, matcher, defaultMatcher, extraBodyFileName);
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -50,6 +50,7 @@ public class RequestPattern implements ValueMatcher<Request> {
     private final Map<String, StringValuePattern> cookies;
     private final BasicCredentials basicAuthCredentials;
     private final List<StringValuePattern> bodyPatterns;
+    private String bodyFileName;
 
     private CustomMatcherDefinition customMatcherDefinition;
     private RequestMatcher matcher;
@@ -81,7 +82,8 @@ public class RequestPattern implements ValueMatcher<Request> {
                           Map<String, StringValuePattern> cookies,
                           BasicCredentials basicAuthCredentials,
                           List<StringValuePattern> bodyPatterns,
-                          CustomMatcherDefinition customMatcherDefinition) {
+                          CustomMatcherDefinition customMatcherDefinition,
+                          String bodyFileName) {
         this.url = url;
         this.method = method;
         this.headers = headers;
@@ -91,6 +93,7 @@ public class RequestPattern implements ValueMatcher<Request> {
         this.bodyPatterns = bodyPatterns;
         this.matcher = defaultMatcher;
         this.customMatcherDefinition = customMatcherDefinition;
+        this.bodyFileName = bodyFileName;
     }
 
     @JsonCreator
@@ -104,7 +107,8 @@ public class RequestPattern implements ValueMatcher<Request> {
                           @JsonProperty("cookies") Map<String, StringValuePattern> cookies,
                           @JsonProperty("basicAuth") BasicCredentials basicAuthCredentials,
                           @JsonProperty("bodyPatterns") List<StringValuePattern> bodyPatterns,
-                          @JsonProperty("customMatcher") CustomMatcherDefinition customMatcherDefinition) {
+                          @JsonProperty("customMatcher") CustomMatcherDefinition customMatcherDefinition,
+                          @JsonProperty("bodyFileName") String bodyFileName) {
 
         this(
             UrlPattern.fromOneOf(url, urlPattern, urlPath, urlPathPattern),
@@ -114,17 +118,18 @@ public class RequestPattern implements ValueMatcher<Request> {
             cookies,
             basicAuthCredentials,
             bodyPatterns,
-            customMatcherDefinition
+            customMatcherDefinition,
+            bodyFileName
         );
     }
 
     public RequestPattern(RequestMatcher customMatcher) {
-        this(null, null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null, null);
         this.matcher = customMatcher;
     }
 
     public RequestPattern(CustomMatcherDefinition customMatcherDefinition) {
-        this(null, null, null, null, null, null, null, customMatcherDefinition);
+        this(null, null, null, null, null, null, null, customMatcherDefinition, null);
     }
 
     @Override
@@ -283,6 +288,14 @@ public class RequestPattern implements ValueMatcher<Request> {
         return customMatcherDefinition;
     }
 
+    public String getBodyFileName() {
+        return bodyFileName;
+    }
+
+    public void setBodyFileName(String bodyFileName) {
+        this.bodyFileName = bodyFileName;
+    }
+
     @Override
     public String getName() {
         return "requestMatching";
@@ -309,12 +322,13 @@ public class RequestPattern implements ValueMatcher<Request> {
             Objects.equal(cookies, that.cookies) &&
             Objects.equal(basicAuthCredentials, that.basicAuthCredentials) &&
             Objects.equal(bodyPatterns, that.bodyPatterns) &&
-            Objects.equal(customMatcherDefinition, that.customMatcherDefinition);
+            Objects.equal(customMatcherDefinition, that.customMatcherDefinition) &&
+            Objects.equal(bodyFileName, that.bodyFileName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(url, method, headers, queryParams, cookies, basicAuthCredentials, bodyPatterns, customMatcherDefinition, matcher, defaultMatcher);
+        return Objects.hashCode(url, method, headers, queryParams, cookies, basicAuthCredentials, bodyPatterns, customMatcherDefinition, matcher, defaultMatcher, bodyFileName);
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -126,6 +126,7 @@ public class RequestPatternBuilder {
                     cookies.isEmpty() ? null : cookies,
                     basicCredentials,
                     bodyPatterns.isEmpty() ? null : bodyPatterns,
+                    null,
                     null
                 );
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -79,6 +79,7 @@ public class CommandLineOptions implements Options {
     private static final String JETTY_HEADER_BUFFER_SIZE = "jetty-header-buffer-size";
     private static final String ROOT_DIR = "root-dir";
     private static final String CONTAINER_THREADS = "container-threads";
+	private static final String RECORD_REQUEST_BODY = "record-request-body";
 
     private final OptionSet optionSet;
 	private String helpText;
@@ -97,7 +98,8 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
-		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
+	    optionParser.accepts(RECORD_REQUEST_BODY, "Save request body to mapping files also");
+		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files").requiredIf(RECORD_REQUEST_BODY);
 		optionParser.accepts(MATCH_HEADERS, "Enable request header matching when recording through a proxy").withRequiredArg();
 		optionParser.accepts(ROOT_DIR, "Specifies path for storing recordings (parent for " + WireMockServer.MAPPINGS_ROOT + " and " + WireMockServer.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
 		optionParser.accepts(VERBOSE, "Enable verbose logging to stdout");
@@ -109,7 +111,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(JETTY_ACCEPT_QUEUE_SIZE, "The size of Jetty's accept queue size").withRequiredArg();
         optionParser.accepts(JETTY_HEADER_BUFFER_SIZE, "The size of Jetty's buffer for request headers").withRequiredArg();
         optionParser.accepts(HELP, "Print this message");
-		
+
 		optionSet = optionParser.parse(args);
         validate();
 		captureHelpTextIfRequested(optionParser);
@@ -144,6 +146,10 @@ public class CommandLineOptions implements Options {
 	
 	public boolean recordMappingsEnabled() {
 		return optionSet.has(RECORD_MAPPINGS);
+	}
+
+	public boolean recordRequestBodyEnabled() {
+		return optionSet.has(RECORD_REQUEST_BODY);
 	}
 	
 	@Override
@@ -343,6 +349,10 @@ public class CommandLineOptions implements Options {
             builder.put(RECORD_MAPPINGS, recordMappingsEnabled())
                     .put(MATCH_HEADERS, matchingHeaders());
         }
+
+	    if (recordRequestBodyEnabled()) {
+		    builder.put(RECORD_REQUEST_BODY, recordRequestBodyEnabled());
+	    }
 
         builder.put(DISABLE_REQUEST_JOURNAL, requestJournalDisabled())
                .put(VERBOSE, verboseLoggingEnabled());

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -79,7 +79,7 @@ public class CommandLineOptions implements Options {
     private static final String JETTY_HEADER_BUFFER_SIZE = "jetty-header-buffer-size";
     private static final String ROOT_DIR = "root-dir";
     private static final String CONTAINER_THREADS = "container-threads";
-	private static final String RECORD_REQUEST_BODY = "record-request-body";
+	private static final String RECORD_MAPPINGS_EXTRA = "record-mappings-extra";
 
     private final OptionSet optionSet;
 	private String helpText;
@@ -98,8 +98,8 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
-	    optionParser.accepts(RECORD_REQUEST_BODY, "Save request body to mapping files also");
-		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files").requiredIf(RECORD_REQUEST_BODY);
+	    optionParser.accepts(RECORD_MAPPINGS_EXTRA, "Save extra information to mapping files about request and response");
+		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files").requiredIf(RECORD_MAPPINGS_EXTRA);
 		optionParser.accepts(MATCH_HEADERS, "Enable request header matching when recording through a proxy").withRequiredArg();
 		optionParser.accepts(ROOT_DIR, "Specifies path for storing recordings (parent for " + WireMockServer.MAPPINGS_ROOT + " and " + WireMockServer.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
 		optionParser.accepts(VERBOSE, "Enable verbose logging to stdout");
@@ -148,8 +148,8 @@ public class CommandLineOptions implements Options {
 		return optionSet.has(RECORD_MAPPINGS);
 	}
 
-	public boolean recordRequestBodyEnabled() {
-		return optionSet.has(RECORD_REQUEST_BODY);
+	public boolean recordMappingsExtraEnabled() {
+		return optionSet.has(RECORD_MAPPINGS_EXTRA);
 	}
 	
 	@Override
@@ -350,8 +350,8 @@ public class CommandLineOptions implements Options {
                     .put(MATCH_HEADERS, matchingHeaders());
         }
 
-	    if (recordRequestBodyEnabled()) {
-		    builder.put(RECORD_REQUEST_BODY, recordRequestBodyEnabled());
+	    if (recordMappingsExtraEnabled()) {
+		    builder.put(RECORD_MAPPINGS_EXTRA, recordMappingsExtraEnabled());
 	    }
 
         builder.put(DISABLE_REQUEST_JOURNAL, requestJournalDisabled())

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -65,7 +65,7 @@ public class WireMockServerRunner {
         wireMockServer = new WireMockServer(options);
 
         if (options.recordMappingsEnabled()) {
-            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource);
+            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource, options.recordRequestBodyEnabled());
         }
 
 		if (options.specifiesProxyUrl()) {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -65,7 +65,7 @@ public class WireMockServerRunner {
         wireMockServer = new WireMockServer(options);
 
         if (options.recordMappingsEnabled()) {
-            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource, options.recordRequestBodyEnabled());
+            wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource, options.recordMappingsExtraEnabled());
         }
 
 		if (options.specifiesProxyUrl()) {

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -42,11 +42,14 @@ public class StubMappingJsonRecorder implements RequestListener {
     private final Admin admin;
     private final List<CaseInsensitiveKey> headersToMatch;
     private IdGenerator idGenerator;
+    private boolean recordRequestBody;
 
-    public StubMappingJsonRecorder(FileSource mappingsFileSource, FileSource filesFileSource, Admin admin, List<CaseInsensitiveKey> headersToMatch) {
+    public StubMappingJsonRecorder(FileSource mappingsFileSource, FileSource filesFileSource, Admin admin, List<CaseInsensitiveKey> headersToMatch, boolean recordRequestBody) {
         this.mappingsFileSource = mappingsFileSource;
         this.filesFileSource = filesFileSource;
         this.admin = admin;
+        // TODO SDV: Use it!
+        this.recordRequestBody = recordRequestBody;
         this.headersToMatch = headersToMatch;
         idGenerator = new VeryShortIdGenerator();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -124,7 +124,7 @@ public class StubMappingJsonRecorder implements RequestListener {
                             request.getUrl(),
                             response.getHeaders().getContentTypeHeader(),
                             body));
-            requestPattern.setBodyFileName(requestBodyFileName);
+            requestPattern.setExtraBodyFileName(requestBodyFileName);
             byte[] requestBody = bodyDecompressedIfRequired(request);
             filesFileSource.writeBinaryFile(requestBodyFileName, requestBody);
         }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -55,7 +55,7 @@ public class WireMockServerTests {
     public void supportsRecordingProgrammaticallyWithoutHeaderMatching() {
         WireMockServer wireMockServer = new WireMockServer(Options.DYNAMIC_PORT, new SingleRootFileSource(tempDir.getRoot()), false, new ProxySettings("proxy.company.com", Options.DYNAMIC_PORT));
         wireMockServer.start();
-        wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir.getRoot() + "/mappings"), new SingleRootFileSource(tempDir.getRoot() + "/__files"));
+        wireMockServer.enableRecordMappings(new SingleRootFileSource(tempDir.getRoot() + "/mappings"), new SingleRootFileSource(tempDir.getRoot() + "/__files"), false);
         wireMockServer.stubFor(get(urlEqualTo("/something")).willReturn(aResponse().withStatus(200)));
 
         WireMockTestClient client = new WireMockTestClient(wireMockServer.port());

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -59,9 +59,9 @@ public class CommandLineOptionsTest {
 	}
 
 	@Test
-	public void returnsRecordRequestBodyTrueWhenOptionPresent() {
-		CommandLineOptions options = new CommandLineOptions("--record-mappings", "--record-request-body");
-		assertThat(options.recordRequestBodyEnabled(), is(true));
+	public void returnsRecordMappingsExtraTrueWhenOptionPresent() {
+		CommandLineOptions options = new CommandLineOptions("--record-mappings", "--record-mappings-extra");
+		assertThat(options.recordMappingsExtraEnabled(), is(true));
 	}
 
     @Test
@@ -78,9 +78,9 @@ public class CommandLineOptionsTest {
 	}
 
 	@Test
-	public void returnsRecordRequestBodyFalseWhenOptionNotPresent() {
+	public void returnsRecordMappingsExtraFalseWhenOptionNotPresent() {
 		CommandLineOptions options = new CommandLineOptions("");
-		assertThat(options.recordRequestBodyEnabled(), is(false));
+		assertThat(options.recordMappingsExtraEnabled(), is(false));
 	}
 
 	@Test
@@ -134,8 +134,8 @@ public class CommandLineOptionsTest {
     }
 
 	@Test(expected=Exception.class)
-	public void throwsExceptionIfRecordRequestBodyEnabledWithoutRecordingOption() {
-		new CommandLineOptions("--record-request-body");
+	public void throwsExceptionIfRecordMappigsExtraEnabledWithoutRecordingOption() {
+		new CommandLineOptions("--record-mappings-extra");
 	}
 
 	@Test(expected=Exception.class)
@@ -178,7 +178,7 @@ public class CommandLineOptionsTest {
 		CommandLineOptions options = new CommandLineOptions("--verbose", "--record-mappings", "--port", "8088", "--proxy-all", "http://somewhere.com");
 		assertThat(options.verboseLoggingEnabled(), is(true));
 		assertThat(options.recordMappingsEnabled(), is(true));
-		assertThat(options.recordRequestBodyEnabled(), is(false));
+		assertThat(options.recordMappingsExtraEnabled(), is(false));
 		assertThat(options.portNumber(), is(8088));
 		assertThat(options.specifiesProxyUrl(), is(true));
 		assertThat(options.proxyUrl(), is("http://somewhere.com"));
@@ -186,10 +186,10 @@ public class CommandLineOptionsTest {
 
 	@Test
 	public void setsAllPlusRequestBodyRecording() {
-		CommandLineOptions options = new CommandLineOptions("--verbose", "--record-mappings", "--port", "8088", "--proxy-all", "http://somewhere.com", "--record-request-body");
+		CommandLineOptions options = new CommandLineOptions("--verbose", "--record-mappings", "--port", "8088", "--proxy-all", "http://somewhere.com", "--record-mappings-extra");
 		assertThat(options.verboseLoggingEnabled(), is(true));
 		assertThat(options.recordMappingsEnabled(), is(true));
-		assertThat(options.recordRequestBodyEnabled(), is(true));
+		assertThat(options.recordMappingsExtraEnabled(), is(true));
 		assertThat(options.portNumber(), is(8088));
 		assertThat(options.specifiesProxyUrl(), is(true));
 		assertThat(options.proxyUrl(), is("http://somewhere.com"));

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -57,7 +57,13 @@ public class CommandLineOptionsTest {
 		CommandLineOptions options = new CommandLineOptions("--record-mappings");
 		assertThat(options.recordMappingsEnabled(), is(true));
 	}
-	
+
+	@Test
+	public void returnsRecordRequestBodyTrueWhenOptionPresent() {
+		CommandLineOptions options = new CommandLineOptions("--record-mappings", "--record-request-body");
+		assertThat(options.recordRequestBodyEnabled(), is(true));
+	}
+
     @Test
     public void returnsHeaderMatchingEnabledWhenOptionPresent() {
     	CommandLineOptions options =  new CommandLineOptions("--match-headers", "Accept,Content-Type");
@@ -70,7 +76,13 @@ public class CommandLineOptionsTest {
 		CommandLineOptions options = new CommandLineOptions("");
 		assertThat(options.recordMappingsEnabled(), is(false));
 	}
-	
+
+	@Test
+	public void returnsRecordRequestBodyFalseWhenOptionNotPresent() {
+		CommandLineOptions options = new CommandLineOptions("");
+		assertThat(options.recordRequestBodyEnabled(), is(false));
+	}
+
 	@Test
      public void setsPortNumberWhenOptionPresent() {
         CommandLineOptions options = new CommandLineOptions("--port", "8086");
@@ -120,7 +132,12 @@ public class CommandLineOptionsTest {
     public void throwsExceptionIfKeyStoreSpecifiedWithoutHttpsPort() {
         new CommandLineOptions("--https-keystore", "/my/keystore");
     }
-	
+
+	@Test(expected=Exception.class)
+	public void throwsExceptionIfRecordRequestBodyEnabledWithoutRecordingOption() {
+		new CommandLineOptions("--record-request-body");
+	}
+
 	@Test(expected=Exception.class)
 	public void throwsExceptionWhenPortNumberSpecifiedWithoutNumber() {
 		new CommandLineOptions("--port");
@@ -161,11 +178,23 @@ public class CommandLineOptionsTest {
 		CommandLineOptions options = new CommandLineOptions("--verbose", "--record-mappings", "--port", "8088", "--proxy-all", "http://somewhere.com");
 		assertThat(options.verboseLoggingEnabled(), is(true));
 		assertThat(options.recordMappingsEnabled(), is(true));
+		assertThat(options.recordRequestBodyEnabled(), is(false));
 		assertThat(options.portNumber(), is(8088));
 		assertThat(options.specifiesProxyUrl(), is(true));
 		assertThat(options.proxyUrl(), is("http://somewhere.com"));
 	}
-	
+
+	@Test
+	public void setsAllPlusRequestBodyRecording() {
+		CommandLineOptions options = new CommandLineOptions("--verbose", "--record-mappings", "--port", "8088", "--proxy-all", "http://somewhere.com", "--record-request-body");
+		assertThat(options.verboseLoggingEnabled(), is(true));
+		assertThat(options.recordMappingsEnabled(), is(true));
+		assertThat(options.recordRequestBodyEnabled(), is(true));
+		assertThat(options.portNumber(), is(8088));
+		assertThat(options.specifiesProxyUrl(), is(true));
+		assertThat(options.proxyUrl(), is("http://somewhere.com"));
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void returnsHelpText() {

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -70,7 +70,8 @@ public class StubMappingJsonRecorderTest {
 	}
 
     private void constructRecordingListener(List<String> headersToRecord) {
-        listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS));
+	    // TODO SDV: Create test for request body record enabled
+        listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS), false);
         listener.setIdGenerator(fixedIdGenerator("1$2!3"));
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -70,7 +70,6 @@ public class StubMappingJsonRecorderTest {
 	}
 
     private void constructRecordingListener(List<String> headersToRecord, boolean recordMappingsExtra) {
-	    // TODO SDV: Create test for request body record enabled
         listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS), recordMappingsExtra);
         listener.setIdGenerator(fixedIdGenerator("1$2!3"));
     }
@@ -86,7 +85,7 @@ public class StubMappingJsonRecorderTest {
 		"		\"bodyFileName\": \"body-recorded-content-1$2!3.txt\"    \n" +
 		"	}												             \n" +
 		"}													               ";
-	
+
 	@Test
 	public void writesMappingFileAndCorrespondingBodyFileOnRequest() {
 		context.checking(new Expectations() {{
@@ -110,7 +109,7 @@ public class StubMappingJsonRecorderTest {
 
 		listener.requestReceived(request, response);
 	}
-	
+
 	private static final String SAMPLE_REQUEST_MAPPING_WITH_HEADERS =
         "{                                                                  \n" +
         "   \"request\": {                                                  \n" +
@@ -152,7 +151,60 @@ public class StubMappingJsonRecorderTest {
 
         listener.requestReceived(request, response);
 	}
-	
+
+	private static final String SAMPLE_REQUEST_MAPPING_WITH_EXTRA =
+			"{                                                                              \n" +
+					"  \"request\" : {                                                      \n" +
+					"    \"url\" : \"/extra/content/on/request/body/\",                     \n" +
+					"    \"method\" : \"POST\",                                             \n" +
+					"    \"bodyPatterns\" : [                                               \n" +
+					"      {                                                                \n" +
+					"        \"equalToJson\" : \"{\\\"dummy\\\" : \\\"nothing\\\"}\",       \n" +
+					"        \"ignoreArrayOrder\" : true,                                   \n" +
+					"        \"ignoreExtraElements\" : true                                 \n" +
+					"      }                                                                \n" +
+					"    ],                                                                 \n" +
+					"    \"extraBodyFileName\" : \"requestbody-request-body-1$2!3.txt\"     \n" +
+					"  },                                                                   \n" +
+					"  \"response\" : {                                                     \n" +
+					"    \"status\" : 200,                                                  \n" +
+					"    \"bodyFileName\" : \"body-request-body-1$2!3.txt\"                 \n" +
+					"  }                                                                    \n" +
+					"}";
+	private static final String SAMPLE_REQUEST_BODY_FOR_MAPPING_WITH_EXTRA = "{\"dummy\" : \"nothing\"}";
+
+
+	@Test
+	public void writesExtendedRequestInformation() {
+		constructRecordingListener(Collections.<String>emptyList(), true);
+
+		context.checking(new Expectations() {{
+			allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
+			one(mappingsFileSource).writeTextFile(with(equal("mapping-request-body-1$2!3.json")),
+					with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_EXTRA, STRICT_ORDER)));
+			one(filesFileSource).writeBinaryFile(with(equal("requestbody-request-body-1$2!3.txt")),
+					with(equal(SAMPLE_REQUEST_BODY_FOR_MAPPING_WITH_EXTRA.getBytes(UTF_8))));
+			one(filesFileSource).writeBinaryFile(with(equal("body-request-body-1$2!3.txt")),
+					with(equal("Response body content sample".getBytes(UTF_8))));
+			ignoring(filesFileSource);
+		}});
+
+		Request request = new MockRequestBuilder(context, "MockRequestExtendedInfo")
+				.withMethod(POST)
+				.withUrl("/extra/content/on/request/body/")
+				.withHeader("Content-Type", "application/json ")
+				.withBody(SAMPLE_REQUEST_BODY_FOR_MAPPING_WITH_EXTRA)
+				.build();
+
+		Response response = response()
+				.status(200)
+				.fromProxy(true)
+				.body("Response body content sample")
+				.build();
+
+		listener.requestReceived(request, response);
+	}
+
 	@Test
 	public void doesNotWriteFileIfRequestAlreadyReceived() {
 	    context.checking(new Expectations() {{

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -66,12 +66,12 @@ public class StubMappingJsonRecorderTest {
 		filesFileSource = context.mock(FileSource.class, "filesFileSource");
         admin = context.mock(Admin.class);
 
-        constructRecordingListener(Collections.<String>emptyList());
+        constructRecordingListener(Collections.<String>emptyList(), false);
 	}
 
-    private void constructRecordingListener(List<String> headersToRecord) {
+    private void constructRecordingListener(List<String> headersToRecord, boolean recordMappingsExtra) {
 	    // TODO SDV: Create test for request body record enabled
-        listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS), false);
+        listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS), recordMappingsExtra);
         listener.setIdGenerator(fixedIdGenerator("1$2!3"));
     }
 
@@ -260,7 +260,7 @@ public class StubMappingJsonRecorderTest {
     
     @Test
     public void includesHeadersInRequestPatternIfHeaderMatchingEnabled() {
-        constructRecordingListener(MATCHING_REQUEST_HEADERS);
+        constructRecordingListener(MATCHING_REQUEST_HEADERS, false);
 
         context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));


### PR DESCRIPTION
BUSINESS CASE

Wiremock intended to be used as a tool to analyze request/response exchange between different parts of application.
For this we need additional information about request, like request body AS IS.

WHY THIS IS NEW FEATURE

Currently we are writing request body patterns only

IMPLEMENTATION DETAILS

New option added to trigger extra information recording.
Tests are added