### PR TITLE
Update docs to extending docs to new getName method

### DIFF
--- a/docs-v2/_docs/extending-wiremock.md
+++ b/docs-v2/_docs/extending-wiremock.md
@@ -77,7 +77,7 @@ public static class ExampleTransformer extends ResponseDefinitionTransformer {
         }
 
         @Override
-        public String name() {
+        public String getName() {
             return "example";
         }
     }
@@ -186,7 +186,7 @@ public static class StubResponseTransformerWithParams extends ResponseTransforme
         }
 
         @Override
-        public String name() {
+        public String getName() {
             return "stub-transformer-with-params";
         }
 }


### PR DESCRIPTION
Seems that that the documentation is behind.  My IDE had me override 'getName' instead of 'name'.  Hope this is correct.