### PR TITLE
Fix binary body corruption for logged responses

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Strings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Strings.java
@@ -15,23 +15,34 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import java.nio.charset.Charset;
+
 import static com.google.common.base.Charsets.UTF_8;
 
 public class Strings {
+    public static final Charset DEFAULT_CHARSET = UTF_8;
 
     public static String stringFromBytes(byte[] bytes) {
+        return stringFromBytes(bytes, DEFAULT_CHARSET);
+    }
+
+    public static String stringFromBytes(byte[] bytes, Charset charset) {
         if (bytes == null) {
             return null;
         }
 
-        return new String(bytes, UTF_8);
+        return new String(bytes, charset);
     }
 
     public static byte[] bytesFromString(String str) {
+        return bytesFromString(str, DEFAULT_CHARSET);
+    }
+
+    public static byte[] bytesFromString(String str, Charset charset) {
         if (str == null) {
             return null;
         }
 
-        return str.getBytes();
+        return str.getBytes(charset);
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -17,6 +17,9 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.google.common.base.Optional;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 public class ContentTypeHeader extends HttpHeader {
 
 	public static final String KEY = "Content-Type";
@@ -52,5 +55,13 @@ public class ContentTypeHeader extends HttpHeader {
 		}
 
 		return Optional.absent();
+	}
+
+	public Charset encodingOrUtf8() {
+		if (isPresent() && encodingPart().isPresent()) {
+			return Charset.forName(encodingPart().get());
+		}
+
+		return StandardCharsets.UTF_8;
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -15,10 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.github.tomakehurst.wiremock.common.Strings;
 import com.google.common.base.Optional;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 public class ContentTypeHeader extends HttpHeader {
 
@@ -57,11 +57,11 @@ public class ContentTypeHeader extends HttpHeader {
 		return Optional.absent();
 	}
 
-	public Charset encodingOrUtf8() {
+	public Charset charset() {
 		if (isPresent() && encodingPart().isPresent()) {
 			return Charset.forName(encodingPart().get());
 		}
 
-		return StandardCharsets.UTF_8;
+		return Strings.DEFAULT_CHARSET;
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
@@ -1,21 +1,26 @@
 package com.github.tomakehurst.wiremock.http;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tomakehurst.wiremock.common.Encoding;
+
+import java.nio.charset.*;
 
 public class LoggedResponse {
 
     private final int status;
     private final HttpHeaders headers;
-    private final String body;
+    private final byte[] body;
     private final Fault fault;
 
     public LoggedResponse(@JsonProperty("status") int status,
                           @JsonProperty("headers") HttpHeaders headers,
-                          @JsonProperty("body") String body,
-                          @JsonProperty("fault") Fault fault) {
+                          @JsonProperty("bodyAsBase64") String bodyAsBase64,
+                          @JsonProperty("fault") Fault fault,
+                          @JsonProperty("body") String ignoredBodyOnlyUsedForBinding) {
         this.status = status;
         this.headers = headers;
-        this.body = body;
+        this.body = Encoding.decodeBase64(bodyAsBase64);
         this.fault = fault;
     }
 
@@ -23,8 +28,9 @@ public class LoggedResponse {
         return new LoggedResponse(
             response.getStatus(),
             response.getHeaders() == null || response.getHeaders().all().isEmpty() ? null : response.getHeaders(),
-            response.getBody() != null ? response.getBodyAsString() : null,
-            response.getFault()
+            Encoding.encodeBase64(response.getBody()),
+            response.getFault(),
+            null
         );
     }
 
@@ -36,8 +42,29 @@ public class LoggedResponse {
         return headers;
     }
 
-    public String getBody() {
+    /**
+     * Retrieve body as a String encoded in the charset in the "Content-Type" header, or, if that's not present, UTF-8.
+     *
+     * @return String encoded using detected charset or UTF-8
+     */
+    @JsonProperty("body")
+    public String getBodyAsString() {
+        if (body == null) {
+            return "";
+        }
+
+        Charset charset = (headers == null) ? StandardCharsets.UTF_8 : headers.getContentTypeHeader().encodingOrUtf8();
+        return new String(body, charset);
+    }
+
+    @JsonIgnore
+    public byte[] getBody() {
         return body;
+    }
+
+    @JsonProperty("bodyAsBase64")
+    public String getBodyAsBase64() {
+        return Encoding.encodeBase64(body);
     }
 
     public Fault getFault() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/LoggedResponse.java
@@ -3,8 +3,9 @@ package com.github.tomakehurst.wiremock.http;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Encoding;
+import com.github.tomakehurst.wiremock.common.Strings;
 
-import java.nio.charset.*;
+import java.nio.charset.Charset;
 
 public class LoggedResponse {
 
@@ -43,9 +44,10 @@ public class LoggedResponse {
     }
 
     /**
-     * Retrieve body as a String encoded in the charset in the "Content-Type" header, or, if that's not present, UTF-8.
+     * Retrieve body as a String encoded in the charset in the "Content-Type" header, or, if that's not present, the
+     * default character set (UTF-8)
      *
-     * @return String encoded using detected charset or UTF-8
+     * @return Encoded string
      */
     @JsonProperty("body")
     public String getBodyAsString() {
@@ -53,8 +55,8 @@ public class LoggedResponse {
             return "";
         }
 
-        Charset charset = (headers == null) ? StandardCharsets.UTF_8 : headers.getContentTypeHeader().encodingOrUtf8();
-        return new String(body, charset);
+        Charset charset = headers == null ? Strings.DEFAULT_CHARSET : headers.getContentTypeHeader().charset();
+        return Strings.stringFromBytes(body, charset);
     }
 
     @JsonIgnore

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -17,10 +17,7 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.google.common.base.Optional;
 
-import java.nio.charset.Charset;
-
 import static com.github.tomakehurst.wiremock.http.HttpHeaders.noHeaders;
-import static com.google.common.base.Charsets.UTF_8;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 
@@ -64,7 +61,7 @@ public class Response {
         this.status = status;
         this.statusMessage = statusMessage;
         this.headers = headers;
-        this.body = body == null ? null : body.getBytes(encodingFromContentTypeHeaderOrUtf8());
+        this.body = body == null ? null : body.getBytes(headers.getContentTypeHeader().encodingOrUtf8());
         this.configured = configured;
         this.fault = fault;
         this.fromProxy = fromProxy;
@@ -83,7 +80,7 @@ public class Response {
     }
 	
 	public String getBodyAsString() {
-        return new String(body, encodingFromContentTypeHeaderOrUtf8());
+        return new String(body, headers.getContentTypeHeader().encodingOrUtf8());
 	}
 	
 	public HttpHeaders getHeaders() {
@@ -94,15 +91,6 @@ public class Response {
         return fault;
     }
 
-    private Charset encodingFromContentTypeHeaderOrUtf8() {
-        ContentTypeHeader contentTypeHeader = headers.getContentTypeHeader();
-        if (contentTypeHeader.isPresent() && contentTypeHeader.encodingPart().isPresent()) {
-            return Charset.forName(contentTypeHeader.encodingPart().get());
-        }
-
-        return UTF_8;
-    }
-	
 	public boolean wasConfigured() {
 		return configured;
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.github.tomakehurst.wiremock.common.Strings;
 import com.google.common.base.Optional;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeaders.noHeaders;
@@ -61,7 +62,7 @@ public class Response {
         this.status = status;
         this.statusMessage = statusMessage;
         this.headers = headers;
-        this.body = body == null ? null : body.getBytes(headers.getContentTypeHeader().encodingOrUtf8());
+        this.body = body == null ? null : Strings.bytesFromString(body, headers.getContentTypeHeader().charset());
         this.configured = configured;
         this.fault = fault;
         this.fromProxy = fromProxy;
@@ -80,7 +81,7 @@ public class Response {
     }
 	
 	public String getBodyAsString() {
-        return new String(body, headers.getContentTypeHeader().encodingOrUtf8());
+        return Strings.stringFromBytes(body, headers.getContentTypeHeader().charset());
 	}
 	
 	public HttpHeaders getHeaders() {

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestQueryAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestQueryAcceptanceTest.java
@@ -17,9 +17,11 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.Dates;
+import com.github.tomakehurst.wiremock.common.Encoding;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit.Stubbing;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.testsupport.MappingJsonSamples;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
@@ -145,9 +147,23 @@ public class RequestQueryAcceptanceTest extends AcceptanceTestBase {
         ServeEvent two = serveEvents.get(1);
         assertThat(two.isNoExactMatch(), is(false));
         assertThat(two.getRequest().getUrl(), is("/two"));
-        assertThat(two.getResponse().getBody(), is("Exactly 2"));
+        assertThat(two.getResponse().getBody(), is("Exactly 2".getBytes()));
+        assertThat(two.getResponse().getBodyAsString(), is("Exactly 2"));
+        assertThat(two.getResponse().getBodyAsBase64(), is(Encoding.encodeBase64("Exactly 2".getBytes())));
 
         assertThat(serveEvents.get(2).isNoExactMatch(), is(true));
+    }
+
+    @Test
+    public void getAllServeEventsPreservesBinaryBody() {
+        dsl.stubFor(any(anyUrl())
+            .willReturn(aResponse().withBody(MappingJsonSamples.BINARY_COMPRESSED_CONTENT)));
+
+        testClient.get("/");
+
+        List<ServeEvent> serveEvents = getAllServeEvents();
+        ServeEvent serveEvent = serveEvents.get(0);
+        assertThat(serveEvent.getResponse().getBody(), is(MappingJsonSamples.BINARY_COMPRESSED_CONTENT));
     }
 
     private Matcher<LoggedRequest> withUrl(final String url) {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.github.tomakehurst.wiremock.common.Strings;
 import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
 import com.google.common.base.Optional;
 import org.jmock.Mockery;
@@ -104,20 +105,20 @@ public class ContentTypeHeaderTest {
 	}
 
 	@Test
-	public void returnsEncodingWhenPresent() {
+	public void returnsCharsetWhenPresent() {
 		ContentTypeHeader header = new ContentTypeHeader("text/plain; charset=iso-8859-1");
-		assertThat(header.encodingOrUtf8(), is(StandardCharsets.ISO_8859_1));
+		assertThat(header.charset(), is(StandardCharsets.ISO_8859_1));
 	}
 
 	@Test
-	public void returnsUtf8WhenEncodingNotPresent() {
+	public void returnsDefaultCharsetWhenEncodingNotPresent() {
 		ContentTypeHeader header = new ContentTypeHeader("text/plain");
-		assertThat(header.encodingOrUtf8(), is(StandardCharsets.UTF_8));
+		assertThat(header.charset(), is(Strings.DEFAULT_CHARSET));
 	}
 
 	@Test
-	public void returnsUtf8WhenAbsent() {
+	public void returnsDefaultCharsetWhenAbsent() {
 		ContentTypeHeader header = ContentTypeHeader.absent();
-		assertThat(header.encodingOrUtf8(), is(StandardCharsets.UTF_8));
+		assertThat(header.charset(), is(Strings.DEFAULT_CHARSET));
 	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -23,6 +23,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
@@ -99,5 +101,23 @@ public class ContentTypeHeaderTest {
 	public void returnsNullFromMimeTypePartWhenContentTypeIsAbsent() {
 		ContentTypeHeader header = ContentTypeHeader.absent();
 		assertThat(header.mimeTypePart(), is(nullValue()));
+	}
+
+	@Test
+	public void returnsEncodingWhenPresent() {
+		ContentTypeHeader header = new ContentTypeHeader("text/plain; charset=iso-8859-1");
+		assertThat(header.encodingOrUtf8(), is(StandardCharsets.ISO_8859_1));
+	}
+
+	@Test
+	public void returnsUtf8WhenEncodingNotPresent() {
+		ContentTypeHeader header = new ContentTypeHeader("text/plain");
+		assertThat(header.encodingOrUtf8(), is(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	public void returnsUtf8WhenAbsent() {
+		ContentTypeHeader header = ContentTypeHeader.absent();
+		assertThat(header.encodingOrUtf8(), is(StandardCharsets.UTF_8));
 	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedResponseTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedResponseTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.*;
 
 public class LoggedResponseTest {
     private static String ISO_8859_1_RESPONSE_BODY = "köttfärssås";
+    private static String UTF8_RESPONSE_BODY = "Foo © bar 𝌆 baz ☃ qux";
 
     @Test
     public void returnsEmptyStringForBodyWhenNotConfigured() {
@@ -37,7 +38,7 @@ public class LoggedResponseTest {
         LoggedResponse loggedResponse = LoggedResponse.from(Response
                 .response()
                 .body(ISO_8859_1_RESPONSE_BODY)
-                .headers(new HttpHeaders(httpHeader("Content-Type", "text/plain; charset=utf-8")))
+                .headers(new HttpHeaders(httpHeader("Content-Type", "text/plain; charset=iso-8859-1")))
                 .build()
         );
         assertThat(ISO_8859_1_RESPONSE_BODY, is(equalTo(loggedResponse.getBodyAsString())));
@@ -47,9 +48,9 @@ public class LoggedResponseTest {
     public void returnsUtf8StringForBodyWhenContentTypeHeaderAbsent() {
         LoggedResponse loggedResponse = LoggedResponse.from(Response
             .response()
-            .body("foobar")
+            .body(UTF8_RESPONSE_BODY)
             .build()
         );
-        assertThat("foobar", is(equalTo(loggedResponse.getBodyAsString())));
+        assertThat(UTF8_RESPONSE_BODY, is(equalTo(loggedResponse.getBodyAsString())));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedResponseTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedResponseTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.verification;
+
+import com.github.tomakehurst.wiremock.http.*;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+
+public class LoggedResponseTest {
+    private static String ISO_8859_1_RESPONSE_BODY = "köttfärssås";
+
+    @Test
+    public void returnsEmptyStringForBodyWhenNotConfigured() {
+        LoggedResponse loggedResponse = LoggedResponse.from(Response.notConfigured());
+        assertEquals(loggedResponse.getBodyAsString(), "");
+    }
+
+    @Test
+    public void returnsEncodedStringForBodyWhenContentTypeHeaderGiven() {
+        LoggedResponse loggedResponse = LoggedResponse.from(Response
+                .response()
+                .body(ISO_8859_1_RESPONSE_BODY)
+                .headers(new HttpHeaders(httpHeader("Content-Type", "text/plain; charset=utf-8")))
+                .build()
+        );
+        assertThat(ISO_8859_1_RESPONSE_BODY, is(equalTo(loggedResponse.getBodyAsString())));
+    }
+
+    @Test
+    public void returnsUtf8StringForBodyWhenContentTypeHeaderAbsent() {
+        LoggedResponse loggedResponse = LoggedResponse.from(Response
+            .response()
+            .body("foobar")
+            .build()
+        );
+        assertThat("foobar", is(equalTo(loggedResponse.getBodyAsString())));
+    }
+}


### PR DESCRIPTION
While working on the snapshot feature, I discovered that binary response bodies were getting corrupted. This is happening because the `LoggedResponse.from()` method sets the body by calling `Response.getBodyAsString()`, which encodes the body in the charset for the content type header (or UTF-8, if that's absent). Any invalid characters in the body get silently replaced with the default replacement character (U+FFFD for Unicode).

I fixed this by just copying what `LoggedRequest` is doing: instantiate the body using a Base64-encoded string and have a `getBodyAsString()` method that does necessary encoding.

I moved the `Response.encodingFromContentTypeHeaderOrUtf8()` method to `ContentTypeHeader.encodingOrUtf8()` so both `Response` and `LoggedResponse` could use it.