### PR TITLE
Updated "record and replay" docs

### DIFF
--- a/docs-v2/_docs/record-playback.md
+++ b/docs-v2/_docs/record-playback.md
@@ -15,8 +15,8 @@ your tests.**
 
 Recording is done by starting the standalone runner like this:
 
-```bash
-$ java -jar wiremock-{{ site.wiremock_version }}-standalone.jar --proxy-all="http://search.twitter.com" --record-mappings --verbose
+```bash  
+$ java -jar wiremock-standalone-{{ site.wiremock_version }}.jar --proxy-all="http://search.twitter.com" --record-mappings --verbose
 ```
 
 Once it's started you send requests to it as if it was the remote


### PR DESCRIPTION
Since version 2 the name pattern of the standalone jar seems to have changed to e.g. "wiremock-standalone-2.6.0.jar"