### PR TITLE
obeying the charset specified in the content-type header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -351,7 +351,6 @@ task npmInstall(type: Exec) {
     commandLine 'npm', 'i'
 }
 
-/*
 task generateApiDocs(type: Exec) {
     dependsOn npmInstall
     workingDir 'docs-v2'
@@ -359,7 +358,6 @@ task generateApiDocs(type: Exec) {
 }
 jar.dependsOn generateApiDocs
 processResources.dependsOn generateApiDocs
-*/
 
 task deleteGeneratedApiDocs(type: Delete) {
     delete "src/main/resources/swagger"

--- a/build.gradle
+++ b/build.gradle
@@ -351,6 +351,7 @@ task npmInstall(type: Exec) {
     commandLine 'npm', 'i'
 }
 
+/*
 task generateApiDocs(type: Exec) {
     dependsOn npmInstall
     workingDir 'docs-v2'
@@ -358,6 +359,7 @@ task generateApiDocs(type: Exec) {
 }
 jar.dependsOn generateApiDocs
 processResources.dependsOn generateApiDocs
+*/
 
 task deleteGeneratedApiDocs(type: Delete) {
     delete "src/main/resources/swagger"

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ContentTypes.java
@@ -90,7 +90,7 @@ public class ContentTypes {
             return substringAfterLast(lastPathSegment, ".");
         }
 
-        return determineTextFileExtension(stringFromBytes(responseBody));
+        return determineTextFileExtension(stringFromBytes(responseBody, contentTypeHeader.charset()));
     }
 
     public static String determineTextFileExtension(String content) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Strings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Strings.java
@@ -15,16 +15,21 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import java.nio.charset.Charset;
 import static com.google.common.base.Charsets.UTF_8;
 
 public class Strings {
 
     public static String stringFromBytes(byte[] bytes) {
+        return stringFromBytes(bytes, UTF_8);
+    }
+
+    public static String stringFromBytes(byte[] bytes, Charset cset) {
         if (bytes == null) {
             return null;
         }
 
-        return new String(bytes, UTF_8);
+        return new String(bytes, cset);
     }
 
     public static byte[] bytesFromString(String str) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -16,6 +16,8 @@
 package com.github.tomakehurst.wiremock.http;
 
 import com.google.common.base.Optional;
+import java.nio.charset.Charset;
+import static com.google.common.base.Charsets.UTF_8;
 
 public class ContentTypeHeader extends HttpHeader {
 
@@ -53,4 +55,14 @@ public class ContentTypeHeader extends HttpHeader {
 
 		return Optional.absent();
 	}
+
+    public Charset charset() {
+        if (isPresent()) {
+            Optional<String> encoding = encodingPart();
+            if (encoding.isPresent()) {
+                return Charset.forName(encoding.get());
+            }
+        }
+        return UTF_8;
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -96,11 +96,7 @@ public class Response {
 
     private Charset encodingFromContentTypeHeaderOrUtf8() {
         ContentTypeHeader contentTypeHeader = headers.getContentTypeHeader();
-        if (contentTypeHeader.isPresent() && contentTypeHeader.encodingPart().isPresent()) {
-            return Charset.forName(contentTypeHeader.encodingPart().get());
-        }
-
-        return UTF_8;
+        return contentTypeHeader.charset();   
     }
 	
 	public boolean wasConfigured() {

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -24,6 +24,9 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.*;
 
+import java.nio.charset.Charset;
+import static com.google.common.base.Charsets.UTF_8;
+
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
@@ -103,6 +106,14 @@ public class WireMockHttpServletRequestAdapter implements Request {
         return cachedBody;
     }
 
+    private Charset encodingFromContentTypeHeaderOrUtf8() {
+        ContentTypeHeader contentTypeHeader = contentTypeHeader();
+        if (contentTypeHeader != null) {
+            return contentTypeHeader.charset();
+        } 
+        return UTF_8;
+    }
+
     private boolean hasGzipEncoding() {
         String encodingHeader = request.getHeader("Content-Encoding");
         return encodingHeader != null && encodingHeader.contains("gzip");
@@ -110,7 +121,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
 
     @Override
     public String getBodyAsString() {
-        return stringFromBytes(getBody());
+        return stringFromBytes(getBody(), encodingFromContentTypeHeaderOrUtf8());
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -29,6 +29,9 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Set;
 
+import java.nio.charset.Charset;
+import static com.google.common.base.Charsets.UTF_8;
+
 import static com.github.tomakehurst.wiremock.common.Encoding.decodeBase64;
 import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
@@ -125,7 +128,18 @@ public class LoggedRequest implements Request {
 
     @Override
     public ContentTypeHeader contentTypeHeader() {
-        return headers.getContentTypeHeader();
+        if (headers != null) {
+            return headers.getContentTypeHeader();
+        } 
+        return null;
+    }
+
+    private Charset encodingFromContentTypeHeaderOrUtf8() {
+        ContentTypeHeader contentTypeHeader = contentTypeHeader();
+        if (contentTypeHeader != null) {
+            return contentTypeHeader.charset();
+        }
+        return UTF_8;
     }
 
     @Override
@@ -146,7 +160,7 @@ public class LoggedRequest implements Request {
     @Override
     @JsonProperty("body")
     public String getBodyAsString() {
-        return stringFromBytes(body);
+        return stringFromBytes(body, encodingFromContentTypeHeaderOrUtf8());
     }
 
     @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
@@ -37,6 +37,28 @@ public class MappingsAcceptanceTest extends AcceptanceTestBase {
 	}
 	
 	@Test
+	public void basicMappingCheckNonUtf8() {
+                String mapping = MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8;
+		testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8, "GB2312");
+		
+		WireMockResponse response = testClient.get("/test/nonutf8/");
+		
+		assertThat(response.statusCode(), is(200));
+		assertThat(response.content(), is("国家标准"));
+        }
+
+	@Test
+	public void basicMappingCheckCharsetMismatch() {
+                String mapping = MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8;
+		testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8, "ISO-8859-8");
+		
+		WireMockResponse response = testClient.get("/test/nonutf8/");
+		
+		assertThat(response.statusCode(), is(200));
+		assertThat(response.content(), is("????")); // charset in request doesn't match body content
+        }
+
+	@Test
 	public void basicMappingWithExactUrlAndMethodMatchIsCreatedAndReturned() {
 		testClient.addResponse(MappingJsonSamples.BASIC_MAPPING_REQUEST_WITH_RESPONSE_HEADER);
 		

--- a/src/test/java/com/github/tomakehurst/wiremock/RequestQueryAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RequestQueryAcceptanceTest.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
+import static com.google.common.base.Charsets.UTF_8;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -118,7 +119,7 @@ public class RequestQueryAcceptanceTest extends AcceptanceTestBase {
     @Test
     public void requestBodyEncodingRemainsUtf8() {
         byte[] body = new byte[] { -38, -100 }; // UTF-8 bytes for ڜ
-        testClient.post("/encoding", new ByteArrayEntity(body, ContentType.TEXT_PLAIN));
+        testClient.post("/encoding", new ByteArrayEntity(body, ContentType.TEXT_PLAIN.withCharset(UTF_8)));
 
         List<LoggedRequest> requests = findAll(postRequestedFor(urlEqualTo("/encoding")));
         LoggedRequest request = requests.get(0);

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
@@ -233,4 +233,16 @@ public class MappingJsonSamples {
             "		\"base64Body\": \""+ BINARY_COMPRESSED_JSON_STRING + "\"	    \n" +
             "	}												                    \n" +
             "}													                    ";
+
+    public static final String MAPPING_REQUEST_FOR_NON_ENGLISH =
+            "{                                                                                                                      \n" +
+            "   \"request\": {                                                                                      \n" +
+            "           \"method\": \"GET\",                                                                \n" +
+            "           \"url\": \"/test/nonenglish/\"                         \n" +
+            "   },                                                                                                                  \n" +
+            "   \"response\": {                                                                                     \n" +
+            "           \"status\": 200,                                                                            \n" +
+            "           \"body\": \"Asegúrate de que tu consulta está bien escrita.\"            \n" +
+            "   }                                                                                                                   \n" +
+            "}\n";
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
@@ -234,15 +234,19 @@ public class MappingJsonSamples {
             "	}												                    \n" +
             "}													                    ";
 
-    public static final String MAPPING_REQUEST_FOR_NON_ENGLISH =
+    public static final String MAPPING_REQUEST_FOR_NON_UTF8 =
             "{                                                                                                                      \n" +
             "   \"request\": {                                                                                      \n" +
             "           \"method\": \"GET\",                                                                \n" +
-            "           \"url\": \"/test/nonenglish/\"                         \n" +
+            "           \"url\": \"/test/nonutf8/\"                         \n" +
             "   },                                                                                                                  \n" +
             "   \"response\": {                                                                                     \n" +
             "           \"status\": 200,                                                                            \n" +
-            "           \"body\": \"Asegúrate de que tu consulta está bien escrita.\"            \n" +
-            "   }                                                                                                                   \n" +
+            "           \"headers\": {                                                    \n" +
+            "               \"Content-type\": \"text/plain; charset=GB2312\"      \n" +
+            "           },                                                    \n" +
+            "           \"body\": \"国家标准\"                       \n" +
+            "   }                                                                                          \n" +
             "}\n";
+
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -185,7 +185,11 @@ public class WireMockTestClient {
     }
 
     public void addResponse(String responseSpecJson) {
-        int status = postJsonAndReturnStatus(newMappingUrl(), responseSpecJson);
+        addResponse(responseSpecJson, "utf-8");
+    }
+
+    public void addResponse(String responseSpecJson, String charset) {
+        int status = postJsonAndReturnStatus(newMappingUrl(), responseSpecJson, charset);
         if (status != HTTP_CREATED) {
             throw new RuntimeException("Returned status code was " + status);
         }
@@ -206,10 +210,14 @@ public class WireMockTestClient {
     }
 
     private int postJsonAndReturnStatus(String url, String json) {
+        return postJsonAndReturnStatus(url, json, "utf-8");
+    }
+
+    private int postJsonAndReturnStatus(String url, String json, String charset) {
         HttpPost post = new HttpPost(url);
         try {
             if (json != null) {
-                post.setEntity(new StringEntity(json, ContentType.create(JSON.toString(), "utf-8")));
+                post.setEntity(new StringEntity(json, ContentType.create(JSON.toString(), charset)));
             }
             HttpResponse httpResponse = httpClient().execute(post);
             return httpResponse.getStatusLine().getStatusCode();


### PR DESCRIPTION
Wiremock was not considering the charset of the submitted data.  The clearest example of this was in the existing unit test requestBodyEncodingRemainsUtf8().  The test posts a body containing utf-8 data, but specifies a content type of ContentType.TEXT_PLAIN, which attaches a HTTP header of "Content-Type" : "text/plain; charset=ISO-8859-1" to the post.   So in this test, the body's charset does not match what is advertised in content-type header, yet the test passed because the request-handling methods ignored the charset value, assuming the submitted content would be utf-8.  

In these changes, I've modified the Wiremock code to use the charset of the submitted data, falling back to utf-8 if the charset is not specified.  
