### PR TITLE
When the XML DTD points to an unknown hostname then XMLUnit will get …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
         "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
         "com.fasterxml.jackson.core:jackson-databind:$versions.jackson"
     compile "org.apache.httpcomponents:httpclient:4.5.1"
-    compile 'org.xmlunit:xmlunit-core:2.1.1'
-    compile 'org.xmlunit:xmlunit-legacy:2.1.1'
+    compile 'org.xmlunit:xmlunit-core:2.3.0'
+    compile 'org.xmlunit:xmlunit-legacy:2.3.0'
     compile "com.jayway.jsonpath:json-path:2.2.0"
     compile "org.slf4j:slf4j-api:1.7.12"
     compile "net.sf.jopt-simple:jopt-simple:4.9"

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -275,6 +275,13 @@ public class EqualToXmlPatternTest {
         WireMock.equalToXml("badly-formed >").match("<well-formed />").isExactMatch();
     }
 
+    @Test
+    public void doesNotFetchDtdBecauseItCouldResultInAFailedMatch() throws Exception {
+        String xmlWithDtdThatCannotBeFetched = "<!DOCTYPE my_request SYSTEM \"https://thishostname.doesnotexist.com/one.dtd\"><do_request/>";
+        EqualToXmlPattern pattern = new EqualToXmlPattern(xmlWithDtdThatCannotBeFetched);
+        assertTrue(pattern.match(xmlWithDtdThatCannotBeFetched).isExactMatch());
+    }
+
     private void expectInfoNotification(final String message) {
         final Notifier notifier = context.mock(Notifier.class);
         context.checking(new Expectations() {{


### PR DESCRIPTION
…an UnknownHostException which results in a failed match. A fix for this was to disable fetching DTDs.

Let me know what you think.