### PR TITLE
Allow equalToJson to accept unencoded JSON (issue #763)

### DIFF
--- a/docs-v2/_docs/request-matching.md
+++ b/docs-v2/_docs/request-matching.md
@@ -347,7 +347,7 @@ JSON:
   "request": {
     ...
     "bodyPatterns" : [ {
-      "equalToJson" : "{ \"total_results\": 4 }"
+      "equalToJson" : { "total_results": 4 }
     } ]
     ...
   },
@@ -355,6 +355,20 @@ JSON:
 }
 ```
 
+JSON with string literal:
+
+```json
+{
+  "request": {
+    ...
+    "bodyPatterns" : [ {
+      "equalToJson" : "{ \"total_results\": 4 }"
+    } ]
+    ...
+  },
+  ...
+}
+```
 
 By default different array orderings and additional object attributes will trigger a non-match. However, both of these conditions can be disabled individually.
 

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/EqualToJsonPattern.java
@@ -38,6 +38,7 @@ public class EqualToJsonPattern extends StringValuePattern {
     private final JsonNode expected;
     private final Boolean ignoreArrayOrder;
     private final Boolean ignoreExtraElements;
+    private final Boolean serializeAsString;
 
     public EqualToJsonPattern(@JsonProperty("equalToJson") String json,
                               @JsonProperty("ignoreArrayOrder") Boolean ignoreArrayOrder,
@@ -46,6 +47,22 @@ public class EqualToJsonPattern extends StringValuePattern {
         expected = Json.read(json, JsonNode.class);
         this.ignoreArrayOrder = ignoreArrayOrder;
         this.ignoreExtraElements = ignoreExtraElements;
+        this.serializeAsString = true;
+    }
+
+    public EqualToJsonPattern(JsonNode jsonNode,
+                              Boolean ignoreArrayOrder,
+                              Boolean ignoreExtraElements) {
+        super(Json.write(jsonNode));
+        expected = jsonNode;
+        this.ignoreArrayOrder = ignoreArrayOrder;
+        this.ignoreExtraElements = ignoreExtraElements;
+        this.serializeAsString = false;
+    }
+
+    @JsonProperty("equalToJson")
+    public Object getSerializedEqualToJson() {
+        return serializeAsString ? getValue() : expected;
     }
 
     public String getEqualToJson() {

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/StringValuePatternJsonDeserializer.java
@@ -110,12 +110,17 @@ public class StringValuePatternJsonDeserializer extends JsonDeserializer<StringV
             throw new JsonMappingException(rootNode.toString() + " is not a valid comparison");
         }
 
-        String operand = rootNode.findValue("equalToJson").textValue();
+        JsonNode operand = rootNode.findValue("equalToJson");
 
         Boolean ignoreArrayOrder = fromNullable(rootNode.findValue("ignoreArrayOrder"));
         Boolean ignoreExtraElements = fromNullable(rootNode.findValue("ignoreExtraElements"));
 
-        return new EqualToJsonPattern(operand, ignoreArrayOrder, ignoreExtraElements);
+        // Allow either a JSON value or a string containing JSON
+        if (operand.isTextual()) {
+            return new EqualToJsonPattern(operand.textValue(), ignoreArrayOrder, ignoreExtraElements);
+        } else {
+            return new EqualToJsonPattern(operand, ignoreArrayOrder, ignoreExtraElements);
+        }
     }
 
     private MatchesJsonPathPattern deserialiseMatchesJsonPathPattern(JsonNode rootNode) throws JsonMappingException {

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToJsonTest.java
@@ -24,6 +24,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -276,7 +277,7 @@ public class EqualToJsonTest {
     }
 
     @Test
-    public void correctlyDeserialisesFromJsonWhenAdditionalParamsPresent() {
+    public void correctlyDeserialisesFromJsonStringWhenAdditionalParamsPresent() {
         StringValuePattern pattern = Json.read(
             "{\n" +
             "    \"equalToJson\": \"2\",\n" +
@@ -287,10 +288,45 @@ public class EqualToJsonTest {
         );
 
         assertThat(pattern, instanceOf(EqualToJsonPattern.class));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreArrayOrder(), is(true));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreExtraElements(), is(true));
+        assertThat(pattern.getExpected(), is("2"));
     }
 
     @Test
-    public void correctlySerialisesToJsonWhenAdditionalParamsPresent() throws JSONException {
+    public void correctlyDeserialisesFromJsonValueWhenAdditionalParamsPresent() throws JSONException {
+        String expectedJson = "{ \"someKey\": \"someValue\" }";
+        String serializedJson =
+            "{                                           \n" +
+            "    \"equalToJson\": " + expectedJson + ",  \n" +
+            "    \"ignoreArrayOrder\": true,             \n" +
+            "    \"ignoreExtraElements\": true           \n" +
+            "}                                             ";
+        StringValuePattern pattern = Json.read(serializedJson, StringValuePattern.class);
+
+        assertThat(pattern, instanceOf(EqualToJsonPattern.class));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreArrayOrder(), is(true));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreExtraElements(), is(true));
+        JSONAssert.assertEquals(pattern.getExpected(), expectedJson, false);
+    }
+
+    @Test
+    public void correctlySerialisesToJsonValueWhenAdditionalParamsPresentAndConstructedWithJsonValue() throws JSONException {
+        String expectedJson = "{ \"someKey\": \"someValue\" }";
+        EqualToJsonPattern pattern = new EqualToJsonPattern(Json.node(expectedJson), true, true);
+
+        String serialised = Json.write(pattern);
+        String expected =
+            "{                                           \n" +
+            "    \"equalToJson\": " + expectedJson + ",  \n" +
+            "    \"ignoreArrayOrder\": true,             \n" +
+            "    \"ignoreExtraElements\": true           \n" +
+            "}                                             ";
+        JSONAssert.assertEquals(expected, serialised, false);
+    }
+
+    @Test
+    public void correctlySerialisesToJsonWhenAdditionalParamsPresentAndConstructedWithString() throws JSONException {
         EqualToJsonPattern pattern = new EqualToJsonPattern("4444", true, true);
 
         String serialised = Json.write(pattern);
@@ -305,7 +341,7 @@ public class EqualToJsonTest {
     }
 
     @Test
-    public void correctlyDeserialisesFromJsonWhenAdditionalParamsAbsent() {
+    public void correctlyDeserialisesFromJsonStringWhenAdditionalParamsAbsent() {
         StringValuePattern pattern = Json.read(
             "{\n" +
             "    \"equalToJson\": \"2\"\n" +
@@ -314,6 +350,29 @@ public class EqualToJsonTest {
         );
 
         assertThat(pattern, instanceOf(EqualToJsonPattern.class));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreArrayOrder(), is(nullValue()));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreExtraElements(), is(nullValue()));
+        assertThat(pattern.getExpected(), is("2"));
+    }
+
+    @Test
+    public void correctlyDeserialisesFromJsonValueWhenAdditionalParamsAbsent() throws JSONException {
+        String expectedJson = "[ 1, 2, \"value\" ]";
+        StringValuePattern pattern = Json.read("{ \"equalToJson\": " + expectedJson + " }", StringValuePattern.class);
+
+        assertThat(pattern, instanceOf(EqualToJsonPattern.class));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreArrayOrder(), is(nullValue()));
+        assertThat(((EqualToJsonPattern) pattern).isIgnoreExtraElements(), is(nullValue()));
+        JSONAssert.assertEquals(pattern.getExpected(), expectedJson, false);
+    }
+
+    @Test
+    public void correctlySerialisesToJsonWhenAdditionalParamsAbsentAndConstructedWithJsonValue() throws JSONException {
+        String expectedJson = "[ 1, 2, \"value\" ]";
+        EqualToJsonPattern pattern = new EqualToJsonPattern(Json.node(expectedJson), null, null);
+
+        String serialised = Json.write(pattern);
+        JSONAssert.assertEquals("{ \"equalToJson\": " + expectedJson + " }", serialised, false);
     }
 
     @Test


### PR DESCRIPTION
This allows setting "equalToJson" to a raw JSON value when submitting a request matcher to the API, as requested in #763 . I updated the serialization code so it will write an unencoded string if the original was unencoded.