### PR TITLE
Ensure persistent non-null notifier for each thread

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+/**
+ * ---------- Deployment to maven repository ----------
+ *
+ * publish -PsonatypeUser=<user> -PsonatypePassword=<password> -PsonatypeRepo=<repoUrl>
+ *
+ * For example:
+ * publish -PsonatypeUser=developer -PsonatypePassword=1234 -PsonatypeRepo=http://127.0.0.1:8081/repository/upstream/
+ *
+ */
+
 buildscript {
     repositories {
         maven {
@@ -162,6 +172,7 @@ shadowJar {
 }
 
 def releaseDirUrl
+def repoUrl
 def repoUser
 def repoPassword
 
@@ -217,6 +228,14 @@ task signStandaloneJarPom(type: Sign, dependsOn: 'generatePomFileForStandaloneJa
     sign new File(standaloneJarPomPath)
 }
 
+//TODO prevent credentials from leaking to default repo hosts
+
+if (!this.hasProperty('sonatypeRepo')) {
+    repoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+} else {
+    repoUrl = sonatypeRepo
+}
+
 if (!this.hasProperty('sonatypeUser')) {
     repoUser = 'default'
 } else {
@@ -258,10 +277,9 @@ final pomInfo = {
 publishing {
     repositories {
         maven {
-            URL localRepo = new File("${System.getProperty('user.home')}/.m2/repository").toURI().toURL()
-            URL repoUrl = shouldPublishLocally ? localRepo : URI.create('https://oss.sonatype.org/service/local/staging/deploy/maven2').toURL()
+            URL localRepoUrl = new File("${System.getProperty('user.home')}/.m2/repository").toURI().toURL()
 
-            url repoUrl
+            url = shouldPublishLocally ? localRepoUrl : repoUrl
 
             if (!shouldPublishLocally) {
                 credentials {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/BodyMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BodyMappingBuilder.java
@@ -1,0 +1,163 @@
+package com.github.tomakehurst.wiremock.client;
+
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.matching.BodyRequestPattern;
+import com.github.tomakehurst.wiremock.matching.BodyRequestPatternBuilder;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.FormFieldPattern;
+import com.github.tomakehurst.wiremock.matching.RequestMatcher;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Maps.newLinkedHashMap;
+
+public class BodyMappingBuilder implements ScenarioMappingBuilder {
+    private BodyRequestPatternBuilder requestPatternBuilder;
+    private ResponseDefinitionBuilder responseDefBuilder;
+    private Integer priority;
+    private String scenarioName;
+    private String requiredScenarioState;
+    private String newScenarioState;
+    private UUID id;
+    private boolean isPersistent = false;
+    private Map<String, Parameters> postServeActions = newLinkedHashMap();
+
+    BodyMappingBuilder(RequestMethod method, UrlPattern urlPattern) {
+        requestPatternBuilder = new BodyRequestPatternBuilder(method, urlPattern);
+    }
+
+    BodyMappingBuilder(RequestMatcher requestMatcher) {
+        requestPatternBuilder = new BodyRequestPatternBuilder(requestMatcher);
+    }
+
+    BodyMappingBuilder(String customRequestMatcherName, Parameters parameters) {
+        requestPatternBuilder = new BodyRequestPatternBuilder(customRequestMatcherName, parameters);
+    }
+
+    @Override
+    public BodyMappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder) {
+        this.responseDefBuilder = responseDefBuilder;
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder atPriority(Integer priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder withHeader(String key, StringValuePattern headerPattern) {
+        requestPatternBuilder.withHeader(key, headerPattern);
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder withCookie(String name, StringValuePattern cookieValuePattern) {
+        requestPatternBuilder.withCookie(name, cookieValuePattern);
+        return this;
+    }
+
+    @Override
+    public <P> ScenarioMappingBuilder withPostServeAction(String extensionName, P parameters) {
+        Parameters params = parameters instanceof Parameters ?
+                (Parameters) parameters :
+                Parameters.of(parameters);
+        postServeActions.put(extensionName, params);
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder withQueryParam(String key, StringValuePattern queryParamPattern) {
+        requestPatternBuilder.withQueryParam(key, queryParamPattern);
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder withRequestBody(StringValuePattern bodyPattern) {
+        requestPatternBuilder.withRequestBody(bodyPattern);
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder inScenario(String scenarioName) {
+        checkArgument(scenarioName != null, "Scenario name must not be null");
+
+        this.scenarioName = scenarioName;
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder whenScenarioStateIs(String stateName) {
+        this.requiredScenarioState = stateName;
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder willSetStateTo(String stateName) {
+        this.newScenarioState = stateName;
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder withId(UUID id) {
+        this.id = id;
+        return this;
+    }
+
+    @Override
+    public ScenarioMappingBuilder persistent() {
+        this.isPersistent = true;
+        return this;
+    }
+
+    @Override
+    public BodyMappingBuilder withBasicAuth(String username, String password) {
+        requestPatternBuilder.withBasicAuth(new BasicCredentials(username, password));
+        return this;
+    }
+
+    /**
+     * @see BodyRequestPattern
+     */
+    public BodyMappingBuilder withFormParam(StringValuePattern key, StringValuePattern value) {
+        requestPatternBuilder.withFormParam(new FormFieldPattern(key, value));
+        return this;
+    }
+
+    /**
+     * @see BodyRequestPattern
+     */
+    public BodyMappingBuilder withFormParam(String key, String value) {
+        requestPatternBuilder.withFormParam(new FormFieldPattern(new EqualToPattern(key), new EqualToPattern(value)));
+        return this;
+    }
+
+    @Override
+    public StubMapping build() {
+        if (scenarioName == null && (requiredScenarioState != null || newScenarioState != null)) {
+            throw new IllegalStateException("Scenario name must be specified to require or set a new scenario state");
+        }
+        BodyRequestPattern requestPattern = requestPatternBuilder.build();
+        ResponseDefinition response = responseDefBuilder.build();
+        StubMapping mapping = new StubMapping(requestPattern, response);
+        mapping.setPriority(priority);
+        mapping.setScenarioName(scenarioName);
+        mapping.setRequiredScenarioState(requiredScenarioState);
+        mapping.setNewScenarioState(newScenarioState);
+        mapping.setUuid(id);
+        mapping.setPersistent(isPersistent);
+
+        mapping.setPostServeActions(postServeActions.isEmpty() ? null : postServeActions);
+
+        return mapping;
+    }
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -404,6 +404,30 @@ public class WireMock {
 		return new BasicMappingBuilder(requestMatcher);
 	}
 
+
+
+	public static BodyMappingBuilder requestWithBody(RequestMethod requestMethod, UrlPattern urlPattern) {
+		return new BodyMappingBuilder(requestMethod, urlPattern);
+	}
+
+	public static BodyMappingBuilder postWithBody(UrlPattern urlPattern) {
+		return requestWithBody(RequestMethod.POST, urlPattern);
+	}
+
+	public static BodyMappingBuilder putWithBody(UrlPattern urlPattern) {
+		return requestWithBody(RequestMethod.PUT, urlPattern);
+	}
+
+	public static BodyMappingBuilder patchWithBody(UrlPattern urlPattern) {
+		return requestWithBody(RequestMethod.PATCH, urlPattern);
+	}
+
+	public static BodyMappingBuilder anyWithBody(UrlPattern urlPattern) {
+		return requestWithBody(RequestMethod.ANY, urlPattern);
+	}
+
+
+
 	public static ResponseDefinitionBuilder aResponse() {
 		return new ResponseDefinitionBuilder();
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/LocalNotifier.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/LocalNotifier.java
@@ -17,21 +17,23 @@ package com.github.tomakehurst.wiremock.common;
 
 public class LocalNotifier {
 
-	private static ThreadLocal<Notifier> notifierHolder = new ThreadLocal<Notifier>();
-	
-	public static Notifier notifier() {
-		Notifier notifier = notifierHolder.get();
-		if (notifier == null) {
-			notifier = new NullNotifier();
+	private static ThreadLocal<Notifier> notifierHolder = new ThreadLocal<Notifier>() {
+		@Override
+		protected Notifier initialValue() {
+			return new NullNotifier();
 		}
-		
-		return notifier;
+	};
+
+	public static Notifier notifier() {
+		return notifierHolder.get();
 	}
-	
+
 	public static void set(Notifier notifier) {
-		notifierHolder.set(notifier);
+        if (notifier == null)
+            notifier = new NullNotifier();
+        notifierHolder.set(notifier);
 	}
-	
+
 	private static class NullNotifier implements Notifier {
 
 		@Override
@@ -45,6 +47,6 @@ public class LocalNotifier {
 		@Override
 		public void error(String message, Throwable t) {
 		}
-		
+
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/BodyRequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/BodyRequestPattern.java
@@ -1,0 +1,154 @@
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tomakehurst.wiremock.client.BasicCredentials;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.google.common.base.Objects;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Matches requests containing form parameters in its body.
+ * As a precondition for any match, the request header <code>Content-Type=application/x-www-form-urlencoded</code> must be present.
+ * <br>
+ * Note: <code>Content-Type=multipart/form-data</code> is not yet supported.
+ */
+public class BodyRequestPattern extends RequestPattern {
+    private List<FormFieldPattern> formFieldPatterns;
+
+    public BodyRequestPattern(UrlPattern url,
+                              RequestMethod method,
+                              Map<String, MultiValuePattern> headers,
+                              Map<String, MultiValuePattern> queryParams,
+                              Map<String, StringValuePattern> cookies,
+                              BasicCredentials basicAuthCredentials,
+                              List<StringValuePattern> bodyPatterns,
+                              List<FormFieldPattern> formFieldPatterns,
+                              CustomMatcherDefinition customMatcherDefinition) {
+        super(url, method, headers, queryParams, cookies, basicAuthCredentials, bodyPatterns, customMatcherDefinition);
+        this.formFieldPatterns = formFieldPatterns;
+    }
+
+    public BodyRequestPattern(@JsonProperty("url") String url,
+                              @JsonProperty("urlPattern") String urlPattern,
+                              @JsonProperty("urlPath") String urlPath,
+                              @JsonProperty("urlPathPattern") String urlPathPattern,
+                              @JsonProperty("method") RequestMethod method,
+                              @JsonProperty("headers") Map<String, MultiValuePattern> headers,
+                              @JsonProperty("queryParameters") Map<String, MultiValuePattern> queryParams,
+                              @JsonProperty("cookies") Map<String, StringValuePattern> cookies,
+                              @JsonProperty("basicAuth") BasicCredentials basicAuthCredentials,
+                              @JsonProperty("bodyPatterns") List<StringValuePattern> bodyPatterns,
+                              @JsonProperty("formFieldPatterns") List<FormFieldPattern> formFieldPatterns,
+                              @JsonProperty("customMatcher") CustomMatcherDefinition customMatcherDefinition) {
+        super(url, urlPattern, urlPath, urlPathPattern, method, headers, queryParams, cookies, basicAuthCredentials, bodyPatterns, customMatcherDefinition);
+        this.formFieldPatterns = formFieldPatterns;
+    }
+
+    public BodyRequestPattern(RequestMatcher customMatcher) {
+        super(customMatcher);
+    }
+
+    public BodyRequestPattern(CustomMatcherDefinition customMatcherDefinition) {
+        super(customMatcherDefinition);
+    }
+
+    public List<FormFieldPattern> getFormFieldPatterns() {
+        return formFieldPatterns;
+    }
+
+    @Override
+    public MatchResult match(Request request) {
+        MatchResult matchResult = super.match(request);
+        if (matchResult.isExactMatch())
+            matchResult = match(request, this.formFieldPatterns);
+        return matchResult;
+    }
+
+    public MatchResult match(Request request, Map<String, RequestMatcherExtension> customMatchers) {
+        MatchResult matchResult = super.match(request, customMatchers);
+        if (matchResult.isExactMatch())
+            matchResult = match(request, this.formFieldPatterns);
+        return matchResult;
+    }
+
+    private static MatchResult match(Request request, List<FormFieldPattern> formFieldPatterns) {
+        if (formFieldPatterns != null) {
+            if (Objects.equal(request.getHeader("Content-Type"), "application/x-www-form-urlencoded")) {
+                Map<String, String> formFields = parseFormFields(request.getBodyAsString());
+
+                for (FormFieldPattern formFieldPattern : formFieldPatterns) {
+                    boolean match = false;
+                    if (formFieldPattern.getNamePattern() instanceof EqualToPattern) {
+                        //optimize for simple equality check
+                        String value = formFields.get(formFieldPattern.getNamePattern().getValue());
+                        if (formFieldPattern.getValuePattern().match(value).isExactMatch())
+                            match = true;
+                    } else {
+                        for (Map.Entry<String, String> formField : formFields.entrySet()) {
+                            if (formFieldPattern.getNamePattern().match(formField.getKey()).isExactMatch()
+                                    && formFieldPattern.getValuePattern().match(formField.getValue()).isExactMatch()) {
+                                match = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (!match)
+                        return MatchResult.of(false);
+                }
+                return MatchResult.of(true);
+            }
+        } else {
+            return MatchResult.of(true);
+        }
+        return MatchResult.of(false);
+    }
+
+    private static Pattern KEY_VALUE_PATTERN = Pattern.compile("([^=&]*)=([^&]*)(?:|&)");
+
+    static LinkedHashMap<String, String> parseFormFields(String input) {
+        LinkedHashMap<String, String> params = new LinkedHashMap<>();
+        Matcher matcher = KEY_VALUE_PATTERN.matcher(input);
+        while (matcher.find())
+            try {
+                params.put(URLDecoder.decode(matcher.group(1), "UTF-8"), URLDecoder.decode(matcher.group(2), "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalStateException(e);
+            }
+        return params;
+    }
+
+    static boolean containsPair(LinkedHashMap<String, String> formParams, String key, String value) {
+        if (key == null)
+            throw new NullPointerException();
+
+        String actualValue = formParams.get(key);
+        return Objects.equal(value, actualValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        BodyRequestPattern that = (BodyRequestPattern) o;
+
+        return formFieldPatterns != null ? formFieldPatterns.equals(that.formFieldPatterns) : that.formFieldPatterns == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (formFieldPatterns != null ? formFieldPatterns.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/BodyRequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/BodyRequestPatternBuilder.java
@@ -1,0 +1,122 @@
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.BasicCredentials;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newLinkedHashMap;
+
+public class BodyRequestPatternBuilder {
+
+    private UrlPattern url;
+    private RequestMethod method;
+    private Map<String, MultiValuePattern> headers = newLinkedHashMap();
+    private Map<String, MultiValuePattern> queryParams = newLinkedHashMap();
+    private List<StringValuePattern> bodyPatterns = newArrayList();
+    private List<FormFieldPattern> formFieldPatterns = newArrayList();
+    private Map<String, StringValuePattern> cookies = newLinkedHashMap();
+    private BasicCredentials basicCredentials;
+
+    private RequestMatcher customMatcher;
+
+    private CustomMatcherDefinition customMatcherDefinition;
+
+    public BodyRequestPatternBuilder() {
+    }
+
+    public BodyRequestPatternBuilder(RequestMatcher customMatcher) {
+        this.customMatcher = customMatcher;
+    }
+
+    public BodyRequestPatternBuilder(RequestMethod method, UrlPattern url) {
+        this.method = method;
+        this.url = url;
+    }
+
+    public BodyRequestPatternBuilder(String customRequestMatcherName, Parameters parameters) {
+        this.customMatcherDefinition = new CustomMatcherDefinition(customRequestMatcherName, parameters);
+    }
+
+    public static BodyRequestPatternBuilder newRequestPattern(RequestMethod method, UrlPattern url) {
+        return new BodyRequestPatternBuilder(method, url);
+    }
+
+    public static BodyRequestPatternBuilder newRequestPattern() {
+        return new BodyRequestPatternBuilder();
+    }
+
+    public static BodyRequestPatternBuilder forCustomMatcher(RequestMatcher requestMatcher) {
+        return new BodyRequestPatternBuilder(requestMatcher);
+    }
+
+    public static BodyRequestPatternBuilder forCustomMatcher(String customRequestMatcherName, Parameters parameters) {
+        return new BodyRequestPatternBuilder(customRequestMatcherName, parameters);
+    }
+
+    public static BodyRequestPatternBuilder allRequests() {
+        return new BodyRequestPatternBuilder(RequestMethod.ANY, WireMock.anyUrl());
+    }
+
+    public BodyRequestPatternBuilder withUrl(String url) {
+        this.url = WireMock.urlEqualTo(url);
+        return this;
+    }
+
+    public BodyRequestPatternBuilder withHeader(String key, StringValuePattern valuePattern) {
+        headers.put(key, MultiValuePattern.of(valuePattern));
+        return this;
+    }
+
+    public BodyRequestPatternBuilder withoutHeader(String key) {
+        headers.put(key, MultiValuePattern.absent());
+        return this;
+    }
+
+    public BodyRequestPatternBuilder withQueryParam(String key, StringValuePattern valuePattern) {
+        queryParams.put(key, MultiValuePattern.of(valuePattern));
+        return this;
+    }
+
+    public BodyRequestPatternBuilder withCookie(String key, StringValuePattern valuePattern) {
+        cookies.put(key, valuePattern);
+        return this;
+    }
+
+    public BodyRequestPatternBuilder withBasicAuth(BasicCredentials basicCredentials) {
+        this.basicCredentials = basicCredentials;
+        return this;
+    }
+
+    public BodyRequestPatternBuilder withRequestBody(StringValuePattern valuePattern) {
+        this.bodyPatterns.add(valuePattern);
+        return this;
+    }
+
+    public BodyRequestPatternBuilder withFormParam(FormFieldPattern formFieldPattern) {
+        this.formFieldPatterns.add(formFieldPattern);
+        return this;
+    }
+
+    public BodyRequestPattern build() {
+        return customMatcher != null ?
+                new BodyRequestPattern(customMatcher) :
+                customMatcherDefinition != null ?
+                        new BodyRequestPattern(customMatcherDefinition) :
+                        new BodyRequestPattern(
+                                url,
+                                method,
+                                headers.isEmpty() ? null : headers,
+                                queryParams.isEmpty() ? null : queryParams,
+                                cookies.isEmpty() ? null : cookies,
+                                basicCredentials,
+                                bodyPatterns.isEmpty() ? null : bodyPatterns,
+                                formFieldPatterns.isEmpty() ? null : formFieldPatterns,
+                                null
+                        );
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/FormFieldPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/FormFieldPattern.java
@@ -1,0 +1,24 @@
+package com.github.tomakehurst.wiremock.matching;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+
+public class FormFieldPattern {
+    private final StringValuePattern namePattern;
+    private final StringValuePattern valuePattern;
+
+    public FormFieldPattern(@JsonProperty("name") StringValuePattern namePattern, @JsonProperty("value") StringValuePattern valuePattern) {
+        this.namePattern = namePattern;
+        this.valuePattern = valuePattern;
+    }
+
+    @JsonProperty("name")
+    public StringValuePattern getNamePattern() {
+        return namePattern;
+    }
+
+    @JsonProperty("value")
+    public StringValuePattern getValuePattern() {
+        return valuePattern;
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/common/LocalNotifierTestCase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/LocalNotifierTestCase.java
@@ -1,0 +1,183 @@
+package com.github.tomakehurst.wiremock.common;
+
+import com.google.common.base.Throwables;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.*;
+
+/**
+ * A rather superfluous test case for thread local notifiers held by {@link LocalNotifier}
+ */
+public class LocalNotifierTestCase {
+    private static final int THREADS = 16;// number of threads to spawn for concurrent testig
+    private static final int EXECUTOR_TIMEOUT = 60000; //[ms]
+
+    @Test
+    public void testThreadLocalDefaultInstance() throws Exception {
+        runConcurrently(THREADS, EXECUTOR_TIMEOUT, new Runnable() {
+            final Set<Notifier> uniqueNotifiers = createConcurrentIdentitySet();
+
+            @Override
+            public void run() {
+                Notifier defaultNotifier1 = LocalNotifier.notifier();
+                Notifier defaultNotifier2 = LocalNotifier.notifier();
+
+                assertTrue(uniqueNotifiers.add(defaultNotifier1));
+
+                assertNotNull(defaultNotifier1);
+                assertSame(defaultNotifier1, defaultNotifier2);
+            }
+        });
+    }
+
+    @Test
+    public void testThreadLocalCustomInstance() throws Exception {
+        runConcurrently(THREADS, EXECUTOR_TIMEOUT, new Runnable() {
+            final Set<Notifier> uniqueNotifiers = createConcurrentIdentitySet();
+
+            @Override
+            public void run() {
+                final Notifier defaultNotifier = LocalNotifier.notifier();
+                assertTrue(uniqueNotifiers.add(defaultNotifier));
+
+                Notifier customNotifier = new Notifier() {
+                    @Override
+                    public void info(String message) {
+                    }
+
+                    @Override
+                    public void error(String message) {
+                    }
+
+                    @Override
+                    public void error(String message, Throwable t) {
+                    }
+                };
+
+                LocalNotifier.set(customNotifier);
+
+                Notifier notifier1 = LocalNotifier.notifier();
+                Notifier notifier2 = LocalNotifier.notifier();
+
+                assertSame(customNotifier, notifier1);
+                assertSame(notifier1, notifier2);
+
+                assertTrue(uniqueNotifiers.add(notifier1));
+            }
+        });
+    }
+
+    @Test
+    public void testThreadLocalNullReplacement() throws Exception {
+        runConcurrently(THREADS, EXECUTOR_TIMEOUT, new Runnable() {
+            final Set<Notifier> uniqueNotifiers = createConcurrentIdentitySet();
+
+            @Override
+            public void run() {
+                final Notifier defaultNotifier = LocalNotifier.notifier();
+                assertTrue(uniqueNotifiers.add(defaultNotifier));
+
+                LocalNotifier.set(null);
+
+                Notifier notifier1 = LocalNotifier.notifier();
+                assertNotNull(notifier1);
+                assertNotSame(notifier1, defaultNotifier);
+
+                Notifier notifier2 = LocalNotifier.notifier();
+                assertSame(notifier1, notifier2);
+
+                assertTrue(uniqueNotifiers.add(notifier1));
+            }
+        });
+    }
+
+    private static <T> Set<T> createConcurrentIdentitySet() {
+        return Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<T, Boolean>()));
+    }
+
+    /**
+     * Executes a single test runnable concurrently in an individual thread per execution.
+     * The calling thread is blocked until all test threads have terminated or an unexpected error occurs.
+     *
+     * @param runnable test implementation
+     */
+    private static void runConcurrently(final int threadCount, final int timeout, final Runnable runnable) throws Exception {
+        if (threadCount < 1)
+            throw new IllegalAccessException("threadCount must be positive");
+        if (runnable == null)
+            throw new NullPointerException();
+
+        final BlockingQueue<Throwable> errors = new LinkedBlockingQueue<>();
+        final List<Thread> threads = new ArrayList<>(threadCount);
+
+        //prepare threads
+        for (int i = 0; i < threadCount; ++i)
+            threads.add(new Thread(runnable, "junit:" + LocalNotifierTestCase.class.getSimpleName()) {
+                @Override
+                public void run() {
+                    try {
+                        super.run();
+                    } catch (Throwable throwable) {
+                        errors.add(throwable);
+                    }
+                }
+            });
+
+        try {
+            //start all threads
+            for (Thread thread : threads)
+                thread.start();
+
+            //join all threads with a timeout
+            final long joinStartTime = System.currentTimeMillis();
+
+            for (Iterator<Thread> iterator = threads.iterator(); iterator.hasNext(); ) {
+                Thread thread = iterator.next();
+                boolean alive = thread.isAlive();
+                if (alive) {
+                    if (timeout >= 0) {
+                        long remainingDelay = (joinStartTime + timeout) - System.currentTimeMillis();
+                        if (remainingDelay > 0) {
+                            thread.join(remainingDelay, 0);
+                            alive = thread.isAlive();
+                        }
+                        if (alive)
+                            throw new TimeoutException("execution timed out");
+                    } else {
+                        thread.join();
+                        alive = thread.isAlive();
+                        if (alive)
+                            throw new Error("joined thread appears to be alive");
+                    }
+                }
+
+                iterator.remove();
+            }
+
+            //wrap exceptions from threads into an appropriate exception
+            if (!errors.isEmpty()) {
+                int assertionErrorCount = 0;
+                int errorCount;
+
+                for (Throwable throwable : errors)
+                    if (throwable instanceof AssertionError)
+                        ++assertionErrorCount;
+                errorCount = errors.size() - assertionErrorCount;
+
+                String message = "Concurrent execution failed: " + assertionErrorCount + " assertion errors, " + errorCount + " other errors";
+                Throwable error = assertionErrorCount == errors.size() ? new AssertionError(message) : new RuntimeException(message);
+                for (Throwable suppressed : errors)
+                    error.addSuppressed(suppressed);
+                throw Throwables.propagate(error);
+            }
+        } finally {
+            for (Thread thread : threads)
+                thread.interrupt();
+        }
+    }
+}


### PR DESCRIPTION
* return a new NullNotifier as the per-thread initial value (avoids extra instances of NullNotifier)
* when the setter is called with a null reference, substitute it with a new NullNotifier