### PR TITLE
Add convenience WireMockServer.url builder method

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -188,6 +188,18 @@ public class WireMockServer implements Container, Stubbing, Admin {
         return httpServer.httpsPort();
     }
 
+    public String url(String path) {
+        boolean https = options.httpsSettings().enabled();
+        String protocol = https ? "https" : "http";
+        int port = https ? httpsPort() : port();
+
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
+
+        return String.format("%s://localhost:%d%s", protocol, port, path);
+    }
+
     public boolean isRunning() {
         return httpServer.isRunning();
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -27,6 +27,8 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -55,6 +57,26 @@ public class WireMockServerTests {
         Options options = new WireMockConfiguration();
         WireMockServer wireMockServer = new WireMockServer(options);
         assertThat(wireMockServer.getOptions(), is(options));
+    }
+
+    @Test
+    public void buildsQualifiedHttpUrlFromPath() {
+        WireMockServer wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+        int port = wireMockServer.port();
+
+        assertThat(wireMockServer.url("/something"), is(String.format("http://localhost:%d/something", port)));
+        assertThat(wireMockServer.url("something"), is(String.format("http://localhost:%d/something", port)));
+    }
+
+    @Test
+    public void buildsQualifiedHttpsUrlFromPath() {
+        WireMockServer wireMockServer = new WireMockServer(options().dynamicHttpsPort());
+        wireMockServer.start();
+        int port = wireMockServer.httpsPort();
+
+        assertThat(wireMockServer.url("/something"), is(String.format("https://localhost:%d/something", port)));
+        assertThat(wireMockServer.url("something"), is(String.format("https://localhost:%d/something", port)));
     }
 
     // https://github.com/tomakehurst/wiremock/issues/193


### PR DESCRIPTION
It's often required to build fully qualified URLs to the WireMock server when interacting with it. This PR adds a `WireMockServer.url` method that produces a fully qualified URL from a given path.