### PR TITLE
Switched base64 encoding to native Java library

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
@@ -15,19 +15,19 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import com.google.common.io.BaseEncoding;
+import java.util.Base64; 
 
 public class Encoding {
 
     public static byte[] decodeBase64(String base64) {
         return base64 != null ?
-            BaseEncoding.base64().decode(base64) :
+            Base64.getDecoder().decode(base64) :
             null;
     }
 
     public static String encodeBase64(byte[] content) {
         return content != null ?
-            BaseEncoding.base64().encode(content) :
+            Base64.getEncoder().encodeToString(content) :
             null;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
@@ -15,19 +15,19 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import java.util.Base64; 
+import javax.xml.bind.DatatypeConverter;
 
 public class Encoding {
 
     public static byte[] decodeBase64(String base64) {
         return base64 != null ?
-            Base64.getDecoder().decode(base64) :
+            DatatypeConverter.parseBase64Binary(base64) :
             null;
     }
 
     public static String encodeBase64(byte[] content) {
         return content != null ?
-            Base64.getEncoder().encodeToString(content) :
+            DatatypeConverter.printBase64Binary(content) :
             null;
     }
 }


### PR DESCRIPTION
Better performing according to this: http://java-performance.info/base64-encoding-and-decoding-performance/

Been profiling stubs with base64 encoded JSON objects and base64->encoding/decoding is by far the hottest method.