### PR TITLE
Upgrade to latest version of zjsonpatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
         exclude group: "org.hamcrest", module: "hamcrest-core"
     }
     compile 'org.apache.commons:commons-lang3:3.4'
-    compile 'com.flipkart.zjsonpatch:zjsonpatch:0.2.1'
+    compile 'com.flipkart.zjsonpatch:zjsonpatch:0.3.0'
     compile 'com.github.jknack:handlebars:4.0.6', {
         exclude group: 'org.mozilla', module: 'rhino'
     }


### PR DESCRIPTION
When checking some projects with DependencyCheck, I discovered that wiremock has a vulnerable dependency:

```
One or more dependencies were identified with known vulnerabilities:

commons-collections4-4.0.jar (cpe:/a:apache:commons_collections:4.0, org.apache.commons:commons-collections4:4.0) : CVE-2015-6420
```

(See http://commons.apache.org/proper/commons-collections/release_4_1.html or https://issues.apache.org/jira/browse/COLLECTIONS-580 for more details.)

Turns out this is dependency is added via zjsonpatch, which has just released a new version which is no longer depending on the vulnerable verison of commons-collections4 (https://github.com/flipkart-incubator/zjsonpatch/releases/tag/0.3.0)


Due to #623 I haven't been able to build wiremock successfully, but I didn't see any worse results after changing the version number.