### PR TITLE
Refactoring to extract URL path logic to a method

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGenerator.java
@@ -15,36 +15,17 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import com.github.tomakehurst.wiremock.http.Request;
-import com.google.common.base.Joiner;
-
 import java.net.URI;
-
-import static com.google.common.base.Splitter.on;
-import static com.google.common.collect.FluentIterable.from;
-import static com.google.common.collect.Iterables.size;
-import static java.lang.Math.min;
 
 public class UniqueFilenameGenerator {
 
-    public static String generate(Request request, String prefix, String id) {
-        return generate(request, prefix, id, "json");
+    public static String generate(String url, String prefix, String id) {
+        return generate(url, prefix, id, "json");
     }
 
-    public static String generate(Request request, String prefix, String id, String extension) {
-        URI uri = URI.create(request.getUrl());
-        Iterable<String> uriPathNodes = on("/").omitEmptyStrings().split(uri.getPath());
-        int nodeCount = size(uriPathNodes);
-
-        String pathPart = nodeCount > 0 ?
-                sanitise(
-                    Joiner.on("-")
-                    .join(from(uriPathNodes)
-                        .skip(nodeCount - min(nodeCount, 2))
-                    )
-                ):
-                "(root)";
-
+    public static String generate(String url, String prefix, String id, String extension) {
+        String pathPart = Urls.urlToPathParts(URI.create(url));
+        pathPart = pathPart.equals("") ? "(root)" : sanitise(pathPart);
 
         return new StringBuilder(prefix)
                 .append("-")

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Urls.java
@@ -16,9 +16,11 @@
 package com.github.tomakehurst.wiremock.common;
 
 import com.github.tomakehurst.wiremock.http.QueryParameter;
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
 import java.io.UnsupportedEncodingException;
@@ -29,6 +31,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.google.common.collect.FluentIterable.from;
 
 public class Urls {
 
@@ -55,6 +58,18 @@ public class Urls {
                 return new QueryParameter(key, ImmutableList.copyOf(values));
             }
         });
+    }
+
+    public static String urlToPathParts(URI uri) {
+        Iterable<String> uriPathNodes = Splitter.on("/").omitEmptyStrings().split(uri.getPath());
+        int nodeCount = Iterables.size(uriPathNodes);
+
+        return nodeCount > 0 ?
+            Joiner.on("-")
+            .join(from(uriPathNodes)
+                .skip(nodeCount - Math.min(nodeCount, 2))
+            ):
+            "";
     }
 
     public static Map<String, QueryParameter> splitQuery(URI uri) {

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorder.java
@@ -99,9 +99,9 @@ public class StubMappingJsonRecorder implements RequestListener {
         String fileId = idGenerator.generate();
         byte[] body = bodyDecompressedIfRequired(response);
 
-        String mappingFileName = UniqueFilenameGenerator.generate(request, "mapping", fileId);
+        String mappingFileName = UniqueFilenameGenerator.generate(request.getUrl(), "mapping", fileId);
         String bodyFileName = UniqueFilenameGenerator.generate(
-            request,
+            request.getUrl(),
             "body",
             fileId,
             ContentTypes.determineFileExtension(

--- a/src/test/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGeneratorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UniqueFilenameGeneratorTest.java
@@ -15,30 +15,17 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import org.jmock.Mockery;
-import org.jmock.integration.junit4.JMock;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-@RunWith(JMock.class)
 public class UniqueFilenameGeneratorTest {
-
-    private Mockery context;
-
-    @Before
-    public void init() {
-        context = new Mockery();
-    }
 
     @Test
     public void generatesValidNameWhenRequestHasUrlWithTwoPathNodes() {
         String fileName = UniqueFilenameGenerator.generate(
-                aRequest(context).withUrl("/some/path").build(),
+                "/some/path",
                 "body",
                 "random123");
 
@@ -48,7 +35,7 @@ public class UniqueFilenameGeneratorTest {
     @Test
     public void generatesValidNameWhenRequestHasUrlWithOnePathNode() {
         String fileName = UniqueFilenameGenerator.generate(
-                aRequest(context).withUrl("/thing").build(),
+                "/thing",
                 "body",
                 "random123");
 
@@ -58,7 +45,7 @@ public class UniqueFilenameGeneratorTest {
     @Test
     public void generatesValidNameWhenRequestHasRootPath() {
         String fileName = UniqueFilenameGenerator.generate(
-                aRequest(context).withUrl("/").build(),
+                "/",
                 "body",
                 "random123");
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/UrlsTest.java
@@ -58,4 +58,22 @@ public class UrlsTest {
         Map<String, QueryParameter> query = Urls.splitQuery(url);
         assertThat(query.get("q").firstValue(), is("a%b"));
     }
+
+    @Test
+    public void returnsEmptyStringForEmptyUrlPathParts() {
+        assertThat(Urls.urlToPathParts(URI.create("/")), is(""));
+        assertThat(Urls.urlToPathParts(URI.create("http://www.wiremock.org/")), is(""));
+    }
+
+    @Test
+    public void returnsNonDelimitedStringForUrlWithOnePathPart() {
+        String pathParts = Urls.urlToPathParts(URI.create("/foo?param=value"));
+        assertThat(pathParts, is("foo"));
+    }
+
+    @Test
+    public void returnsDelimitedStringForUrlWithTwoPathParts() {
+        String pathParts = Urls.urlToPathParts(URI.create("/foo/bar/?param=value"));
+        assertThat(pathParts, is("foo-bar"));
+    }
 }


### PR DESCRIPTION
This is split off from PR #674  to make it easier to review. I extracted some logic in `UniqueFilenameGenerator` for turning URL paths into a hyphen-delimited string over to a method in Urls, `urlToPathParts()`, and wrote tests for it. I also changed `UniqueFilenameGenerator` to accept a URL string instead of a Request so it can be used by the Snapshot API in PR #674.