### PR TITLE
Add the shutdown function to the docs (#545)

### DIFF
--- a/src/main/resources/raml/wiremock-admin-api.raml
+++ b/src/main/resources/raml/wiremock-admin-api.raml
@@ -294,3 +294,11 @@ schemas:
     responses:
       200:
         description: Settings successfully updated
+
+/__admin/shutdown:
+  description: Shutdown function
+  post:
+    description: Shutdown the WireMock server
+    responses:
+      200:
+        description: Server will be shut down


### PR DESCRIPTION
This is a suggested change to the RAML file to document the shutdown command. I am familiar with Swagger, but not RAML unfortunately, so this is untested guesswork! Happy to tweak, or feel free to use this as a base for more changes before merging.
