### PR TITLE
added missing dependency "uri": "^0.1.0"

### DIFF
--- a/docs-v2/package.json
+++ b/docs-v2/package.json
@@ -29,7 +29,8 @@
     "onchange": "^2.2.0",
     "postcss-cli": "^2.5.1",
     "raml2html": "3.0.1",
-    "uglify-js": "^2.6.1"
+    "uglify-js": "^2.6.1",
+    "uri": "^0.1.0"
   },
   "scripts": {
     "scss": "node-sass --output-style compressed -o assets/css assets/_scss",


### PR DESCRIPTION
I found the uri package to be missing, when I attempted a local build.