### PR TITLE
When running the build from command line (not IntelliJ) it was failin…

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/NearMissesRuleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NearMissesRuleAcceptanceTest.java
@@ -58,8 +58,8 @@ public class NearMissesRuleAcceptanceTest {
         @Rule
         public ExpectedException thrown = ExpectedException.none();
 
-        @ClassRule
-        public static WireMockRule wm = new WireMockRule(options()
+        @Rule
+        public WireMockRule wm = new WireMockRule(options()
             .dynamicPort()
             .notifier(testNotifier)
             .withRootDirectory("src/main/resources/empty"),
@@ -149,8 +149,8 @@ public class NearMissesRuleAcceptanceTest {
 
     public static class CustomMatcherWithNearMissesTest {
 
-        @ClassRule
-        public static WireMockRule wm = new WireMockRule(options()
+        @Rule
+        public WireMockRule wm = new WireMockRule(options()
             .dynamicPort()
             .withRootDirectory("src/main/resources/empty")
             .extensions(new RequestMatcherExtension() {


### PR DESCRIPTION
…g complaining it has found 4 not 1 near misses in successfullyCalculatesNearMissesWhenACustomMatcherIsRegistered