### PR TITLE
adding silent error handler to DocumentBuilder to suppress Fatal Error Logging

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/SilentErrorHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/SilentErrorHandler.java
@@ -1,0 +1,22 @@
+package com.github.tomakehurst.wiremock.common;
+
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+public class SilentErrorHandler implements ErrorHandler {
+    @Override
+    public void warning(final SAXParseException exception) throws SAXException {
+        throw exception;
+    }
+
+    @Override
+    public void error(final SAXParseException exception) throws SAXException {
+        throw exception;
+    }
+
+    @Override
+    public void fatalError(final SAXParseException exception) throws SAXException {
+        throw exception;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock.matching;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tomakehurst.wiremock.common.SilentErrorHandler;
 import com.google.common.collect.ImmutableMap;
 import org.custommonkey.xmlunit.NamespaceContext;
 import org.custommonkey.xmlunit.SimpleNamespaceContext;
@@ -27,7 +28,9 @@ import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
+import javax.xml.parsers.DocumentBuilder;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Collections;
 import java.util.Map;
 
@@ -72,7 +75,9 @@ public class MatchesXPathPattern extends StringValuePattern {
         }
 
         try {
-            Document inDocument = XMLUnit.buildControlDocument(value);
+            DocumentBuilder documentBuilder = XMLUnit.newControlParser();
+            documentBuilder.setErrorHandler(new SilentErrorHandler());
+            Document inDocument = XMLUnit.buildDocument(documentBuilder, new StringReader(value));
             XpathEngine simpleXpathEngine = XMLUnit.newXpathEngine();
             if (xpathNamespaces != null) {
                 NamespaceContext namespaceContext = new SimpleNamespaceContext(xpathNamespaces);


### PR DESCRIPTION
adding silent error handler to DocumentBuilder to suppress Fatal Error Logging occurring on attempt to evaluate XPath on non XML string