### PR TITLE
Add getOptions() to Admin interface

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -372,6 +372,11 @@ public class WireMockServer implements Container, Stubbing, Admin {
     }
 
     @Override
+    public Options getOptions() {
+        return options;
+    }
+
+    @Override
     public void shutdownServer() {
         shutdown();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/HttpAdminClient.java
@@ -24,6 +24,8 @@ import com.github.tomakehurst.wiremock.common.AdminException;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.global.GlobalSettings;
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
@@ -256,6 +258,11 @@ public class HttpAdminClient implements Admin {
                 urlFor(GlobalSettingsUpdateTask.class),
                 Json.write(settings),
                 HTTP_OK);
+    }
+
+    @Override
+    public Options getOptions() {
+        return new WireMockConfiguration().port(port).bindAddress(host);
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -52,5 +52,7 @@ public interface Admin {
 
     void updateGlobalSettings(GlobalSettings settings);
 
+    Options getOptions();
+
     void shutdownServer();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -334,6 +334,11 @@ public class WireMockApp implements StubServer, Admin {
     }
 
     @Override
+    public Options getOptions() {
+        return options;
+    }
+
+    @Override
     public void shutdownServer() {
         container.shutdown();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -50,6 +50,13 @@ public class WireMockServerTests {
         }
     }
 
+    @Test
+    public void returnsOptionsWhenCallingGetOptions() {
+        Options options = new WireMockConfiguration();
+        WireMockServer wireMockServer = new WireMockServer(options);
+        assertThat(wireMockServer.getOptions(), is(options));
+    }
+
     // https://github.com/tomakehurst/wiremock/issues/193
     @Test
     public void supportsRecordingProgrammaticallyWithoutHeaderMatching() {

--- a/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/HttpAdminClientTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2017 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.client;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class HttpAdminClientTest {
+
+    @Test
+    public void returnsOptionsWhenCallingGetOptions() {
+        Options options = new WireMockConfiguration().port(8080).bindAddress("localhost");
+        HttpAdminClient client = new HttpAdminClient("localhost", 8080);
+        assertThat(client.getOptions().portNumber(), is(8080));
+        assertThat(client.getOptions().bindAddress(), is("localhost"));
+    }
+}


### PR DESCRIPTION
For the new recording API endpoint, we'll want to be able to extract response bodies to a file and load stub mapping transformer extensions. This means having access to `Options.filesSource()` so it can write out the extracted bodies, and `Options.extensionsOfType()` for loading the transformer extensions.

I'm not sure if `WireMockServer.getOptions()` and `WireMockApp.getOptions()` are really worth testing, since they're simple getters. I wrote a test for former since there's already a test class for it.

(I'll reply to your comments in PR #674 tomorrow. Just wanted to get this out here)