### PR TITLE
Relative rootPath in FileSource

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -123,7 +123,7 @@ public abstract class AbstractFileSource implements FileSource {
         assertWritable();
         final Path writablePath = Paths.get(name);
         if (writablePath.isAbsolute()) {
-            if (!writablePath.startsWith(rootDirectory.toPath())) {
+            if (!writablePath.startsWith(rootDirectory.toPath().toAbsolutePath())) {
                 throw new IllegalArgumentException(name + " is an absolute path not under the root directory");
             }
             return writablePath.toFile();

--- a/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
@@ -15,8 +15,12 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.fileNamed;
@@ -60,5 +64,13 @@ public class SingleRootFileSourceTest {
 	public void deleteThrowsExceptionWhenGivenPathNotUnderRoot() {
 		SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource");
 		fileSource.deleteFile("/somewhere/not/under/root");
+	}
+
+	@Test
+	public void writesTextFileEvenWhenRootIsARelativePath() throws IOException {
+		String relativeRootPath = "./target/tmp/";
+		FileUtils.forceMkdir(new File(relativeRootPath));
+		SingleRootFileSource fileSource = new SingleRootFileSource(relativeRootPath);
+		fileSource.writeTextFile(Paths.get(relativeRootPath).toAbsolutePath().resolve("myFile").toString(), "stuff");
 	}
 }


### PR DESCRIPTION
Sometimes you might want to provide the rootPath relative to the current directory, for example ../external/wiremock-files-root. I have made that possible now.