### PR TITLE
Document the usage of RequestMatcherExtension with WireMock.verify

### DIFF
--- a/docs-v2/_docs/extending-wiremock.md
+++ b/docs-v2/_docs/extending-wiremock.md
@@ -218,6 +218,18 @@ wireMockServer.stubFor(requestMatching(new RequestMatcherExtension() {
 }).willReturn(aResponse().withStatus(422)));
 ```
 
+
+To use it in a verification :
+```java
+WireMock.verify(RequestPatternBuilder.forCustomMatcher(new RequestMatcherExtension() {
+    @Override
+    public MatchResult match(Request request, Parameters parameters) {
+        return MatchResult.of(request.getBody().length > 2048);
+    }
+}));
+```
+
+
 In Java 8 and above this can be achieved using a lambda:
 
 ```java


### PR DESCRIPTION
Just wanted to document the usage of a `RequestMatcherExtension` in verification.

https://stackoverflow.com/questions/46703213/wiremock-verify-headers-contains-many-values-via-custom-valuematcherstrategy/46726960#comment80478529_46726960