### PR TITLE
Byte dribble delay support

### DIFF
--- a/docs-v2/_docs/simulating-faults.md
+++ b/docs-v2/_docs/simulating-faults.md
@@ -150,6 +150,47 @@ To use, instantiate a `new UniformDistribution(15, 25)`, or via JSON:
 }
 ```
 
+## Chunked Dribble Delay
+
+In addition to fixed and random delays, you can dibble your response back in chunks. 
+This is useful for simulating a slow network and testing deterministic timeouts. 
+
+Use `#withChunkedDribbleDelay` on the stub to pass in the desired chunked response, it takes two parameters:
+
+-   numberOfChunks - how many chunks you want your response body divided up into
+-   totalDuration - the total duration you want the response to take in milliseconds
+
+```java
+stubFor(get(urlEqualTo("/chunked/delayed")).willReturn(
+        aResponse()
+                .withStatus(200)
+                .withBody("Hello world!")
+                .withChunkedDribbleDelay(5, 1000)));
+```
+
+Or set it on the `chunkedDribbleDelay` field via the JSON api:
+
+```json
+{
+    "request": {
+            "method": "GET",
+            "url": "/chunked/delayed"
+    },
+    "response": {
+            "status": 200,
+            "body": "Hello world!",
+            "chunkedDribbleDelay": {
+                    "numberOfChunks": 5,
+                    "totalDuration": 1000
+            }
+
+    }
+}
+```
+
+With the above settings the `Hello world!` response body will be broken into 
+five chunks and returned one at a time with a 200ms gap between each.  
+
 ## Bad responses
 
 It is also possible to create several kinds of corrupted responses:

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -17,13 +17,7 @@ package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
-import com.github.tomakehurst.wiremock.http.DelayDistribution;
-import com.github.tomakehurst.wiremock.http.Fault;
-import com.github.tomakehurst.wiremock.http.HttpHeader;
-import com.github.tomakehurst.wiremock.http.HttpHeaders;
-import com.github.tomakehurst.wiremock.http.LogNormal;
-import com.github.tomakehurst.wiremock.http.ResponseDefinition;
-import com.github.tomakehurst.wiremock.http.UniformDistribution;
+import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -46,6 +40,7 @@ public class ResponseDefinitionBuilder {
 	protected List<HttpHeader> headers = newArrayList();
 	protected Integer fixedDelayMilliseconds;
 	protected DelayDistribution delayDistribution;
+	protected ChunkedDribbleDelay chunkedDribbleDelay;
 	protected String proxyBaseUrl;
 	protected Fault fault;
 	protected List<String> responseTransformerNames;
@@ -132,6 +127,11 @@ public class ResponseDefinitionBuilder {
 
 	public ResponseDefinitionBuilder withUniformRandomDelay(int lowerMilliseconds, int upperMilliseconds) {
 		return withRandomDelay(new UniformDistribution(lowerMilliseconds, upperMilliseconds));
+	}
+
+	public ResponseDefinitionBuilder withChunkedDribbleDelay(int numberOfChunks, int chunkedDuration) {
+		this.chunkedDribbleDelay = new ChunkedDribbleDelay(numberOfChunks, chunkedDuration);
+		return this;
 	}
 
 	public ResponseDefinitionBuilder withTransformers(String... responseTransformerNames) {
@@ -246,6 +246,7 @@ public class ResponseDefinitionBuilder {
 						additionalProxyRequestHeaders,
 						fixedDelayMilliseconds,
 						delayDistribution,
+						chunkedDribbleDelay,
 						proxyBaseUrl,
 						fault,
 						responseTransformerNames,
@@ -262,6 +263,7 @@ public class ResponseDefinitionBuilder {
 						additionalProxyRequestHeaders,
 						fixedDelayMilliseconds,
 						delayDistribution,
+						chunkedDribbleDelay,
 						proxyBaseUrl,
 						fault,
 						responseTransformerNames,

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -60,6 +60,7 @@ public class ResponseDefinitionBuilder {
 		builder.bodyFileName = responseDefinition.getBodyFileName();
 		builder.fixedDelayMilliseconds = responseDefinition.getFixedDelayMilliseconds();
 		builder.delayDistribution = responseDefinition.getDelayDistribution();
+		builder.chunkedDribbleDelay = responseDefinition.getChunkedDribbleDelay();
 		builder.proxyBaseUrl = responseDefinition.getProxyBaseUrl();
 		builder.fault = responseDefinition.getFault();
 		builder.responseTransformerNames = responseDefinition.getTransformers();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ChunkedDribbleDelay.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ChunkedDribbleDelay.java
@@ -1,0 +1,24 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ChunkedDribbleDelay {
+
+    private final Integer numberOfChunks;
+    private final Integer totalDuration;
+
+    @JsonCreator
+    public ChunkedDribbleDelay(@JsonProperty("numberOfChunks") Integer numberOfChunks, @JsonProperty("totalDuration") Integer totalDuration) {
+        this.numberOfChunks = numberOfChunks;
+        this.totalDuration = totalDuration;
+    }
+
+    public Integer getNumberOfChunks() {
+        return numberOfChunks;
+    }
+
+    public Integer getTotalDuration() {
+        return totalDuration;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ChunkedDribbleDelay.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ChunkedDribbleDelay.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock.http;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -31,6 +31,7 @@ public class Response {
 	private final boolean configured;
 	private final Fault fault;
 	private final boolean fromProxy;
+    private final ChunkedDribbleDelay chunkedDribbleDelay;
 
 	public static Response notConfigured() {
         return new Response(
@@ -40,6 +41,7 @@ public class Response {
                 noHeaders(),
                 false,
                 null,
+                null,
                 false
         );
 	}
@@ -48,23 +50,25 @@ public class Response {
         return new Builder();
     }
 
-	public Response(int status, String statusMessage, byte[] body, HttpHeaders headers, boolean configured, Fault fault, boolean fromProxy) {
+	public Response(int status, String statusMessage, byte[] body, HttpHeaders headers, boolean configured, Fault fault, ChunkedDribbleDelay chunkedDribbleDelay, boolean fromProxy) {
 		this.status = status;
         this.statusMessage = statusMessage;
         this.body = body;
         this.headers = headers;
         this.configured = configured;
         this.fault = fault;
+        this.chunkedDribbleDelay = chunkedDribbleDelay;
         this.fromProxy = fromProxy;
     }
 
-    public Response(int status, String statusMessage, String body, HttpHeaders headers, boolean configured, Fault fault, boolean fromProxy) {
+    public Response(int status, String statusMessage, String body, HttpHeaders headers, boolean configured, Fault fault, ChunkedDribbleDelay chunkedDribbleDelay, boolean fromProxy) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.headers = headers;
         this.body = body == null ? null : Strings.bytesFromString(body, headers.getContentTypeHeader().charset());
         this.configured = configured;
         this.fault = fault;
+        this.chunkedDribbleDelay = chunkedDribbleDelay;
         this.fromProxy = fromProxy;
     }
 
@@ -90,6 +94,14 @@ public class Response {
 
     public Fault getFault() {
         return fault;
+    }
+
+    public ChunkedDribbleDelay getChunkedDribbleDelay() {
+        return chunkedDribbleDelay;
+    }
+
+    public boolean shouldAddChunkedDribbleDelay() {
+        return chunkedDribbleDelay != null;
     }
 
 	public boolean wasConfigured() {
@@ -122,6 +134,7 @@ public class Response {
         private Fault fault;
         private boolean fromProxy;
         private Optional<ResponseDefinition> renderedFromDefinition;
+        private ChunkedDribbleDelay chunkedDribbleDelay;
 
         public static Builder like(Response response) {
             Builder responseBuilder = new Builder();
@@ -130,6 +143,7 @@ public class Response {
             responseBuilder.headers = response.getHeaders();
             responseBuilder.configured = response.wasConfigured();
             responseBuilder.fault = response.getFault();
+            responseBuilder.chunkedDribbleDelay = response.getChunkedDribbleDelay();
             responseBuilder.fromProxy = response.isFromProxy();
             return responseBuilder;
         }
@@ -183,6 +197,11 @@ public class Response {
             return this;
         }
 
+        public Builder chunkedDribbleDelay(ChunkedDribbleDelay chunkedDribbleDelay) {
+            this.chunkedDribbleDelay = chunkedDribbleDelay;
+            return this;
+        }
+
         public Builder fromProxy(boolean fromProxy) {
             this.fromProxy = fromProxy;
             return this;
@@ -190,11 +209,11 @@ public class Response {
 
         public Response build() {
             if (body != null) {
-                return new Response(status, statusMessage, body, headers, configured, fault, fromProxy);
+                return new Response(status, statusMessage, body, headers, configured, fault, chunkedDribbleDelay, fromProxy);
             } else if (bodyString != null) {
-                return new Response(status, statusMessage, bodyString, headers, configured, fault, fromProxy);
+                return new Response(status, statusMessage, bodyString, headers, configured, fault, chunkedDribbleDelay, fromProxy);
             } else {
-                return new Response(status, statusMessage, new byte[0], headers, configured, fault, fromProxy);
+                return new Response(status, statusMessage, new byte[0], headers, configured, fault, chunkedDribbleDelay, fromProxy);
             }
         }
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
-import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static java.net.HttpURLConnection.*;
 
 public class ResponseDefinition {
@@ -44,6 +43,7 @@ public class ResponseDefinition {
     private final HttpHeaders additionalProxyRequestHeaders;
     private final Integer fixedDelayMilliseconds;
     private final DelayDistribution delayDistribution;
+    private final ChunkedDribbleDelay chunkedDribbleDelay;
     private final String proxyBaseUrl;
     private final Fault fault;
     private final List<String> transformers;
@@ -64,12 +64,13 @@ public class ResponseDefinition {
                               @JsonProperty("additionalProxyRequestHeaders") HttpHeaders additionalProxyRequestHeaders,
                               @JsonProperty("fixedDelayMilliseconds") Integer fixedDelayMilliseconds,
                               @JsonProperty("delayDistribution") DelayDistribution delayDistribution,
+                              @JsonProperty("chunkedDribbleDelay") ChunkedDribbleDelay chunkedDribbleDelay,
                               @JsonProperty("proxyBaseUrl") String proxyBaseUrl,
                               @JsonProperty("fault") Fault fault,
                               @JsonProperty("transformers") List<String> transformers,
                               @JsonProperty("transformerParameters") Parameters transformerParameters,
                               @JsonProperty("fromConfiguredStub") Boolean wasConfigured) {
-        this(status, statusMessage, Body.fromOneOf(null, body, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, proxyBaseUrl, fault, transformers, transformerParameters, wasConfigured);
+        this(status, statusMessage, Body.fromOneOf(null, body, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, chunkedDribbleDelay, proxyBaseUrl, fault, transformers, transformerParameters, wasConfigured);
     }
 
     public ResponseDefinition(int status,
@@ -82,12 +83,13 @@ public class ResponseDefinition {
                               HttpHeaders additionalProxyRequestHeaders,
                               Integer fixedDelayMilliseconds,
                               DelayDistribution delayDistribution,
+                              ChunkedDribbleDelay chunkedDribbleDelay,
                               String proxyBaseUrl,
                               Fault fault,
                               List<String> transformers,
                               Parameters transformerParameters,
                               Boolean wasConfigured) {
-        this(status, statusMessage, Body.fromOneOf(body, null, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, proxyBaseUrl, fault, transformers, transformerParameters, wasConfigured);
+        this(status, statusMessage, Body.fromOneOf(body, null, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, chunkedDribbleDelay, proxyBaseUrl, fault, transformers, transformerParameters, wasConfigured);
     }
 
     private ResponseDefinition(int status,
@@ -98,6 +100,7 @@ public class ResponseDefinition {
                                HttpHeaders additionalProxyRequestHeaders,
                                Integer fixedDelayMilliseconds,
                                DelayDistribution delayDistribution,
+                               ChunkedDribbleDelay chunkedDribbleDelay,
                                String proxyBaseUrl,
                                Fault fault,
                                List<String> transformers,
@@ -113,6 +116,7 @@ public class ResponseDefinition {
         this.additionalProxyRequestHeaders = additionalProxyRequestHeaders;
         this.fixedDelayMilliseconds = fixedDelayMilliseconds;
         this.delayDistribution = delayDistribution;
+        this.chunkedDribbleDelay = chunkedDribbleDelay;
         this.proxyBaseUrl = proxyBaseUrl;
         this.fault = fault;
         this.transformers = transformers;
@@ -121,15 +125,15 @@ public class ResponseDefinition {
     }
 
     public ResponseDefinition(final int statusCode, final String bodyContent) {
-        this(statusCode, null, Body.fromString(bodyContent), null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
+        this(statusCode, null, Body.fromString(bodyContent), null, null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
     }
 
     public ResponseDefinition(final int statusCode, final byte[] bodyContent) {
-        this(statusCode, null, Body.fromBytes(bodyContent), null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
+        this(statusCode, null, Body.fromBytes(bodyContent), null, null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
     }
 
     public ResponseDefinition() {
-        this(HTTP_OK, null, Body.none(), null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
+        this(HTTP_OK, null, Body.none(), null, null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
     }
 
     public static ResponseDefinition notFound() {
@@ -195,6 +199,7 @@ public class ResponseDefinition {
             original.additionalProxyRequestHeaders,
             original.fixedDelayMilliseconds,
             original.delayDistribution,
+            original.chunkedDribbleDelay,
             original.proxyBaseUrl,
             original.fault,
             original.transformers,
@@ -256,6 +261,10 @@ public class ResponseDefinition {
 
     public DelayDistribution getDelayDistribution() {
         return delayDistribution;
+    }
+
+    public ChunkedDribbleDelay getChunkedDribbleDelay() {
+        return chunkedDribbleDelay;
     }
 
     @JsonIgnore
@@ -331,6 +340,7 @@ public class ResponseDefinition {
             Objects.equals(additionalProxyRequestHeaders, that.additionalProxyRequestHeaders) &&
             Objects.equals(fixedDelayMilliseconds, that.fixedDelayMilliseconds) &&
             Objects.equals(delayDistribution, that.delayDistribution) &&
+            Objects.equals(chunkedDribbleDelay, that.chunkedDribbleDelay) &&
             Objects.equals(proxyBaseUrl, that.proxyBaseUrl) &&
             fault == that.fault &&
             Objects.equals(transformers, that.transformers) &&
@@ -341,7 +351,7 @@ public class ResponseDefinition {
 
     @Override
     public int hashCode() {
-        return Objects.hash(status, statusMessage, body, bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, proxyBaseUrl, fault, transformers, transformerParameters, browserProxyUrl, wasConfigured);
+        return Objects.hash(status, statusMessage, body, bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, chunkedDribbleDelay, proxyBaseUrl, fault, transformers, transformerParameters, browserProxyUrl, wasConfigured);
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -88,7 +88,8 @@ public class StubResponseRenderer implements ResponseRenderer {
                 .status(responseDefinition.getStatus())
 				.statusMessage(responseDefinition.getStatusMessage())
                 .headers(responseDefinition.getHeaders())
-                .fault(responseDefinition.getFault());
+                .fault(responseDefinition.getFault())
+				.chunkedDribbleDelay(responseDefinition.getChunkedDribbleDelay());
 
 		if (responseDefinition.specifiesBodyFile()) {
 			BinaryFile bodyFile = fileSource.getBinaryFileNamed(responseDefinition.getBodyFileName());

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/BodyChunker.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/BodyChunker.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock.servlet;
 
 import com.github.tomakehurst.wiremock.common.Notifier;

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/BodyChunker.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/BodyChunker.java
@@ -1,0 +1,48 @@
+package com.github.tomakehurst.wiremock.servlet;
+
+import com.github.tomakehurst.wiremock.common.Notifier;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+
+import java.util.Arrays;
+
+public class BodyChunker {
+
+    private static final Notifier notifier = new Slf4jNotifier(false);
+
+    public static byte[][] chunkBody(byte[] body, int numberOfChunks) {
+
+        if (numberOfChunks < 1) {
+            notifier.error("Number of chunks set to value less than 1: " + numberOfChunks);
+            numberOfChunks = 1;
+        }
+
+        if (body.length < numberOfChunks) {
+            notifier.error("Number of chunks set to value greater then body length. Number of chunks: " + numberOfChunks +
+                    ". Body length: " + body.length + ". Overriding number of chunks to body length.");
+            numberOfChunks = body.length;
+        }
+
+        int chunkSize = body.length / numberOfChunks;
+        int excessSize = body.length % numberOfChunks;
+
+        byte[][] chunkedBody = new byte[numberOfChunks][];
+
+        for (int chunkIndex = 0; chunkIndex < numberOfChunks; chunkIndex++) {
+            int chunkStart = chunkIndex * chunkSize;
+            int chunkEnd = chunkStart + chunkSize;
+
+            chunkedBody[chunkIndex] = Arrays.copyOfRange(body, chunkStart, chunkEnd);
+        }
+
+        if (excessSize > 0) {
+            int lastChunkIndex = numberOfChunks - 1;
+
+            int chunkStart = lastChunkIndex * chunkSize;
+            int newChunkEnd = chunkStart + chunkSize + excessSize;
+
+            chunkedBody[lastChunkIndex] = Arrays.copyOfRange(body, chunkStart, newChunkEnd);
+        }
+
+        return chunkedBody;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
@@ -41,23 +41,23 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
 	public static final String MAPPED_UNDER_KEY = "mappedUnder";
 
 	private static final long serialVersionUID = -6602042274260495538L;
-	
+
     private RequestHandler requestHandler;
     private FaultInjectorFactory faultHandlerFactory;
 	private String mappedUnder;
 	private Notifier notifier;
 	private String wiremockFileSourceRoot = "/";
 	private boolean shouldForwardToFilesContext;
-	
+
 	@Override
 	public void init(ServletConfig config) {
 	    ServletContext context = config.getServletContext();
 	    shouldForwardToFilesContext = getFileContextForwardingFlagFrom(config);
-	    
+
 	    if (context.getInitParameter("WireMockFileSourceRoot") != null) {
 	        wiremockFileSourceRoot = context.getInitParameter("WireMockFileSourceRoot");
 	    }
-		
+
         String handlerClassName = config.getInitParameter(RequestHandler.HANDLER_CLASS_KEY);
 		String faultInjectorFactoryClassName = config.getInitParameter(FaultInjectorFactory.INJECTOR_CLASS_KEY);
 		mappedUnder = getNormalizedMappedUnder(config);
@@ -71,7 +71,7 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
 
 		notifier = (Notifier) context.getAttribute(Notifier.KEY);
 	}
-	
+
 	/**
 	 * @param config Servlet configuration to read
 	 * @return Normalized mappedUnder attribute without trailing slash
@@ -86,7 +86,7 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
 		}
 		return mappedUnder;
 	}
-	
+
 	private boolean getFileContextForwardingFlagFrom(ServletConfig config) {
 		String flagValue = config.getInitParameter(SHOULD_FORWARD_TO_FILES_CONTEXT);
 		return Boolean.valueOf(flagValue);
@@ -95,7 +95,7 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
 	@Override
 	protected void service(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ServletException, IOException {
 		LocalNotifier.set(notifier);
-		
+
 		Request request = new WireMockHttpServletRequestAdapter(httpServletRequest, mappedUnder);
 
 		ServletHttpResponder responder = new ServletHttpResponder(httpServletRequest, httpServletResponse);
@@ -155,7 +155,11 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
             }
         }
 
-        writeAndTranslateExceptions(httpServletResponse, response.getBody());
+        if (response.shouldAddChunkedDribbleDelay()) {
+			writeAndTranslateExceptionsWithChunkedDribbleDelay(httpServletResponse, response.getBody(), response.getChunkedDribbleDelay());
+		} else {
+			writeAndTranslateExceptions(httpServletResponse, response.getBody());
+		}
     }
 
 	private FaultInjector buildFaultInjector(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
@@ -172,6 +176,31 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
             throwUnchecked(e);
         }
     }
+
+	private void writeAndTranslateExceptionsWithChunkedDribbleDelay(HttpServletResponse httpServletResponse, byte[] body, ChunkedDribbleDelay chunkedDribbleDelay) {
+
+		try (ServletOutputStream out = httpServletResponse.getOutputStream()) {
+
+			if (body.length < 1) {
+				notifier.error("Cannot chunk dribble delay when no body set");
+				out.flush();
+				return;
+			}
+
+			byte[][] chunkedBody = BodyChunker.chunkBody(body, chunkedDribbleDelay.getNumberOfChunks());
+
+			int chunkInterval = chunkedDribbleDelay.getTotalDuration() / chunkedBody.length;
+
+			for (byte[] bodyChunk : chunkedBody) {
+				Thread.sleep(chunkInterval);
+				out.write(bodyChunk);
+				out.flush();
+			}
+
+		} catch (IOException | InterruptedException e) {
+			throwUnchecked(e);
+		}
+	}
 
     private void forwardToFilesContext(HttpServletRequest httpServletRequest,
             HttpServletResponse httpServletResponse, Request request) throws ServletException, IOException {

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.core.Options;

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDribbleAcceptanceTest.java
@@ -1,0 +1,75 @@
+package com.github.tomakehurst.wiremock;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public class ResponseDribbleAcceptanceTest {
+
+    private static final int SOCKET_TIMEOUT_MILLISECONDS = 500;
+    private static final int DOUBLE_THE_SOCKET_TIMEOUT = SOCKET_TIMEOUT_MILLISECONDS * 2;
+
+    private static final byte[] BODY_OF_THREE_BYTES = new byte[] {1, 2, 3};
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(Options.DYNAMIC_PORT, Options.DYNAMIC_PORT);
+
+    private HttpClient httpClient;
+
+    @Before
+    public void init() {
+        httpClient = HttpClientFactory.createClient(SOCKET_TIMEOUT_MILLISECONDS);
+    }
+
+    @Test
+    public void requestIsSuccessfulButTakesLongerThanSocketTimeoutWhenDribbleIsEnabled() throws Exception {
+
+        stubFor(get(urlEqualTo("/delayedDribble")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withBody(BODY_OF_THREE_BYTES)
+                        .withChunkedDribbleDelay(BODY_OF_THREE_BYTES.length, DOUBLE_THE_SOCKET_TIMEOUT)));
+
+        HttpResponse response = httpClient.execute(new HttpGet(String.format("http://localhost:%d/delayedDribble", wireMockRule.port())));
+
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+
+        long start = System.currentTimeMillis();
+        byte[] responseBody = IOUtils.toByteArray(response.getEntity().getContent());
+        int duration = (int) (System.currentTimeMillis() - start);
+
+        assertThat(BODY_OF_THREE_BYTES, is(responseBody));
+        assertThat(duration, greaterThanOrEqualTo(SOCKET_TIMEOUT_MILLISECONDS));
+    }
+
+    @Test
+    public void requestIsSuccessfulAndBelowSocketTimeoutWhenDribbleIsDisabled() throws Exception {
+        stubFor(get(urlEqualTo("/nonDelayedDribble")).willReturn(
+                aResponse()
+                        .withStatus(200)
+                        .withBody(BODY_OF_THREE_BYTES)));
+
+        HttpResponse response = httpClient.execute(new HttpGet(String.format("http://localhost:%d/nonDelayedDribble", wireMockRule.port())));
+
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+
+        long start = System.currentTimeMillis();
+        byte[] responseBody = IOUtils.toByteArray(response.getEntity().getContent());
+        int duration = (int) (System.currentTimeMillis() - start);
+
+        assertThat(BODY_OF_THREE_BYTES, is(responseBody));
+        assertThat(duration, lessThan(SOCKET_TIMEOUT_MILLISECONDS));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -15,7 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.Charsets;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -38,5 +41,27 @@ public class ResponseDefinitionBuilderTest {
 
         assertThat(originalResponseDefinition.getTransformerParameters().getString("name"), is("original"));
         assertThat(transformedResponseDefinition.getTransformerParameters().getString("name"), is("changed"));
+    }
+
+    @Test
+    public void likeShouldCreateCompleteResponseDefinitionCopy() throws Exception {
+        ResponseDefinition originalResponseDefinition = ResponseDefinitionBuilder.responseDefinition()
+                .withStatus(200)
+                .withStatusMessage("OK")
+                .withBody("some body")
+                .withBase64Body(Base64.encodeBase64String("some body".getBytes(Charsets.UTF_8)))
+                .withBodyFile("some_body.json")
+                .withHeader("some header", "some value")
+                .withFixedDelay(100)
+                .withUniformRandomDelay(1, 2)
+                .withChunkedDribbleDelay(1, 1000)
+                .withFault(Fault.EMPTY_RESPONSE)
+                .withTransformers("some transformer")
+                .withTransformerParameter("some param", "some value")
+                .build();
+
+        ResponseDefinition copiedResponseDefinition = ResponseDefinitionBuilder.like(originalResponseDefinition).build();
+
+        assertThat(copiedResponseDefinition, is(originalResponseDefinition));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/servlet/BodyChunkerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/servlet/BodyChunkerTest.java
@@ -1,0 +1,71 @@
+package com.github.tomakehurst.wiremock.servlet;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class BodyChunkerTest {
+
+    @Test
+    public void returnsBodyAsSingleChunkWhenChunkSizeIsOne() {
+        byte[] body = "1234".getBytes();
+        int numberOfChunks = 1;
+
+        byte[][] chunkedBody = BodyChunker.chunkBody(body, numberOfChunks);
+
+        assertThat(chunkedBody, arrayWithSize(numberOfChunks));
+        assertThat(chunkedBody[0], equalTo(body));
+    }
+
+    @Test
+    public void returnsEvenlyChunkedBody() {
+        byte[] body = "1234".getBytes();
+        int numberOfChunks = 2;
+
+        byte[][] chunkedBody = BodyChunker.chunkBody(body, numberOfChunks);
+
+        assertThat(chunkedBody, arrayWithSize(numberOfChunks));
+        assertThat(chunkedBody[0], equalTo("12".getBytes()));
+        assertThat(chunkedBody[1], equalTo("34".getBytes()));
+    }
+
+    @Test
+    public void addsExcessBytesToLastChunk() {
+        byte[] body = "1234".getBytes();
+        int numberOfChunks = 3;
+
+        byte[][] chunkedBody = BodyChunker.chunkBody(body, numberOfChunks);
+
+        assertThat(chunkedBody, arrayWithSize(numberOfChunks));
+        assertThat(chunkedBody[0], equalTo("1".getBytes()));
+        assertThat(chunkedBody[1], equalTo("2".getBytes()));
+        assertThat(chunkedBody[2], equalTo("34".getBytes()));
+    }
+
+    @Test
+    public void defaultsChunkSizeToOneIfNumberOfChunksGreaterThenBodyLength() {
+        byte[] body = "1234".getBytes();
+        int numberOfChunks = 5;
+
+        byte[][] chunkedBody = BodyChunker.chunkBody(body, numberOfChunks);
+
+        assertThat(chunkedBody, arrayWithSize(body.length));
+        assertThat(chunkedBody[0], equalTo("1".getBytes()));
+        assertThat(chunkedBody[1], equalTo("2".getBytes()));
+        assertThat(chunkedBody[2], equalTo("3".getBytes()));
+        assertThat(chunkedBody[3], equalTo("4".getBytes()));
+    }
+
+    @Test
+    public void defaultsChunkSizeToOneIfNumberOfChunksLessThanOne() {
+        byte[] body = "1234".getBytes();
+        int numberOfChunks = -1;
+
+        byte[][] chunkedBody = BodyChunker.chunkBody(body, numberOfChunks);
+
+        assertThat(chunkedBody, arrayWithSize(1));
+        assertThat(chunkedBody[0], equalTo(body));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/servlet/BodyChunkerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/servlet/BodyChunkerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.tomakehurst.wiremock.servlet;
 
 import org.junit.Test;

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -47,6 +47,7 @@ public class ResponseDefinitionTest {
                 null,
                 1112,
                 null,
+                null,
                 "http://base.com",
                 Fault.EMPTY_RESPONSE,
                 ImmutableList.of("transformer-1"),


### PR DESCRIPTION
Allow setting configurable delay after each byte WireMock is sending in the response body.

This resolves #472

Example:

```
stubFor(get(urlEqualTo("/delayedDribble")).willReturn(
    .aResponse()
        .withStatus(200)
        .withBody(new byte[] {1, 2, 3})
        .withByteDribbleDelay(10)));
```

Removed some spurious white spaces as a separate commit because they were inconsistent within the same class file (WireMockHandlerDispatchingServlet) we were working on.