### PR TITLE
Publish testJar to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,11 @@ task sourcesJar(type: Jar, dependsOn: classes) {
     from sourceSets.main.allSource
 }
 
+task testJar(type: Jar, dependsOn: testClasses) {
+    classifier = 'tests'
+    from sourceSets.test.output
+}
+
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
@@ -181,6 +186,7 @@ artifacts {
     archives sourcesJar
     archives javadocJar
     archives shadowJar
+    archives testJar
     thinJarPom new File(thinJarPomPath)
     standaloneJarPom new File(standaloneJarPomPath)
 }
@@ -190,9 +196,10 @@ signing {
     sign configurations.archives
 }
 
-task signJars(type: Sign, dependsOn: [javadocJar, sourcesJar]) {
+task signJars(type: Sign, dependsOn: [javadocJar, sourcesJar, testJar]) {
     sign javadocJar
     sign sourcesJar
+    sign testJar
 }
 task signThinJar(type: Sign, dependsOn: jar) {
     sign jar
@@ -268,6 +275,7 @@ publishing {
             from components.java
             artifact sourcesJar
             artifact javadocJar
+            artifact testJar
             (signJars.signatures + signThinJar.singleSignature).each { signature ->
                 artifact(signature) {
                     classifier = signature.classifier == '' ? null : signature.classifier


### PR DESCRIPTION
When writing tests for extensions, the test classes in `com.github.tomakehurst.wiremock.matching` and `com.github.tomakehurst.wiremock.matching` are very helpful. Since it's not possible to include those as Maven Central dependencies, [I had to add wiremock as a Git submodule](https://github.com/MasonM/wiremock-snapshot/commit/d9e9f1c4a4abd1f1209e5788426cc0fc90c88dca) in my wiremock-snapshot extension so I could use them.

Another extension, wiremock-velocity-transformer, seems to have had the same issue and just did a [straight copy of the test sources](https://github.com/adamyork/wiremock-velocity-transformer/tree/master/src/test/java/com/github/tomakehurst/wiremock/testsupport).