### PR TITLE
Issue #592- Fix ResponseDefinitionBuilder.like() to copy transformerParameters

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -68,7 +68,9 @@ public class ResponseDefinitionBuilder {
 		builder.proxyBaseUrl = responseDefinition.getProxyBaseUrl();
 		builder.fault = responseDefinition.getFault();
 		builder.responseTransformerNames = responseDefinition.getTransformers();
-		builder.transformerParameters = responseDefinition.getTransformerParameters();
+		builder.transformerParameters = responseDefinition.getTransformerParameters() != null ?
+			Parameters.from(responseDefinition.getTransformerParameters()) :
+			Parameters.empty();
 		builder.wasConfigured = responseDefinition.isFromConfiguredStub();
 		return builder;
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2017 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.client;
+
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ResponseDefinitionBuilderTest {
+
+    @Test
+    public void withTransformerParameterShouldNotChangeOriginalTransformerParametersValue() {
+        ResponseDefinition originalResponseDefinition = ResponseDefinitionBuilder
+            .responseDefinition()
+            .withTransformerParameter("name", "original")
+            .build();
+
+        ResponseDefinition transformedResponseDefinition = ResponseDefinitionBuilder
+            .like(originalResponseDefinition)
+            .but()
+                .withTransformerParameter("name", "changed")
+            .build();
+
+        assertThat(originalResponseDefinition.getTransformerParameters().getString("name"), is("original"));
+        assertThat(transformedResponseDefinition.getTransformerParameters().getString("name"), is("changed"));
+    }
+}


### PR DESCRIPTION
This fixes issue #592. When `ResponseDefinitionBuilder.like()` was called with a ResponseDefinition that had transformer parameters, it just copied the reference. This means subsequent calls to `withTransformerParameter()` would modify the original object.
