### PR TITLE
changes 'failOnUnmatchedStubs' to 'failOnUnmatchedRequests'

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
@@ -43,20 +43,20 @@ public class VerificationException extends AssertionError {
         return new VerificationException("A request was unmatched by any stub mapping. Closest stub mapping was:", diff);
     }
 
-    public static VerificationException forUnmatchedRequests(List<NearMiss> nearMisses) {
+    public static VerificationException forUnmatchedNearMisses(List<NearMiss> nearMisses) {
         if (nearMisses.size() == 1) {
             return forSingleUnmatchedRequest(nearMisses.get(0).getDiff());
         }
 
         return new VerificationException(nearMisses.size() +
             " requests were unmatched by any stub mapping. Shown with closest stub mappings:\n" +
-            renderNearMisses(nearMisses));
+            renderList(nearMisses));
 
     }
 
-    private static String renderNearMisses(List<NearMiss> nearMisses) {
+    private static String renderList(List list) {
         return Joiner.on("\n\n").join(
-            from(nearMisses).transform(toStringFunction())
+            from(list).transform(toStringFunction())
         );
     }
 
@@ -85,5 +85,16 @@ public class VerificationException extends AssertionError {
             expectedCount.toString().toLowerCase(),
             actualCount,
             expected.toString()));
+    }
+
+    public static VerificationException forUnmatchedRequests(List<LoggedRequest> unmatchedRequests) {
+        if (unmatchedRequests.size() == 1) {
+            return new VerificationException(String.format("A request was unmatched by any stub mapping. Request was: ",
+                    unmatchedRequests.get(0)));
+        }
+
+        return new VerificationException(unmatchedRequests.size() +
+                " requests were unmatched by any stub mapping. Requests are:\n" +
+                renderList(unmatchedRequests));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/junit/WireMockRuleFailOnUnmatchedRequestsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit/WireMockRuleFailOnUnmatchedRequestsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.junit;
+
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import com.github.tomakehurst.wiremock.testsupport.WireMockTestClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.hamcrest.Matchers.containsString;
+
+public class WireMockRuleFailOnUnmatchedRequestsTest {
+
+
+    public ExpectedException expectedException = ExpectedException.none();
+
+    public WireMockRule wm = new WireMockRule(options()
+        .dynamicPort()
+        .withRootDirectory("src/main/resources/empty"),
+        true);
+
+    @Rule
+    public TestRule chain = RuleChain
+            .outerRule(expectedException)
+            .around(wm);
+
+    WireMockTestClient client;
+
+    @Before
+    public void init() {
+        client = new WireMockTestClient(wm.port());
+    }
+
+
+    @Test
+    public void singleUnmatchedRequestShouldThrowVerificationException() {
+        expectedException.expect(VerificationException.class);
+        expectedException.expectMessage(containsString("A request was unmatched by any stub mapping"));
+        wm.stubFor(get(urlEqualTo("/hit")).willReturn(aResponse().withStatus(200)));
+        client.get("/near-misssss");
+    }
+
+    @Test
+    public void manyUnmatchedRequestsShouldThrowVerificationException() {
+        expectedException.expect(VerificationException.class);
+        expectedException.expectMessage(containsString("3 requests were unmatched by any stub mapping"));
+        wm.stubFor(get(urlEqualTo("/hit")).willReturn(aResponse().withStatus(200)));
+        client.get("/near-misssss");
+        client.get("/hat");
+        client.get("/whatevs");
+    }
+
+    @Test
+    public void unmatchedRequestButMatchedStubShouldThrowVerificationException() {
+        expectedException.expect(VerificationException.class);
+        expectedException.expectMessage(containsString("A request was unmatched by any stub mapping"));
+        wm.stubFor(get(urlEqualTo("/hit")).willReturn(aResponse().withStatus(200)));
+        client.get("/near-misssss");
+        client.get("/hit");
+    }
+    @Test
+    public void matchedRequestButUnmatchedStubShouldNotThrowVerificationException() {
+        expectedException = ExpectedException.none();
+        wm.stubFor(get(urlEqualTo("/hit")).willReturn(aResponse().withStatus(200)));
+        wm.stubFor(get(urlEqualTo("/miss")).willReturn(aResponse().withStatus(404)));
+        client.get("/hit");
+    }
+    @Test
+    public void unmatchedRequestWithoutStubShouldThrowVerificationException() {
+        expectedException.expect(VerificationException.class);
+        expectedException.expectMessage(containsString("A request was unmatched by any stub mapping."));
+        client.get("/miss");
+    }
+    @Test
+    public void unmatchedStubWithoutRequestShouldNotThrowVerificationException() {
+        expectedException = ExpectedException.none();
+        wm.stubFor(get(urlEqualTo("/miss")).willReturn(aResponse().withStatus(404)));
+    }
+}


### PR DESCRIPTION
changes 'failOnUnmatchedStubs' to 'failOnUnmatchedRequests' like intended.

Fixes #676.