### PR TITLE
documenting existing behaviour when Content-Length or Transfer-Encodi…

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
@@ -126,7 +126,47 @@ public class MappingsAcceptanceTest extends AcceptanceTestBase {
 		assertThat(response.statusCode(), is(200));
 		assertThat(response.content(), is("{\"key\":\"value\",\"array\":[1,2,3]}"));
 	}
-	
+
+    @Test
+    public void appendsTransferEncodingHeaderIfNoContentLengthHeaderIsPresentInMapping() throws Exception {
+        testClient.addResponse(
+                "{ 													\n" +
+                        "	\"request\": {									\n" +
+                        "		\"method\": \"GET\",						\n" +
+                        "		\"url\": \"/with/body\"						\n" +
+                        "	},												\n" +
+                        "	\"response\": {									\n" +
+                        "		\"status\": 200,							\n" +
+                        "		\"body\": \"Some content\"					\n" +
+                        "	}												\n" +
+                        "}													");
+
+        WireMockResponse response = testClient.get("/with/body");
+
+        assertThat(response.firstHeader("Transfer-Encoding"), is("chunked"));
+    }
+
+    @Test
+    public void responseContainsContentLengthHeaderIfItIsDefinedInTheMapping() throws Exception {
+        testClient.addResponse(
+                "{ 													\n" +
+                        "	\"request\": {									\n" +
+                        "		\"method\": \"GET\",						\n" +
+                        "		\"url\": \"/with/body\"						\n" +
+                        "	},												\n" +
+                        "	\"response\": {									\n" +
+                        "		\"status\": 200,							\n" +
+                        "		\"headers\": {								\n" +
+                        "			\"Content-Length\": \"12\"		        \n" +
+                        "		},											\n" +
+                        "		\"body\": \"Some content\"					\n" +
+                        "	}												\n" +
+                        "}													");
+        WireMockResponse response = testClient.get("/with/body");
+
+        assertThat(response.firstHeader("Content-Length"), is("12"));
+    }
+
 	private void getResponseAndAssert200Status(String url) {
 		WireMockResponse response = testClient.get(url);
 		assertThat(response.statusCode(), is(200));


### PR DESCRIPTION
…ng will be returned

See https://github.com/tomakehurst/wiremock/issues/406 