### PR TITLE
Add response templating for proxyBaseUrl

### DIFF
--- a/docs-v2/_docs/response-templating.md
+++ b/docs-v2/_docs/response-templating.md
@@ -5,7 +5,7 @@ toc_rank: 71
 description: Generating dynamic responses using Handlebars templates
 ---
 
-Response headers and bodies can optionally be rendered using [Handlebars templates](http://handlebarsjs.com/). This enables attributes of the request
+Response headers and bodies, as well as proxy URLs, can optionally be rendered using [Handlebars templates](http://handlebarsjs.com/). This enables attributes of the request
 to be used in generating the response e.g. to pass the value of a request ID header as a response header or
 render an identifier from part of the URL in the response body.
  
@@ -48,6 +48,37 @@ wm.stubFor(get(urlPathEqualTo("/templated"))
     },
     "response": {
         "body": "{{request.path.[0]}}",
+        "transformers": ["response-template"]
+    }
+}
+```
+{% endraw %}
+
+## Proxying
+
+Templating also works when defining proxy URLs, e.g.
+
+### Java
+
+{% raw %}
+```java
+wm.stubFor(get(urlPathEqualTo("/templated"))
+  .willReturn(aResponse()
+      .proxiedFrom("{{request.headers.X-WM-Proxy-Url}}")
+      .withTransformers("response-template")));
+```
+{% endraw %}
+
+
+{% raw %}
+### JSON
+```json
+{
+    "request": {
+        "urlPath": "/templated"
+    },
+    "response": {
+        "proxyBaseUrl": "{{request.headers.X-WM-Proxy-Url}}",
         "transformers": ["response-template"]
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -94,6 +94,12 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
             newResponseDefBuilder.withHeaders(new HttpHeaders(newResponseHeaders));
         }
 
+        if (responseDefinition.getProxyBaseUrl() != null) {
+            Template proxyBaseUrlTemplate = uncheckedCompileTemplate(responseDefinition.getProxyBaseUrl());
+            String newProxyBaseUrl = uncheckedApplyTemplate(proxyBaseUrlTemplate, model);
+            newResponseDefBuilder.proxiedFrom(newProxyBaseUrl);
+        }
+
         return newResponseDefBuilder.build();
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -227,6 +227,19 @@ public class ResponseTemplateTransformerTest {
         assertThat(transformedResponseDef.getBody(), is("5"));
     }
 
+    @Test
+    public void proxyBaseUrl() {
+        ResponseDefinition transformedResponseDef = transform(mockRequest()
+                .url("/things")
+                .header("X-WM-Uri", "http://localhost:8000"),
+            aResponse().proxiedFrom("{{request.headers.X-WM-Uri}}")
+        );
+
+        assertThat(transformedResponseDef.getProxyBaseUrl(), is(
+            "http://localhost:8000"
+        ));
+    }
+
     private ResponseDefinition transform(Request request, ResponseDefinitionBuilder responseDefinitionBuilder) {
         return transformer.transform(
             request,


### PR DESCRIPTION
This extends the response templating extension to work with proxy URLs. This is very useful when
using the proxy/intercept setup with multiple API providers, especially when the
endpoints aren't known ahead of time. The browser proxy mode is perhaps better suited to this use
case, but it's not an option for HTTPS-only APIs due to the lack of SSL support.

Specific use case: I'm working with a large legacy codebase that has many API tests that I want to stub with Wiremock for performance reasons. I don't know all the API endpoints involved, but I do have the ability to tamper with the request before it's sent. The example I added to the docs is what I want to do: set a header named `X-WM-Proxy-Url` with the API endpoint and template it with `"proxyBaseUrl": "{{request.headers.X-WM-Proxy-Url}}"`.