### PR TITLE
added wiremock exclusive handlebars helpers:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     compile 'com.github.jknack:handlebars:4.0.6', {
         exclude group: 'org.mozilla', module: 'rhino'
     }
+    compile 'com.jayway.jsonpath:json-path:2.2.0'
 
     testCompile "org.hamcrest:hamcrest-all:1.3"
     testCompile("org.jmock:jmock:2.5.1") {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.TextFile;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.WiremockHelpers;
 import com.github.tomakehurst.wiremock.http.HttpHeader;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.Request;
@@ -59,6 +60,11 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
         handlebars = new Handlebars();
 
         for (StringHelpers helper: StringHelpers.values()) {
+            handlebars.registerHelper(helper.name(), helper);
+        }
+
+        //Add all available wiremock helpers
+        for(WiremockHelpers helper: WiremockHelpers.values()){
             handlebars.registerHelper(helper.name(), helper);
         }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelper.java
@@ -1,0 +1,54 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Helper;
+
+import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
+
+/**
+ * This abstract class is the base for all defined Handlebars helper in wiremock. It basically allows simpler error
+ * handling.
+ *
+ * @param <T> Type used as context for the Handlebars helper.
+ * @author Christopher Holomek
+ */
+public abstract class HandlebarsHelper<T> implements Helper<T> {
+    public static final String ERROR_PREFIX = "Handlebars Helper Error: ";
+
+
+    /**
+     * Handle invalid helper data without exception details or because none was thrown.
+     *
+     * @param message message to log and return
+     * @return a message which will be used as content
+     */
+    protected String handleError(final String message) {
+        notifier().error(ERROR_PREFIX + message);
+        return ERROR_PREFIX + message;
+    }
+
+    /**
+     * Handle invalid helper data with exception details in the log message.
+     *
+     * @param message message to log and return
+     * @param cause   which occurred during application of the helper
+     * @return a message which will be used as content
+     */
+    protected String handleError(final String message, final Throwable cause) {
+        notifier().error(ERROR_PREFIX + message, cause);
+        return ERROR_PREFIX + message;
+    }
+
+    /**
+     * Handle invalid helper data with exception details in the log message. Also additional information regarding the
+     * issue is written in the logs.
+     *
+     * @param message      message to log and return
+     * @param logExclusive additional information just for the log
+     * @param cause        which occured during application of the helper
+     * @return a message which will be used as content
+     */
+    protected String handleError(final String message, final String logExclusive, final Throwable cause) {
+        notifier().error(ERROR_PREFIX + message + " - " + logExclusive, cause);
+        return ERROR_PREFIX + message;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelper.java
@@ -1,0 +1,33 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.JsonPath;
+
+import java.io.IOException;
+
+
+/**
+ * This class uses JsonPath from jayway for reading a json via jsonPath so that the result can be used for response
+ * templating.
+ *
+ * @author Christopher Holomek
+ */
+public class HandlebarsJsonHelper extends HandlebarsHelper<String> {
+
+    @Override
+    public Object apply(final String context, final Options options) throws IOException {
+        if (context == null || options == null || options.param(0, null) == null) {
+            return this.handleError("HandlebarsJsonHelper: No parameters defined. Helper not applied");
+        }
+
+        final String jsonPath = options.param(0);
+        try {
+            return String.valueOf(JsonPath.read(context, jsonPath));
+        } catch (final InvalidJsonException e) {
+            return this.handleError(
+                    "HandlebarsJsonHelper: An error occurred. Helper not applied. See cause for more details.",
+                    e.getJson(), e);
+        }
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelper.java
@@ -3,6 +3,7 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.jknack.handlebars.Options;
 import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.JsonPathException;
 
 import java.io.IOException;
 
@@ -28,6 +29,9 @@ public class HandlebarsJsonHelper extends HandlebarsHelper<String> {
             return this.handleError(
                     "HandlebarsJsonHelper: An error occurred. Helper not applied. See cause for more details.",
                     e.getJson(), e);
+        }catch(final JsonPathException e){
+            return this.handleError(
+                    "HandlebarsJsonHelper: An error occurred. Helper not applied. See cause for more details.", e);
         }
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelper.java
@@ -1,0 +1,15 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+/**
+ * This class uses HandlebarsXmlHelper as a base an just set a prefix which reduce the written handlebars helper to the
+ * relevant part
+ *
+ * @author Christopher Holomek
+ */
+public class HandlebarsSoapHelper extends HandlebarsXmlHelper {
+
+    @Override
+    protected String getXPathPrefix() {
+        return "/Envelope/Body/";
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXmlHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXmlHelper.java
@@ -1,0 +1,60 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.StringReader;
+
+/**
+ * This class uses javax.xml.xpath.* for reading a xml via xPath so that the result can be used for response
+ * templating.
+ *
+ * @author Christopher Holomek
+ */
+public class HandlebarsXmlHelper extends HandlebarsHelper<String> {
+
+    @Override
+    public Object apply(final String context, final Options options) throws IOException {
+        if (context == null || options == null || options.param(0, null) == null) {
+            return this.handleError(this.getClass().getSimpleName() + ": No parameters defined. Helper not applied");
+        }
+
+        final String xPathInput = options.param(0);
+
+        try (final StringReader reader = new StringReader(context)) {
+            final InputSource source = new InputSource(reader);
+
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            final Document doc = builder.parse(source);
+
+            final XPathFactory xPathfactory = XPathFactory.newInstance();
+            final XPath xpath = xPathfactory.newXPath();
+
+            return xpath.evaluate(getXPathPrefix() + xPathInput, doc);
+
+        } catch (SAXException | XPathExpressionException | ParserConfigurationException e) {
+            return this.handleError(this.getClass().getSimpleName() + ": An error occurred. Helper not applied.", e);
+        }
+    }
+
+
+    /**
+     * No prefix by default. It allows to extend this class with a specified prefix. Just overwrite this method to do
+     * so.
+     *
+     * @return a prefix which will be applied before the specified xpath.
+     */
+    protected String getXPathPrefix() {
+        return "";
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WiremockHelpers.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/WiremockHelpers.java
@@ -1,0 +1,39 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+import java.io.IOException;
+
+/**
+ * This enum is implemented similar to the StringHelpers of handlebars.
+ * It is basically a library of all available wiremock helpers
+ *
+ * @author Christopher Holomek
+ */
+public enum WiremockHelpers implements Helper<Object> {
+    wmXml {
+        private HandlebarsXmlHelper helper = new HandlebarsXmlHelper();
+
+        @Override
+        public Object apply(final Object context, final Options options) throws IOException {
+            return this.helper.apply(String.valueOf(context), options);
+        }
+    },
+    wmSoap {
+        private HandlebarsSoapHelper helper = new HandlebarsSoapHelper();
+
+        @Override
+        public Object apply(final Object context, final Options options) throws IOException {
+            return this.helper.apply(String.valueOf(context), options);
+        }
+    },
+    wmJson {
+        private HandlebarsJsonHelper helper = new HandlebarsJsonHelper();
+
+        @Override
+        public Object apply(final Object context, final Options options) throws IOException {
+            return this.helper.apply(String.valueOf(context), options);
+        }
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelperTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelperTestBase.java
@@ -1,0 +1,42 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This class is the test base for all handlebars helper
+ *
+ * @author Christopher Holomek
+ */
+public abstract class HandlebarsHelperTestBase {
+
+    protected static final String FAIL_GRACEFULLY_MSG = "Handlebars helper should fail gracefully and show the issue directly in the response.";
+
+    protected static <T> void testHelperError(final Helper<T> helper,
+                                              final T content, final String xPath) {
+        try {
+            assertThat((String) helper.apply(content, createOptions(xPath)), startsWith(HandlebarsHelper.ERROR_PREFIX));
+        } catch (final IOException e) {
+            Assert.fail(FAIL_GRACEFULLY_MSG);
+        }
+    }
+
+    protected static <T> void testHelper(final Helper<T> helper,
+                                         final T content, final String optionParam, final String expected) throws
+                                                                                                           IOException {
+        assertThat((String) helper.apply(content, createOptions(optionParam)), is(expected));
+    }
+
+    protected static Options createOptions(final String optionParam) {
+        return new Options(null, null, null, null, null, null,
+                           new Object[]{optionParam}, null, new ArrayList<String>(0));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelperTest.java
@@ -1,0 +1,51 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This class tests the HandlebarsJsonHelper
+ *
+ * @author Christopher Holomek
+ */
+public class HandlebarsJsonHelperTest extends HandlebarsHelperTestBase {
+
+    private HandlebarsJsonHelper helper;
+
+    @Before
+    public void init() {
+        this.helper = new HandlebarsJsonHelper();
+    }
+
+    @Test
+    public void positiveTestSimpleJson() throws IOException {
+        testHelper(this.helper, "{\"test\":\"success\"}", "$.test", "success");
+    }
+
+    @Test
+    public void negativeTestInvalidJson() {
+        testHelperError(this.helper, "{\"test\":\"success}", "$.test");
+    }
+
+    @Test
+    public void negativeTestInvalidJsonPath() {
+        testHelperError(this.helper, "{\"test\":\"success}", "$.\\test");
+    }
+
+    @Test
+    public void negativeTestJsonNull() {
+        testHelperError(this.helper, null, "$.test");
+    }
+
+    @Test
+    public void negativeTestJsonPathNull() {
+        testHelperError(this.helper, "{\"test\":\"success}", null);
+    }
+
+    @Test
+    public void negativeTestAllNull() {
+        testHelperError(this.helper, null, null);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonHelperTest.java
@@ -1,9 +1,19 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static com.github.tomakehurst.wiremock.testsupport.NoFileSource.noFileSource;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
 
 /**
  * This class tests the HandlebarsJsonHelper
@@ -13,15 +23,41 @@ import java.io.IOException;
 public class HandlebarsJsonHelperTest extends HandlebarsHelperTestBase {
 
     private HandlebarsJsonHelper helper;
+    private ResponseTemplateTransformer transformer;
 
     @Before
     public void init() {
         this.helper = new HandlebarsJsonHelper();
+        this.transformer = new ResponseTemplateTransformer(true);
     }
 
     @Test
     public void positiveTestSimpleJson() throws IOException {
         testHelper(this.helper, "{\"test\":\"success\"}", "$.test", "success");
+    }
+
+    @Test
+    public void positiveTestResponseTemplate(){
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+                mockRequest().url("/json").body(
+                        "{\"a\": {\"test\": \"success\"}}"),
+                aResponse().withBody("{\"test\": \"{{wmJson request.body '$.a.test'}}\"}").build(),
+                noFileSource(),
+                Parameters.empty());
+
+        assertThat(responseDefinition.getBody(), is("{\"test\": \"success\"}"));
+    }
+
+    @Test
+    public void negativeTestResponseTemplate(){
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+                mockRequest().url("/json").body(
+                        "{\"a\": {\"test\": \"success\"}}"),
+                aResponse().withBody("{\"test\": \"{{wmJson request.body '$.b.test'}}\"}").build(),
+                noFileSource(),
+                Parameters.empty());
+
+        assertThat(responseDefinition.getBody(), startsWith("{\"test\": \"" + HandlebarsHelper.ERROR_PREFIX));
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelperTest.java
@@ -1,9 +1,18 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static com.github.tomakehurst.wiremock.testsupport.NoFileSource.noFileSource;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * This class tests the HandlebarsSoapHelper
@@ -13,14 +22,40 @@ import java.io.IOException;
 public class HandlebarsSoapHelperTest extends HandlebarsHelperTestBase {
 
     private HandlebarsSoapHelper helper;
+    private ResponseTemplateTransformer transformer;
 
     @Before
     public void init() {
         this.helper = new HandlebarsSoapHelper();
+        this.transformer = new ResponseTemplateTransformer(true);
     }
 
     @Test
     public void positiveTestSimpleSoap() throws IOException {
         testHelper(this.helper, "<Envelope><Body><test>success</test></Body></Envelope>", "/test", "success");
+    }
+
+    @Test
+    public void positiveTestResponseTemplate(){
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+                mockRequest().url("/soap").body(
+                        "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope/\"><soap:Body><m:a><m:test>success</m:test></m:a></soap:Body></soap:Envelope>"),
+                aResponse().withBody("<test>{{wmSoap request.body '/a/test'}}</test>").build(),
+                noFileSource(),
+                Parameters.empty());
+
+        assertThat(responseDefinition.getBody(), is("<test>success</test>"));
+    }
+
+    @Test
+    public void negativeTestResponseTemplate(){
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+                mockRequest().url("/soap").body(
+                        "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope/\"><soap:Body><m:a><m:test>success</m:test></m:a></soap:Body></soap:Envelope>"),
+                aResponse().withBody("<test>{{wmSoap request.body '/b/test'}}</test>").build(),
+                noFileSource(),
+                Parameters.empty());
+
+        assertThat(responseDefinition.getBody(), is("<test></test>"));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsSoapHelperTest.java
@@ -1,0 +1,26 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This class tests the HandlebarsSoapHelper
+ *
+ * @author Christopher Holomek
+ */
+public class HandlebarsSoapHelperTest extends HandlebarsHelperTestBase {
+
+    private HandlebarsSoapHelper helper;
+
+    @Before
+    public void init() {
+        this.helper = new HandlebarsSoapHelper();
+    }
+
+    @Test
+    public void positiveTestSimpleSoap() throws IOException {
+        testHelper(this.helper, "<Envelope><Body><test>success</test></Body></Envelope>", "/test", "success");
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXmlHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXmlHelperTest.java
@@ -1,9 +1,19 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
+import static com.github.tomakehurst.wiremock.testsupport.NoFileSource.noFileSource;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
 
 /**
  * This class tests the HandlebarsXmlHelper
@@ -13,15 +23,39 @@ import java.io.IOException;
 public class HandlebarsXmlHelperTest extends HandlebarsHelperTestBase {
 
     private HandlebarsXmlHelper helper;
+    private ResponseTemplateTransformer transformer;
 
     @Before
     public void init() {
         this.helper = new HandlebarsXmlHelper();
+        this.transformer = new ResponseTemplateTransformer(true);
     }
 
     @Test
     public void positiveTestSimpleXml() throws IOException {
         testHelper(this.helper, "<test>success</test>", "/test", "success");
+    }
+
+    @Test
+    public void positiveTestResponseTemplate(){
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+                mockRequest().url("/xml").body("<a><test>success</test></a>"),
+                aResponse().withBody("<test>{{wmXml request.body '/a/test'}}</test>").build(),
+                noFileSource(),
+                Parameters.empty());
+
+        assertThat(responseDefinition.getBody(), is("<test>success</test>"));
+    }
+
+    @Test
+    public void negativeTestResponseTemplate(){
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+                mockRequest().url("/xml").body("<a><test>success</test></a>"),
+                aResponse().withBody("<test>{{wmXml request.body '/b/test'}}</test>").build(),
+                noFileSource(),
+                Parameters.empty());
+
+        assertThat(responseDefinition.getBody(), startsWith("<test></test>"));
     }
 
     @Test
@@ -48,4 +82,6 @@ public class HandlebarsXmlHelperTest extends HandlebarsHelperTestBase {
     public void negativeTestAllNull() {
         testHelperError(this.helper, null, null);
     }
+
+
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXmlHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsXmlHelperTest.java
@@ -1,0 +1,51 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * This class tests the HandlebarsXmlHelper
+ *
+ * @author Christopher Holomek
+ */
+public class HandlebarsXmlHelperTest extends HandlebarsHelperTestBase {
+
+    private HandlebarsXmlHelper helper;
+
+    @Before
+    public void init() {
+        this.helper = new HandlebarsXmlHelper();
+    }
+
+    @Test
+    public void positiveTestSimpleXml() throws IOException {
+        testHelper(this.helper, "<test>success</test>", "/test", "success");
+    }
+
+    @Test
+    public void negativeTestInvalidXml() {
+        testHelperError(this.helper, "<testsuccess</test>", "/test");
+    }
+
+    @Test
+    public void negativeTestInvalidXPath() {
+        testHelperError(this.helper, "<test>success</test>", "/\\test");
+    }
+
+    @Test
+    public void negativeTestXmlNull() {
+        testHelperError(this.helper, null, "/test");
+    }
+
+    @Test
+    public void negativeTestXPathNull() {
+        testHelperError(this.helper, "<test>success</test>", null);
+    }
+
+    @Test
+    public void negativeTestAllNull() {
+        testHelperError(this.helper, null, null);
+    }
+}


### PR DESCRIPTION
Hi,
as I promised in  #704 . Here the three helpers for xml, soap and json content. Xml and soap are plain old Java but Json via JsonPath uses a lib described below. I also added some tests. Here some other points:

1.  Feel free to rename the classes. I was not sure about the naming
2.  I was not sure about the handling of errors if xml/json or xPath/jsonPath are invalid. Currently it fails gracefully and shows an error message in the response. The intention was that it is easier to find the issue.

Best regards,
Christopher


-added com.jayway.jsonpath:json-path:2.2.0 to dependencies which allows the JsonPath implementation