### PR TITLE
Wire up stop timeout for embedded Jetty server

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -72,6 +72,7 @@ public class WireMockConfiguration implements Options {
     private Integer jettyAcceptors;
     private Integer jettyAcceptQueueSize;
     private Integer jettyHeaderBufferSize;
+    private Long jettyStopTimeout;
 
     private Map<String, Extension> extensions = newLinkedHashMap();
     private WiremockNetworkTrafficListener networkTrafficListener = new DoNothingWiremockNetworkTrafficListener();
@@ -129,6 +130,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration jettyHeaderBufferSize(Integer jettyHeaderBufferSize) {
         this.jettyHeaderBufferSize = jettyHeaderBufferSize;
+        return this;
+    }
+
+    public WireMockConfiguration jettyStopTimeout(Long jettyStopTimeout) {
+        this.jettyStopTimeout = jettyStopTimeout;
         return this;
     }
 
@@ -305,6 +311,7 @@ public class WireMockConfiguration implements Options {
                 .withAcceptors(jettyAcceptors)
                 .withAcceptQueueSize(jettyAcceptQueueSize)
                 .withRequestHeaderSize(jettyHeaderBufferSize)
+                .withStopTimeout(jettyStopTimeout)
                 .build();
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -90,7 +90,7 @@ public class JettyHttpServer implements HttpServer {
 
         jettyServer.setHandler(createHandler(options, adminRequestHandler, stubRequestHandler));
 
-        finalizeSetup();
+        finalizeSetup(options);
     }
 
     protected HandlerCollection createHandler(Options options, AdminRequestHandler adminRequestHandler, StubRequestHandler stubRequestHandler) {
@@ -110,8 +110,10 @@ public class JettyHttpServer implements HttpServer {
         return handlers;
     }
 
-    protected void finalizeSetup() {
-        jettyServer.setStopTimeout(0);
+    protected void finalizeSetup(Options options) {
+        if(!options.jettySettings().getStopTimeout().isPresent()) {
+            jettyServer.setStopTimeout(0);
+        }
     }
 
     protected Server createServer(Options options) {
@@ -174,6 +176,10 @@ public class JettyHttpServer implements HttpServer {
     @Override
     public int httpsPort() {
         return httpsConnector.getLocalPort();
+    }
+
+    protected long stopTimeout() {
+        return jettyServer.getStopTimeout();
     }
 
     protected ServerConnector createHttpConnector(

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -1,0 +1,27 @@
+package com.github.tomakehurst.wiremock.core;
+
+import com.google.common.base.Optional;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class WireMockConfigurationTest {
+
+    @Test
+    public void testJettyStopTimeout() {
+        Long expectedStopTimeout = 500L;
+        WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig().jettyStopTimeout(expectedStopTimeout);
+        Optional<Long> jettyStopTimeout = wireMockConfiguration.jettySettings().getStopTimeout();
+
+        assertThat(jettyStopTimeout.isPresent(), is(true));
+        assertThat(jettyStopTimeout.get(), is(expectedStopTimeout));
+    }
+
+    @Test
+    public void testJettyStopTimeoutNotSet() {
+        WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig();
+        Optional<Long> jettyStopTimeout = wireMockConfiguration.jettySettings().getStopTimeout();
+        assertThat(jettyStopTimeout.isPresent(), is(false));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
@@ -1,0 +1,65 @@
+package com.github.tomakehurst.wiremock.jetty9;
+
+import com.github.tomakehurst.wiremock.admin.AdminRoutes;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.core.StubServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.PostServeAction;
+import com.github.tomakehurst.wiremock.http.AdminRequestHandler;
+import com.github.tomakehurst.wiremock.http.BasicResponseRenderer;
+import com.github.tomakehurst.wiremock.http.ResponseRenderer;
+import com.github.tomakehurst.wiremock.http.StubRequestHandler;
+import com.github.tomakehurst.wiremock.verification.RequestJournal;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(JMock.class)
+public class JettyHttpServerTest {
+
+    private Mockery context;
+    private AdminRequestHandler adminRequestHandler;
+    private StubRequestHandler stubRequestHandler;
+
+    @Before
+    public void init() {
+        context = new Mockery();
+        Admin admin = context.mock(Admin.class);
+
+        adminRequestHandler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer());
+        stubRequestHandler = new StubRequestHandler(context.mock(StubServer.class),
+                context.mock(ResponseRenderer.class),
+                admin,
+                Collections.<String, PostServeAction>emptyMap(),
+                context.mock(RequestJournal.class));
+    }
+
+    @Test
+    public void testStopTimeout() {
+        long expectedStopTimeout = 500L;
+        WireMockConfiguration config = WireMockConfiguration
+                .wireMockConfig()
+                .jettyStopTimeout(expectedStopTimeout);
+
+        JettyHttpServer jettyHttpServer = new JettyHttpServer(config, adminRequestHandler, stubRequestHandler);
+
+        assertThat(jettyHttpServer.stopTimeout(), is(expectedStopTimeout));
+    }
+
+    @Test
+    public void testStopTimeoutNotSet() {
+        long expectedStopTimeout = 0L;
+        WireMockConfiguration config = WireMockConfiguration.wireMockConfig();
+
+        JettyHttpServer jettyHttpServer = new JettyHttpServer(config, adminRequestHandler, stubRequestHandler);
+
+        assertThat(jettyHttpServer.stopTimeout(), is(expectedStopTimeout));
+    }
+}

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -372,6 +372,9 @@ public class Examples extends AcceptanceTestBase {
             // Set the size of Jetty's header buffer (to avoid exceptions when very large request headers are sent). Defaults to 8192.
             .jettyHeaderBufferSize(16834)
 
+            // Set the timeout to wait for Jetty to stop in milliseconds. Defaults to 0 (no wait)
+            .jettyStopTimeout(5000L)
+
             // Set the keystore containing the HTTPS certificate
             .keystorePath("/path/to/https-certs-keystore.jks")
 


### PR DESCRIPTION
This PR wires up the jetty stop timeout for use with embedded jetty. 

It adds jettyStopTimeout to WireMockConfiguration and changes JettyHttpServer.finalizeSetup() to not overwrite the timeout value on setup.

