### PR TITLE
Add absolute url in the RequestTemplateModel tomakehurst/wiremock#717

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 public class RequestTemplateModel {
 
+    private final String absoluteUrl;
     private final String url;
     private final UrlPath path;
     private final Map<String, ListOrSingle<String>> query;
@@ -21,7 +22,8 @@ public class RequestTemplateModel {
     private final String body;
 
 
-    public RequestTemplateModel(String url, UrlPath path, Map<String, ListOrSingle<String>> query, Map<String, ListOrSingle<String>> headers, Map<String, ListOrSingle<String>> cookies, String body) {
+    public RequestTemplateModel(String absoluteUrl, String url, UrlPath path, Map<String, ListOrSingle<String>> query, Map<String, ListOrSingle<String>> headers, Map<String, ListOrSingle<String>> cookies, String body) {
+        this.absoluteUrl = absoluteUrl;
         this.url = url;
         this.path = path;
         this.query = query;
@@ -50,6 +52,7 @@ public class RequestTemplateModel {
         UrlPath path = new UrlPath(request.getUrl());
 
         return new RequestTemplateModel(
+            request.getAbsoluteUrl(),
             request.getUrl(),
             path,
             adaptedQuery,
@@ -57,6 +60,10 @@ public class RequestTemplateModel {
             adaptedCookies,
             request.getBodyAsString()
         );
+    }
+
+    public String getAbsoluteUrl() {
+        return absoluteUrl;
     }
 
     public String getUrl() {


### PR DESCRIPTION
Looking for comment about this first attempt.
In particular I look to have feedback on the change in the signature of the public constructor. It doesn't seems to cause issues in the project and I don't see why some other codebase would want to reuse this class but arguably I don't have the full picture.

A solution might be to have 2 constructors. Alternatively if nobody is meant to directly instantiate this class (but use the static method `RequestTemplateModel from(final Request request)`) then what about making the constructor private (or protected)?

