### PR TITLE
Add ability to require absent query parameter.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Request.java
@@ -37,6 +37,7 @@ public interface Request {
     Map<String, Cookie> getCookies();
 
     QueryParameter queryParameter(String key);
+    Set<String> getAllQueryParameterKeys();
 
     byte[] getBody();
     String getBodyAsString();

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPatternBuilder.java
@@ -131,6 +131,11 @@ public class RequestPatternBuilder {
         return this;
     }
 
+    public RequestPatternBuilder withoutQueryParam(String key) {
+        queryParams.put(key, MultiValuePattern.absent());
+        return this;
+    }
+
     public RequestPatternBuilder withCookie(String key, StringValuePattern valuePattern) {
         cookies.put(key, valuePattern);
         return this;

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -221,6 +221,11 @@ public class WireMockHttpServletRequestAdapter implements Request {
     }
 
     @Override
+    public Set<String> getAllQueryParameterKeys() {
+        return splitQuery(request.getQueryString()).keySet();
+    }
+
+    @Override
     public boolean isBrowserProxyRequest() {
         if (!isJetty()) {
             return false;

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/LoggedRequest.java
@@ -186,6 +186,12 @@ public class LoggedRequest implements Request {
         return queryParams;
     }
 
+    @Override
+    @JsonIgnore
+    public Set<String> getAllQueryParameterKeys() {
+        return queryParams.keySet();
+    }
+
     public HttpHeaders getHeaders() {
         return headers;
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -147,7 +147,14 @@ public class MockRequest implements Request {
     @Override
     public QueryParameter queryParameter(String key) {
         Map<String, QueryParameter> queryParams = Urls.splitQuery(URI.create(url));
-        return queryParams.get(key);
+        QueryParameter queryParameter = queryParams.get(key);
+        return queryParameter != null ? queryParameter : QueryParameter.absent(key);
+    }
+
+    @Override
+    public Set<String> getAllQueryParameterKeys() {
+        Map<String, QueryParameter> queryParams = Urls.splitQuery(URI.create(url));
+        return queryParams.keySet();
     }
 
     @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -300,6 +300,35 @@ public class RequestPatternTest {
     }
 
     @Test
+    public void doesNotMatchWhenRequiredAbsentQueryParameterIsPresent() {
+        RequestPattern requestPattern =
+                newRequestPattern(GET, WireMock.urlPathEqualTo("/my/url"))
+                        .withQueryParam("myparam", absent())
+                        .build();
+
+        MatchResult matchResult = requestPattern.match(mockRequest()
+                .method(GET)
+                .url("/my/url?myparam=foo"));
+
+        assertFalse("Request is a match for the request pattern and should not be", matchResult.isExactMatch());
+    }
+
+    @Test
+    public void matchesExactlyWhenRequiredAbsentQueryParameterIsAbsent() {
+        RequestPattern requestPattern =
+                newRequestPattern(GET, WireMock.urlPathEqualTo("/my/url"))
+                        .withQueryParam("param1", absent())
+                        .withQueryParam("param2", equalTo("expected-value"))
+                        .build();
+
+        MatchResult matchResult = requestPattern.match(mockRequest()
+                .method(GET)
+                .url("/my/url?param2=expected-value"));
+
+        assertTrue(matchResult.isExactMatch());
+    }
+
+    @Test
     public void matchesExactlyWhenAllCookiesMatch() {
         RequestPattern requestPattern =
             newRequestPattern(POST, WireMock.urlPathEqualTo("/my/url"))

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -16,14 +16,17 @@
 package com.github.tomakehurst.wiremock.testsupport;
 
 import com.github.tomakehurst.wiremock.http.*;
+import com.google.common.collect.Sets;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.github.tomakehurst.wiremock.http.HttpHeader.httpHeader;
+import static com.github.tomakehurst.wiremock.http.QueryParameter.queryParam;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Maps.newHashMap;
@@ -126,9 +129,13 @@ public class MockRequestBuilder {
 				}
 			}
 
+            Set<String> queryParameterKeys = Sets.newLinkedHashSet();
 			for (QueryParameter queryParameter: queryParameters) {
 				allowing(request).queryParameter(queryParameter.key()); will(returnValue(queryParameter));
+                queryParameterKeys.add(queryParameter.key());
 			}
+            allowing(request).getAllQueryParameterKeys(); will(returnValue(newLinkedHashSet(queryParameterKeys)));
+            allowing(request).queryParameter(with(any(String.class))); will(returnValue(queryParam("key", "value")));
 
 			allowing(request).header(with(any(String.class))); will(returnValue(httpHeader("key", "value")));
 


### PR DESCRIPTION
It is sometimes needed to be able to verify that a request was sent without a query parameter. 
This pull request add this ability, similar to the existing support for requiring absent headers.