### PR TITLE
Fixed #567 - Allow duplicate cookies 

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -22,7 +22,6 @@ import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Maps.EntryTransformer;
 import com.google.common.collect.Multimaps;
@@ -64,7 +63,7 @@ public class RequestTemplateModel {
             }
         });
 
-        ImmutableMap<String, Collection<Cookie>> indexedCookies = Multimaps.index(request.getCookies(), new Function<Cookie, String>() {
+        Map<String, Collection<Cookie>> indexedCookies = Multimaps.index(request.getCookies(), new Function<Cookie, String>() {
             @Override
             public String apply(Cookie input) {
                 return input.getName();

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -15,23 +15,18 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.MultiValue;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
-
+import com.google.common.collect.*;
 import com.google.common.collect.Maps.EntryTransformer;
-import com.google.common.collect.Multimaps;
+
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class RequestTemplateModel {
@@ -73,7 +68,7 @@ public class RequestTemplateModel {
         Map<String, ListOrSingle<String>> adaptedCookies = Maps.transformEntries(indexedCookies , new EntryTransformer<String, Collection<Cookie>, ListOrSingle<String>>() {
             @Override
             public ListOrSingle<String> transformEntry(String key, Collection<Cookie> value) {
-                ArrayList<String> cookieValues = newArrayList(Collections2.transform(value, new Function<Cookie, String>() {
+                List<String> cookieValues = Lists.<String>newArrayList(Collections2.<Cookie, String>transform(value, new Function<Cookie, String>() {
                     @Override
                     public String apply(Cookie input) {
                         return input.getValue();

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -15,18 +15,23 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
+import static com.google.common.collect.Lists.newArrayList;
+
 import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.MultiValue;
 import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.google.common.base.Function;
-import com.google.common.collect.*;
-import com.google.common.collect.Maps.EntryTransformer;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 
+import com.google.common.collect.Maps.EntryTransformer;
+import com.google.common.collect.Multimaps;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public class RequestTemplateModel {
@@ -68,7 +73,7 @@ public class RequestTemplateModel {
         Map<String, ListOrSingle<String>> adaptedCookies = Maps.transformEntries(indexedCookies , new EntryTransformer<String, Collection<Cookie>, ListOrSingle<String>>() {
             @Override
             public ListOrSingle<String> transformEntry(String key, Collection<Cookie> value) {
-                List<String> cookieValues = Lists.<String>newArrayList(Collections2.<Cookie, String>transform(value, new Function<Cookie, String>() {
+                ArrayList<String> cookieValues = newArrayList(Collections2.transform(value, new Function<Cookie, String>() {
                     @Override
                     public String apply(Cookie input) {
                         return input.getValue();

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -24,7 +24,6 @@ import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 import com.google.common.collect.Maps.EntryTransformer;
@@ -63,26 +62,23 @@ public class RequestTemplateModel {
             }
         });
 
-        ImmutableMap<String, Collection<Cookie>> groupedCookies = Multimaps.index(request.getCookies(), new Function<Cookie, String>() {
-                @Override
-                public String apply(Cookie input) {
-                    return input.getName();
-                }
-            })
-            .asMap();
-
-        Map<String, ListOrSingle<String>> adaptedCookies = Maps.transformEntries(groupedCookies, new EntryTransformer<String, Collection<Cookie>, ListOrSingle<String>>() {
-                @Override
-                public ListOrSingle<String> transformEntry(String key, Collection<Cookie> value) {
-                    return ListOrSingle.of(newArrayList(Collections2.transform(value, new Function<Cookie, String>() {
-                        @Override
-                        public String apply(Cookie input) {
-                            return input.getValue();
-
-                        }
-                    })));
-                }
-            });
+        Map<String, ListOrSingle<String>> adaptedCookies = Maps.transformEntries(Multimaps.index(request.getCookies(), new Function<Cookie, String>() {
+                    @Override
+                    public String apply(Cookie input) {
+                        return input.getName();
+                    }
+                }).asMap()
+                , new EntryTransformer<String, Collection<Cookie>, ListOrSingle<String>>() {
+                    @Override
+                    public ListOrSingle<String> transformEntry(String key, Collection<Cookie> value) {
+                        return ListOrSingle.of(newArrayList(Collections2.transform(value, new Function<Cookie, String>() {
+                            @Override
+                            public String apply(Cookie input) {
+                                return input.getValue();
+                            }
+                        })));
+                    }
+                });
 
         UrlPath path = new UrlPath(request.getUrl());
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -15,8 +15,6 @@
  */
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 import com.github.tomakehurst.wiremock.common.Urls;
 import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.MultiValue;
@@ -26,13 +24,15 @@ import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-
 import com.google.common.collect.Maps.EntryTransformer;
 import com.google.common.collect.Multimaps;
+
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 public class RequestTemplateModel {
 
@@ -73,7 +73,7 @@ public class RequestTemplateModel {
         Map<String, ListOrSingle<String>> adaptedCookies = Maps.transformEntries(indexedCookies , new EntryTransformer<String, Collection<Cookie>, ListOrSingle<String>>() {
             @Override
             public ListOrSingle<String> transformEntry(String key, Collection<Cookie> value) {
-                ArrayList<String> cookieValues = newArrayList(Collections2.transform(value, new Function<Cookie, String>() {
+                List<String> cookieValues = newArrayList(Collections2.transform(value, new Function<Cookie, String>() {
                     @Override
                     public String apply(Cookie input) {
                         return input.getValue();

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
@@ -79,5 +79,4 @@ public class Cookie {
     public String toString() {
         return isAbsent() ? "(absent)" : getSerializable().toString();
     }
-
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java
@@ -15,24 +15,38 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableMap;
+
+import java.io.Serializable;
 
 public class Cookie {
+
+    private String name;
 
     private String value;
 
     @JsonCreator
-    public static Cookie cookie(String value) {
-        return new Cookie(value);
+    public static Cookie cookie(@JsonProperty("name") String name, @JsonProperty("value") String value) {
+        return new Cookie(name, value);
+    }
+
+    @JsonAnySetter
+    public void set(String name, String value) {
+        this.name = name;
+        this.value = value;
     }
 
     public static Cookie absent() {
-        return new Cookie(null);
+        return new Cookie(null, null);
     }
 
-    public Cookie(String value) {
+    public Cookie(String name, String value) {
+        this.name = name;
         this.value = value;
     }
 
@@ -46,13 +60,24 @@ public class Cookie {
         return value == null;
     }
 
-    @JsonValue
+    @JsonIgnore
     public String getValue() {
         return value;
     }
 
+    @JsonValue
+    public Serializable getSerializable() {
+        return ImmutableMap.of(name, value);
+    }
+
+    @JsonIgnore
+    public String getName() {
+        return name;
+    }
+
     @Override
     public String toString() {
-        return isAbsent() ? "(absent)" : value;
+        return isAbsent() ? "(absent)" : getSerializable().toString();
     }
+
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -15,7 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Set;
 
 public interface Request {
@@ -32,7 +32,7 @@ public interface Request {
     boolean containsHeader(String key);
     Set<String> getAllHeaderKeys();
 
-    Map<String, Cookie> getCookies();
+    List<Cookie> getCookies();
 
     QueryParameter queryParameter(String key);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 
+import com.google.common.collect.Iterables;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -161,12 +162,17 @@ public class RequestPattern implements NamedValueMatcher<Request> {
             return MatchResult.aggregate(
                 from(cookies.entrySet())
                     .transform(new Function<Map.Entry<String, StringValuePattern>, MatchResult>() {
-                        public MatchResult apply(Map.Entry<String, StringValuePattern> cookiePattern) {
-                            Cookie cookie =
-                                firstNonNull(request.getCookies().get(cookiePattern.getKey()), Cookie.absent());
-
+                        public MatchResult apply(final Map.Entry<String, StringValuePattern> cookiePattern) {
+                            Cookie cookie = Iterables.tryFind(request.getCookies(), new Predicate<Cookie>() {
+                                @Override
+                                public boolean apply(Cookie input) {
+                                    return cookiePattern.getKey().equals(input.getName());
+                                }
+                            }).or(Cookie.absent());
                             return cookiePattern.getValue().match(cookie.getValue());
                         }
+
+
                     }).toList()
             );
         }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -171,8 +171,6 @@ public class RequestPattern implements NamedValueMatcher<Request> {
                             }).or(Cookie.absent());
                             return cookiePattern.getValue().match(cookie.getValue());
                         }
-
-
                     }).toList()
             );
         }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.servlet;
 import com.github.tomakehurst.wiremock.common.Gzip;
 import com.github.tomakehurst.wiremock.http.*;
 import com.github.tomakehurst.wiremock.jetty9.JettyUtils;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import javax.servlet.http.HttpServletRequest;
@@ -192,19 +193,19 @@ public class WireMockHttpServletRequestAdapter implements Request {
     }
 
     @Override
-    public Map<String, Cookie> getCookies() {
-        ImmutableMap.Builder<String, Cookie> builder = ImmutableMap.builder();
+    public List<Cookie> getCookies() {
+        ImmutableList.Builder<Cookie> builder = ImmutableList.builder();
 
         for (javax.servlet.http.Cookie cookie :
             firstNonNull(request.getCookies(), new javax.servlet.http.Cookie[0])) {
-            builder.put(cookie.getName(), convertCookie(cookie));
+            builder.add(convertCookie(cookie));
         }
 
         return builder.build();
     }
 
     private static Cookie convertCookie(javax.servlet.http.Cookie servletCookie) {
-        return new Cookie(servletCookie.getValue());
+        return new Cookie(servletCookie.getName(), servletCookie.getValue());
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/Diff.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/Diff.java
@@ -98,7 +98,6 @@ public class Diff {
                         return key.equals(input.getName());
                     }
                 }).or(Cookie.absent());
-
                 Section<String> section = new Section<>(
                     pattern,
                     cookie.isPresent() ? "Cookie: " + key + "=" + cookie.getValue() : "",

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.http.*;
-import com.google.common.collect.ImmutableMap;
 
 import java.net.URI;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,6 +38,7 @@ import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.common.Urls.splitQuery;
 import static com.github.tomakehurst.wiremock.http.HttpHeaders.copyOf;
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.Lists.*;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LoggedRequest implements Request {
@@ -47,7 +48,7 @@ public class LoggedRequest implements Request {
     private final String clientIp;
     private final RequestMethod method;
     private final HttpHeaders headers;
-    private final Map<String, Cookie> cookies;
+    private final List<Cookie> cookies;
     private final Map<String, QueryParameter> queryParams;
     private final byte[] body;
     private final boolean isBrowserProxyRequest;
@@ -59,7 +60,7 @@ public class LoggedRequest implements Request {
             request.getMethod(),
             request.getClientIp(),
             copyOf(request.getHeaders()),
-            ImmutableMap.copyOf(request.getCookies()),
+            newArrayList(request.getCookies()),
             request.isBrowserProxyRequest(),
             new Date(),
             request.getBodyAsBase64(),
@@ -73,7 +74,7 @@ public class LoggedRequest implements Request {
             @JsonProperty("method") RequestMethod method,
             @JsonProperty("clientIp") String clientIp,
             @JsonProperty("headers") HttpHeaders headers,
-            @JsonProperty("cookies") Map<String, Cookie> cookies,
+            @JsonProperty("cookies") List<Cookie> cookies,
             @JsonProperty("browserProxyRequest") boolean isBrowserProxyRequest,
             @JsonProperty("loggedDate") Date loggedDate,
             @JsonProperty("bodyAsBase64") String bodyAsBase64,
@@ -148,7 +149,7 @@ public class LoggedRequest implements Request {
     }
 
     @Override
-    public Map<String, Cookie> getCookies() {
+    public List<Cookie> getCookies() {
         return cookies;
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
@@ -97,14 +97,29 @@ public class CookieMatchingAcceptanceTest extends AcceptanceTestBase {
     @Test
     public void matchesWhenRequiredAbsentCookieIsAbsent() {
         stubFor(get(urlEqualTo("/absent/cookie"))
-            .withCookie("not_this_cookie", absent())
-            .willReturn(aResponse().withStatus(200)));
+                .withCookie("not_this_cookie", absent())
+                .willReturn(aResponse().withStatus(200)));
 
         WireMockResponse response =
-            testClient.get("/absent/cookie",
-                withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; irrelevant_cookie=whatever"));
+                testClient.get("/absent/cookie",
+                        withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; irrelevant_cookie=whatever"));
 
         assertThat(response.statusCode(), is(200));
+    }
+
+    @Test
+    public void matchesWhenRequiredCookieSentAsDuplicate() {
+        stubFor(get(urlEqualTo("/duplicate/cookie"))
+                .withCookie("my_cookie", containing("mycookievalue"))
+                .withCookie("my_other_cookie", equalTo("exact-other-value"))
+                .willReturn(aResponse().withStatus(200)));
+
+        WireMockResponse response =
+                testClient.get("/duplicate/cookie",
+                        withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; my_other_cookie=exact-other-value"));
+
+        assertThat(response.statusCode(), is(200));
+
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
@@ -15,8 +15,10 @@
  */
 package com.github.tomakehurst.wiremock;
 
+import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.List;
@@ -25,6 +27,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.testsupport.TestHttpHeader.withHeader;
 import static com.google.common.net.HttpHeaders.COOKIE;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -124,6 +127,7 @@ public class CookieMatchingAcceptanceTest extends AcceptanceTestBase {
         List<LoggedRequest> requests = findAll(getRequestedFor(urlEqualTo("/good/cookies")));
 
         assertThat(requests.size(), is(1));
-        assertThat(requests.get(0).getCookies().keySet(), hasItem("my_other_cookie"));
+        assertThat(requests.get(0).getCookies(), hasItem(Matchers.<Cookie>hasProperty("name", is("my_other_cookie"))));
+        assertThat(requests.get(0).getCookies(), hasItem(Matchers.<Cookie>hasProperty("value", is("exact-other-value"))));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
@@ -119,7 +119,6 @@ public class CookieMatchingAcceptanceTest extends AcceptanceTestBase {
                 withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; my_other_cookie=exact-other-value"));
 
         assertThat(response.statusCode(), is(200));
-
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/CookieMatchingAcceptanceTest.java
@@ -97,12 +97,12 @@ public class CookieMatchingAcceptanceTest extends AcceptanceTestBase {
     @Test
     public void matchesWhenRequiredAbsentCookieIsAbsent() {
         stubFor(get(urlEqualTo("/absent/cookie"))
-                .withCookie("not_this_cookie", absent())
-                .willReturn(aResponse().withStatus(200)));
+            .withCookie("not_this_cookie", absent())
+            .willReturn(aResponse().withStatus(200)));
 
         WireMockResponse response =
-                testClient.get("/absent/cookie",
-                        withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; irrelevant_cookie=whatever"));
+            testClient.get("/absent/cookie",
+                withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; irrelevant_cookie=whatever"));
 
         assertThat(response.statusCode(), is(200));
     }
@@ -110,13 +110,13 @@ public class CookieMatchingAcceptanceTest extends AcceptanceTestBase {
     @Test
     public void matchesWhenRequiredCookieSentAsDuplicate() {
         stubFor(get(urlEqualTo("/duplicate/cookie"))
-                .withCookie("my_cookie", containing("mycookievalue"))
-                .withCookie("my_other_cookie", equalTo("exact-other-value"))
-                .willReturn(aResponse().withStatus(200)));
+            .withCookie("my_cookie", containing("mycookievalue"))
+            .withCookie("my_other_cookie", equalTo("exact-other-value"))
+            .willReturn(aResponse().withStatus(200)));
 
         WireMockResponse response =
-                testClient.get("/duplicate/cookie",
-                        withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; my_other_cookie=exact-other-value"));
+            testClient.get("/duplicate/cookie",
+                withHeader(COOKIE, "my_cookie=xxx-mycookievalue-xxx; my_other_cookie=exact-other-value; my_other_cookie=exact-other-value"));
 
         assertThat(response.statusCode(), is(200));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -27,20 +27,21 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Predicate;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.collect.Iterables.tryFind;
-import static com.google.common.collect.Maps.newHashMap;
+import static com.google.common.collect.Lists.newArrayList;
 
 public class MockRequest implements Request {
 
     private String url = "/";
     private RequestMethod method = RequestMethod.ANY;
     private HttpHeaders headers = new HttpHeaders();
-    private Map<String, Cookie> cookies = newHashMap();
+    private List<Cookie> cookies = newArrayList();
     private byte[] body;
     private String clientIp = "1.1.1.1";
 
@@ -64,7 +65,7 @@ public class MockRequest implements Request {
     }
 
     public MockRequest cookie(String key, String value) {
-        cookies.put(key, new Cookie(value));
+        cookies.add(new Cookie(key, value));
         return this;
     }
 
@@ -138,7 +139,7 @@ public class MockRequest implements Request {
     }
 
     @Override
-    public Map<String, Cookie> getCookies() {
+    public List<Cookie> getCookies() {
         return cookies;
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -36,7 +36,7 @@ public class MockRequestBuilder {
 	private RequestMethod method = GET;
 	private String clientIp = "x.x.x.x";
 	private List<HttpHeader> individualHeaders = newArrayList();
-	private Map<String, Cookie> cookies = newHashMap();
+	private List<Cookie> cookies = newArrayList();
 	private List<QueryParameter> queryParameters = newArrayList();
 	private String body = "";
 	private String bodyAsBase64 = "";
@@ -87,7 +87,7 @@ public class MockRequestBuilder {
 	}
 
 	public MockRequestBuilder withCookie(String key, String value) {
-		cookies.put(key, new Cookie(value));
+		cookies.add(new Cookie(key, value));
 		return this;
 	}
 

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -22,7 +22,7 @@ import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 
 import com.github.tomakehurst.wiremock.http.Cookie;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
 import org.junit.Before;
@@ -87,10 +87,10 @@ public class LoggedRequestTest {
             "      \"headers\" : {\n" +
             "        \"Accept-Language\" : \"en-us,en;q=0.5\"\n" +
             "      },\n" +
-            "      \"cookies\" : {\n" +
-            "        \"first_cookie\"   : \"yum\",\n" +
-            "        \"monster_cookie\" : \"COOKIIIEESS\"\n" +
-            "      },\n" +
+            "      \"cookies\" : [\n" +
+            "        {\"first_cookie\"   : \"yum\"},\n" +
+            "        {\"monster_cookie\" : \"COOKIIIEESS\"}\n" +
+            "      ],\n" +
             "      \"browserProxyRequest\" : true,\n" +
             "      \"loggedDate\" : %d,\n" +
             "      \"bodyAsBase64\" : \"" + REQUEST_BODY_AS_BASE64 + "\",\n" +
@@ -101,9 +101,9 @@ public class LoggedRequestTest {
     @Test
     public void jsonRepresentation() throws Exception {
         HttpHeaders headers = new HttpHeaders(httpHeader("Accept-Language", "en-us,en;q=0.5"));
-        Map<String, Cookie> cookies = ImmutableMap.of(
-                "first_cookie", new Cookie("yum"),
-                "monster_cookie", new Cookie("COOKIIIEESS")
+        List<Cookie> cookies = Lists.newArrayList(
+                new Cookie("first_cookie", "yum"),
+                new Cookie("monster_cookie", "COOKIIIEESS")
         );
 
         Date loggedDate = Dates.parse(DATE);

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -18,11 +18,9 @@ package com.github.tomakehurst.wiremock.verification;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.common.Dates;
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.http.Cookie;
 import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
-
-import com.github.tomakehurst.wiremock.http.Cookie;
-import com.google.common.collect.Lists;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
 import org.junit.Before;
@@ -40,6 +38,7 @@ import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder.aRequest;
 import static com.github.tomakehurst.wiremock.verification.LoggedRequest.createFrom;
+import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
@@ -105,7 +104,7 @@ public class LoggedRequestTest {
     @Test
     public void jsonRepresentation() throws Exception {
         HttpHeaders headers = new HttpHeaders(httpHeader("Accept-Language", "en-us,en;q=0.5"));
-        List<Cookie> cookies = Lists.newArrayList(
+        List<Cookie> cookies = newArrayList(
                 new Cookie("first_cookie", "yum"),
                 new Cookie("monster_cookie", "COOKIIIEESS")
         );

--- a/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/verification/LoggedRequestTest.java
@@ -88,8 +88,12 @@ public class LoggedRequestTest {
             "        \"Accept-Language\" : \"en-us,en;q=0.5\"\n" +
             "      },\n" +
             "      \"cookies\" : [\n" +
-            "        {\"first_cookie\"   : \"yum\"},\n" +
-            "        {\"monster_cookie\" : \"COOKIIIEESS\"}\n" +
+            "        {\n" +
+            "           \"first_cookie\"   : \"yum\"\n" +
+            "        },\n" +
+            "        {\n" +
+            "           \"monster_cookie\" : \"COOKIIIEESS\"\n" +
+            "        }\n" +
             "      ],\n" +
             "      \"browserProxyRequest\" : true,\n" +
             "      \"loggedDate\" : %d,\n" +


### PR DESCRIPTION
Fixed #567

**Issue**
https://github.com/tomakehurst/wiremock/issues/567#issue-199911597
> If I make a request with two values for one cookie, like this:
>$ curl 'http://localhost:8080/test' -H 'Cookie: cookie1=190283aJDS;cookie1=190283aJDS'
> I get the following response:
> 
> <html>
> 
> <head>
>     <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1" />
>     <title>Error 500 </title>
> </head>
> </html>
> 
> 
> But if I remove the duplication, it works.

**Reply**
https://github.com/tomakehurst/wiremock/issues/567#issuecomment-272279919
>Cookies are represented by a map internally and the map builder blows up if you try to add more than one with the same key.

**Fix**
- Changes in [Cookie:](https://github.com/mushanga/wiremock/blob/master/src/main/java/com/github/tomakehurst/wiremock/http/Cookie.java) 
  - `String name` property added
  - Json `value` representation replaced with `object`
- Changes in interface [Request:](https://github.com/mushanga/wiremock/blob/master/src/main/java/com/github/tomakehurst/wiremock/http/Request.java) `Map<String, Cookie> getCookies()` method replaced with `List<Cookie> getCookies()`


