### PR TITLE
Add additional information about file serving to the documentation

### DIFF
--- a/docs-v2/_docs/running-standalone.md
+++ b/docs-v2/_docs/running-standalone.md
@@ -180,7 +180,7 @@ You can push a collection of mappings to a remote
 
 ## File serving
 
-When running standalone files placed under the `__files` directory will
+When running the standalone JAR, files placed under the `__files` directory will
 be served up as if from under the docroot, except if stub mapping
 matching the URL exists. For example if a file exists
 `__files/things/myfile.html` and no stub mapping will match

--- a/docs-v2/_docs/stubbing.md
+++ b/docs-v2/_docs/stubbing.md
@@ -346,6 +346,16 @@ To do the equivalent via the JSON API, `PUT` the edited stub mapping to `/__admi
 }
 ```
 
+## File serving
+When running the standalone JAR, files placed under the `__files` directory will
+be served up as if from under the docroot, except if stub mapping
+matching the URL exists. For example if a file exists
+`__files/things/myfile.html` and no stub mapping will match
+`/things/myfile.html` then hitting
+`http://<host>:<port>/things/myfile.html` will serve the file.
+
+This feature is also available with the standard JAR. To use it, define the filesRoot using `options.withRootDirectory()`, i.e. `options.withRootDirectory(getClass.getResource("/wiremock").getPath)`
+
 ## Removing stubs
 
 Stub mappings can be deleted via the Java API as follows:


### PR DESCRIPTION
I added additional information about file serving, especially when using the standard JAR. 

I love this feature for its simplicity and think more people should be aware of it.