### PR TITLE
Add RequestPatternBuilder.like() and but() methods

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -315,6 +315,11 @@ public class RequestPattern implements NamedValueMatcher<Request> {
         return customMatcherDefinition;
     }
 
+    @JsonIgnore
+    public ValueMatcher<Request> getMatcher() {
+        return matcher;
+    }
+
     @Override
     public String getName() {
         return "requestMatching";

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -77,6 +77,40 @@ public class RequestPatternBuilder {
         return new RequestPatternBuilder(RequestMethod.ANY, WireMock.anyUrl());
     }
 
+    /**
+     * Construct a builder that uses an existing RequestPattern as a template
+     *
+     * @param requestPattern A RequestPattern to copy
+     * @return A builder based on the RequestPattern
+     */
+    public static RequestPatternBuilder like(RequestPattern requestPattern) {
+        RequestPatternBuilder builder = new RequestPatternBuilder();
+        builder.url = requestPattern.getUrlMatcher();
+        builder.method = requestPattern.getMethod();
+        if (requestPattern.getHeaders() != null) {
+            builder.headers = requestPattern.getHeaders();
+        }
+        if (requestPattern.getQueryParameters() != null) {
+            builder.queryParams = requestPattern.getQueryParameters();
+        }
+        if (requestPattern.getCookies() != null) {
+            builder.cookies = requestPattern.getCookies();
+        }
+        if (requestPattern.getBodyPatterns() != null) {
+            builder.bodyPatterns = requestPattern.getBodyPatterns();
+        }
+        if (requestPattern.hasCustomMatcher()) {
+            builder.customMatcher = requestPattern.getMatcher();
+        }
+        builder.basicCredentials = requestPattern.getBasicAuthCredentials();
+        builder.customMatcherDefinition = requestPattern.getCustomMatcher();
+        return builder;
+    }
+
+    public RequestPatternBuilder but() {
+        return this;
+    }
+
     public RequestPatternBuilder withUrl(String url) {
         this.url = WireMock.urlEqualTo(url);
         return this;

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.matching;
+
+import com.github.tomakehurst.wiremock.client.BasicCredentials;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.Is.is;
+
+public class RequestPatternBuilderTest {
+    @Test
+    public void likeRequestPatternWithDifferentUrl() {
+        RequestPattern requestPattern = RequestPattern.everything();
+
+        RequestPattern newRequestPattern = RequestPatternBuilder
+            .like(requestPattern)
+            .but()
+            .withUrl("/foo")
+            .build();
+
+        assertThat(newRequestPattern.getUrl(), is("/foo"));
+        assertThat(newRequestPattern, not(equalTo(requestPattern)));
+    }
+
+    @Test
+    public void likeRequestPatternWithoutCustomMatcher() {
+        // Use a RequestPattern with everything defined except a custom matcher to ensure all fields are set properly
+        RequestPattern requestPattern = new RequestPattern(
+            WireMock.urlEqualTo("/foo"),
+            RequestMethod.POST,
+            ImmutableMap.of("X-Header", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            ImmutableMap.of("query_param", MultiValuePattern.of(WireMock.equalTo("bar"))),
+            ImmutableMap.of("cookie", WireMock.equalTo("yum")),
+            new BasicCredentials("user", "pass"),
+            ImmutableList.<ContentPattern<?>>of(WireMock.equalTo("BODY")),
+            null
+        );
+
+        RequestPattern newRequestPattern = RequestPatternBuilder.like(requestPattern).build();
+        assertThat(newRequestPattern, is(requestPattern));
+    }
+
+    @Test
+    public void likeRequestPatternWithCustomMatcher() {
+        RequestMatcher customRequestMatcher = new RequestMatcherExtension() {
+            @Override
+            public MatchResult match(Request request, Parameters parameters) {
+                return MatchResult.noMatch();
+            }
+        };
+        RequestPattern requestPattern = new RequestPattern(customRequestMatcher);
+
+        RequestPattern newRequestPattern = RequestPatternBuilder.like(requestPattern).build();
+        assertThat(newRequestPattern, is(requestPattern));
+    }
+
+    @Test
+    public void likeRequestPatternWithCustomMatcherDefinition() {
+        CustomMatcherDefinition customMatcherDefinition = new CustomMatcherDefinition("foo", Parameters.empty());
+        RequestPattern requestPattern = new RequestPattern(customMatcherDefinition);
+
+        RequestPattern newRequestPattern = RequestPatternBuilder.like(requestPattern).build();
+        assertThat(newRequestPattern, is(requestPattern));
+    }
+}


### PR DESCRIPTION
Sometimes, when writing a StubMappingTransformer extension, you want to change a single field in the RequestPattern (e.g. the URL). This is difficult because RequestPattern is immutable and RequestPatternBuilder can't build off an existing object the way ResponseDefinitionBuilder can.

This adds two new methods to RequestPatternBuilder, like() and but(), that do the same thing as the corresponding methods in ResponseDefinitionBuilder.