### PR TITLE
In some cases you do not want Wiremock to return "Server" header if y…

### DIFF
--- a/docs-v2/_docs/running-standalone.md
+++ b/docs-v2/_docs/running-standalone.md
@@ -101,6 +101,8 @@ com.mycorp.HeaderTransformer,com.mycorp.BodyTransformer. See extending-wiremock.
 
 `--print-all-network-traffic`: Print all raw incoming and outgoing network traffic to console.
 
+`--disable-server-version`: Configure HTTP server to skip sending the 'Server' header. Sending server version is enabled by default.
+
 `--global-response-templating`: Render all response definitions using Handlebars templates.
 `--local-response-templating`: Enable rendering of response definitions using Handlebars templates for specific stub mappings.
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -52,4 +52,5 @@ public interface Options {
     HttpServerFactory httpServerFactory();
     <T extends Extension> Map<String, T> extensionsOfType(Class<T> extensionType);
     WiremockNetworkTrafficListener networkTrafficListener();
+    boolean disableServerVersion();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -75,6 +75,7 @@ public class WireMockConfiguration implements Options {
 
     private Map<String, Extension> extensions = newLinkedHashMap();
     private WiremockNetworkTrafficListener networkTrafficListener = new DoNothingWiremockNetworkTrafficListener();
+    private boolean disableServerVersion;
 
     private MappingsSource getMappingsSource() {
         if (mappingsSource == null) {
@@ -218,6 +219,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration disableRequestJournal() {
         requestJournalDisabled = true;
+        return this;
+    }
+
+    public WireMockConfiguration disableServerVersion(boolean disableServerVersion) {
+        this.disableServerVersion = disableServerVersion;
         return this;
     }
 
@@ -382,5 +388,10 @@ public class WireMockConfiguration implements Options {
     @Override
     public WiremockNetworkTrafficListener networkTrafficListener() {
         return networkTrafficListener;
+    }
+
+    @Override
+    public boolean disableServerVersion() {
+        return disableServerVersion;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -1,12 +1,12 @@
 package com.github.tomakehurst.wiremock.servlet;
 
 import com.github.tomakehurst.wiremock.common.*;
-import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.core.MappingsSaver;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.standalone.JsonFileMappingsSource;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
@@ -125,5 +125,10 @@ public class WarConfiguration implements Options {
     @Override
     public WiremockNetworkTrafficListener networkTrafficListener() {
         return new DoNothingWiremockNetworkTrafficListener();
+    }
+
+    @Override
+    public boolean disableServerVersion() {
+        return false;
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/DisableSendServerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/DisableSendServerAcceptanceTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.junit.Assert.assertThat;
+
+public class DisableSendServerAcceptanceTest extends AcceptanceTestBase {
+    @BeforeClass
+    public static void setupServer() {
+        setupServer(new WireMockConfiguration().disableServerVersion(true));
+    }
+
+    @Test
+    public void disablesServerResponseHeader() {
+        WireMockResponse wireMockResponse = testClient.get("/a/non-registered/resource");
+
+        assertThat(wireMockResponse.headers().get("Server"), emptyCollectionOf(String.class));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -31,13 +31,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class CommandLineOptionsTest {
@@ -300,6 +294,19 @@ public class CommandLineOptionsTest {
         CommandLineOptions options = new CommandLineOptions("--print-all-network-traffic");
         assertThat(options.networkTrafficListener(), is(instanceOf(ConsoleNotifyingWiremockNetworkTrafficListener.class)));
     }
+
+    @Test
+    public void returnsDisableServerVersionTrueWhenOptionPresent() {
+        CommandLineOptions options = new CommandLineOptions("--disable-server-version");
+        assertThat(options.disableServerVersion(), is(true));
+    }
+
+    @Test
+    public void returnsDisableServerVersionFalseWhenOptionNotPresent() {
+        CommandLineOptions options = new CommandLineOptions("");
+        assertThat(options.disableServerVersion(), is(false));
+    }
+
 
     @Test
     public void enablesGlobalResponseTemplating() {


### PR DESCRIPTION
…ou the mappings do not contain it. I have added the possibility to disable sending the server version response header.

Let me know what you think.