### PR TITLE
Added proxy settings to connect to remote wiremock server over a http proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     compile("junit:junit:4.12") {
         exclude group: "org.hamcrest", module: "hamcrest-core"
     }
-    compile 'org.apache.commons:commons-lang3:3.4'
+    compile 'org.apache.commons:commons-lang3:3.5'
     compile 'com.flipkart.zjsonpatch:zjsonpatch:0.2.1'
     compile 'com.github.jknack:handlebars:4.0.6', {
         exclude group: 'org.mozilla', module: 'rhino'
@@ -84,6 +84,7 @@ dependencies {
     testCompile "com.googlecode.jarjar:jarjar:1.3"
     testCompile "commons-io:commons-io:2.4"
     testCompile 'org.scala-lang:scala-library:2.11.8'
+    testCompile 'org.littleshoot:littleproxy:1.1.2'
 
     testRuntime 'org.slf4j:slf4j-log4j12:1.7.12'
     testRuntime files('src/test/resources/classpath file source/classpathfiles.zip', 'src/test/resources/classpath-filesource.jar')

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -142,6 +142,10 @@ public class WireMock {
 		defaultInstance.set(new WireMock(scheme, host, port));
 	}
 
+    public static void configureFor(String scheme, String host, int port, String proxyHost, int proxyPort) {
+        defaultInstance.set(new WireMock(scheme, host, port, "", null, proxyHost, proxyPort));
+    }
+
 	public static void configure() {
 		defaultInstance.set(new WireMock());
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -86,6 +86,10 @@ public class WireMock {
 		admin = new HttpAdminClient(scheme, host, port, urlPathPrefix);
 	}
 
+    public WireMock(String scheme, String host, int port, String urlPathPrefix, String hostHeader, String proxyHost, int proxyPort) {
+        admin = new HttpAdminClient(scheme, host, port, urlPathPrefix, hostHeader, proxyHost, proxyPort);
+    }
+
 	public WireMock() {
 		admin = new HttpAdminClient(DEFAULT_HOST, DEFAULT_PORT);
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -41,9 +41,13 @@ import static com.github.tomakehurst.wiremock.http.RequestMethod.*;
 public class HttpClientFactory {
 
     public static final int DEFAULT_MAX_CONNECTIONS = 50;
+    public static final int DEFAULT_TIMEOUT = 30000;
 
     public static CloseableHttpClient createClient(
-            int maxConnections, int timeoutMilliseconds, ProxySettings proxySettings, KeyStoreSettings trustStoreSettings) {
+            int maxConnections,
+            int timeoutMilliseconds,
+            ProxySettings proxySettings,
+            KeyStoreSettings trustStoreSettings) {
 
         HttpClientBuilder builder = HttpClientBuilder.create()
                 .disableAuthCaching()
@@ -104,9 +108,13 @@ public class HttpClientFactory {
 		return createClient(DEFAULT_MAX_CONNECTIONS, timeoutMilliseconds);
 	}
 
-	public static CloseableHttpClient createClient() {
-		return createClient(30000);
-	}
+    public static CloseableHttpClient createClient(ProxySettings proxySettings) {
+        return createClient(DEFAULT_MAX_CONNECTIONS, DEFAULT_TIMEOUT, proxySettings, NO_STORE);
+    }
+
+    public static CloseableHttpClient createClient() {
+      return createClient(DEFAULT_TIMEOUT);
+    }
 
     public static HttpUriRequest getHttpRequestFor(RequestMethod method, String url) {
         notifier().info("Proxying: " + method + " " + url);

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.client;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import java.net.InetSocketAddress;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+public class WireMockClientWithProxyAcceptanceTest {
+	
+	private WireMockServer wireMockServer;
+	private WireMockTestClient testClient;
+	private HttpProxyServer proxyServer;
+
+	@Before
+	public void init() {
+
+		wireMockServer = new WireMockServer(Options.DYNAMIC_PORT);
+		wireMockServer.start();
+		InetSocketAddress proxyAddress = new InetSocketAddress(Options.DYNAMIC_PORT);
+		proxyServer = DefaultHttpProxyServer.bootstrap().withAddress(proxyAddress).start();
+
+		WireMock.configureFor("http", "localhost", wireMockServer.port(), proxyServer.getListenAddress().getHostString(), proxyServer.getListenAddress().getPort());
+		testClient = new WireMockTestClient(wireMockServer.port());
+	}
+	
+	@After
+	public void stopServer() {
+		wireMockServer.stop();
+		proxyServer.stop();
+	}
+
+	@Test
+	public void buildsMappingWithUrlOnlyRequestAndStatusOnlyResponse() {
+		WireMock wireMock = new WireMock("http", "localhost", wireMockServer.port(), "", null, proxyServer.getListenAddress().getHostString(), proxyServer.getListenAddress().getPort());
+		wireMock.register(
+				get(urlEqualTo("/my/new/resource"))
+				.willReturn(
+						aResponse()
+						.withStatus(304)));
+		
+		assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
+	}
+
+	@Test
+	public void buildsMappingFromStaticSyntax() {
+		givenThat(get(urlEqualTo("/my/new/resource"))
+					.willReturn(aResponse()
+						.withStatus(304)));
+
+		assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
+	}
+
+	@Test
+	public void buildsMappingWithUrlOnyRequestAndResponseWithJsonBodyWithDiacriticSigns() {
+		WireMock wireMock = new WireMock("http", "localhost", wireMockServer.port(), "", null, proxyServer.getListenAddress().getHostString(), proxyServer.getListenAddress().getPort());
+		wireMock.register(
+				get(urlEqualTo("/my/new/resource"))
+				.willReturn(
+						aResponse()
+						.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
+						.withStatus(200)));
+
+		assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+	}
+}


### PR DESCRIPTION
e.g.
       WireMock instance = new WireMock("https", "wiremock.server.url", 443, null, "" "proxyhost", proxyport);