### PR TITLE
#643 Prevent null pointer exception when getting MimeTypePart

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -41,7 +41,7 @@ public class ContentTypeHeader extends HttpHeader {
     }
 
 	public String mimeTypePart() {
-		return parts[0];
+		return parts != null ? parts[0] : null;
 	}
 	
 	public Optional<String> encodingPart() {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -92,5 +93,11 @@ public class ContentTypeHeaderTest {
 			.build();
 	
         request.contentTypeHeader();
+	}
+	
+	@Test
+	public void returnsNullFromMimeTypePartWhenContentTypeIsAbsent() {
+		ContentTypeHeader header = ContentTypeHeader.absent();
+		assertThat(header.mimeTypePart(), is(nullValue()));
 	}
 }


### PR DESCRIPTION
NullPointer exception was generated when getting MimeTypePart from ContentTypeHeader as described in #643. This commit fixes this behavior and return null value instead.