### PR TITLE
Xpath matcher fix

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -38,6 +38,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class MatchesXPathPattern extends StringValuePattern {
 
+    private final static  Pattern xmlPattern = Pattern.compile("<(\\S+?)(.*?)>(.*?)</\\1>",
+                                                            Pattern.CASE_INSENSITIVE | Pattern.DOTALL );
     private final Map<String, String> xpathNamespaces;
 
     public MatchesXPathPattern(@JsonProperty("matchesXPath") String expectedValue,
@@ -99,9 +101,8 @@ public class MatchesXPathPattern extends StringValuePattern {
         if (value == null || value.trim().isEmpty() || !value.trim().startsWith("<")) {
             return false;
         }
-        Pattern pattern = Pattern.compile("<(\\S+?)(.*?)>(.*?)</\\1>",
-                                          Pattern.CASE_INSENSITIVE | Pattern.DOTALL );
-        Matcher matcher = pattern.matcher(value);
+
+        Matcher matcher = xmlPattern.matcher(value);
         return matcher.matches();
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -30,6 +30,8 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -67,7 +69,7 @@ public class MatchesXPathPattern extends StringValuePattern {
     }
 
     private boolean isXPathMatch(String value) {
-        if (value == null) {
+        if (!isXml(value)) {
             return false;
         }
 
@@ -91,5 +93,15 @@ public class MatchesXPathPattern extends StringValuePattern {
             notifier().info("Warning: failed to evaluate the XPath expression " + expectedValue);
             return false;
         }
+    }
+
+    private boolean isXml(String value) {
+        if (value == null || value.trim().isEmpty() || !value.trim().startsWith("<")) {
+            return false;
+        }
+        Pattern pattern = Pattern.compile("<(\\S+?)(.*?)>(.*?)</\\1>",
+                                          Pattern.CASE_INSENSITIVE | Pattern.DOTALL );
+        Matcher matcher = pattern.matcher(value);
+        return matcher.matches();
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -98,7 +98,7 @@ public class MatchesXPathPattern extends StringValuePattern {
     }
 
     private boolean isXml(String value) {
-        if (value == null || value.trim().isEmpty() || !value.trim().startsWith("<")) {
+        if (value == null) {
             return false;
         }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -75,9 +75,20 @@ public class MatchesXPathPatternTest {
 
     @Test
     public void returnsNoExactMatchWhenXmlIsBadlyFormed() {
-        String mySolarSystemXML = "solar-system>"
+        String mySolarSystemXML = "<solar-system>"
             + "<planet name='Earth' position='3' supportsLife='yes'/>"
-            + "<planet name='Venus' position='4'/></solar-system>";
+            + "<planet name='Venus' position='4></solar-system>";
+
+        StringValuePattern pattern = WireMock.matchingXPath("//star[@name='Venus']");
+
+        MatchResult match = pattern.match(mySolarSystemXML);
+        assertFalse("Expected XPath non-match", match.isExactMatch());
+        assertThat(match.getDistance(), is(1.0));
+    }
+
+    @Test
+    public void returnsNoExactMatchForNonXml() {
+        String mySolarSystemXML = "asd";
 
         StringValuePattern pattern = WireMock.matchingXPath("//star[@name='alpha centauri']");
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPatternTest.java
@@ -48,6 +48,20 @@ public class MatchesXPathPatternTest {
     }
 
     @Test
+    public void returnsExactMatchWhenXPathMatchesForMultilineXml() {
+        String mySolarSystemXML = "<solar-system>\n"
+                + "<planet name='Earth' position='3' supportsLife='yes'/>"
+                + "<planet name='Venus' position='4'/></solar-system>";
+
+
+        StringValuePattern pattern = WireMock.matchingXPath("//planet[@name='Earth']");
+
+        MatchResult match = pattern.match(mySolarSystemXML);
+        assertTrue("Expected XPath match", match.isExactMatch());
+        assertThat(match.getDistance(), is(0.0));
+    }
+
+    @Test
     public void returnsNoExactMatchWhenXPathDoesNotMatch() {
         String mySolarSystemXML = "<solar-system>"
             + "<planet name='Earth' position='3' supportsLife='yes'/>"
@@ -88,7 +102,9 @@ public class MatchesXPathPatternTest {
 
     @Test
     public void returnsNoExactMatchForNonXml() {
-        String mySolarSystemXML = "asd";
+        String mySolarSystemXML = "asd<solar-system>\n" +
+                "<planet name='Earth' position='3' supportsLife='yes'/>" +
+                "<planet name='Venus' position='4></solar-system>";
 
         StringValuePattern pattern = WireMock.matchingXPath("//star[@name='alpha centauri']");
 


### PR DESCRIPTION
We have faced nasty issue after updating from Wiremock 1.57 to 2.x. In case there're mock mappings that has only xpath pattern and wiremock gets request with non-xml body (even for get request I think), it will generate a log record:
_[Fatal Error] :1:1: Content is not allowed in prolog._
for each xpath matching attempt.

So, lets say we have 30 mocks waiting for xpath and 5 waiting for some json, in case wiremock gets json body, it will write _[Fatal Error] :1:1: Content is not allowed in prolog._ 30 times. In our environment it produces lots of log garbage and impacts performance.

The message itself comes from attempt to build Document from non-xml thing, so I am suggesting to check with simple regexp if request body at least looks like xml.

There's a possible (although hackish) workaround to check for content-type first, but I though it would be great if we could move without it.
