### PR TITLE
Fixing path issues on Windows. The issue was that for a URI "file:/c:…

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/TextFile.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/TextFile.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
+import java.io.File;
 import java.net.URI;
 
 import static com.google.common.base.Charsets.UTF_8;
@@ -28,4 +29,8 @@ public class TextFile extends BinaryFile {
 	public String readContentsAsString() {
         return new String(super.readContents(), UTF_8);
 	}
+
+    public String getPath() {
+        return new File(getUri().getSchemeSpecificPart()).getPath();
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
@@ -15,7 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.standalone;
 
-import com.github.tomakehurst.wiremock.common.*;
+import com.github.tomakehurst.wiremock.common.AbstractFileSource;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.SafeNames;
+import com.github.tomakehurst.wiremock.common.TextFile;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.stubbing.StubMappings;
 
@@ -82,7 +85,8 @@ public class JsonFileMappingsSource implements MappingsSource {
             StubMapping mapping = StubMapping.buildFrom(mappingFile.readContentsAsString());
             mapping.setDirty(false);
 			stubMappings.addMapping(mapping);
-			fileNameMap.put(mapping.getId(), mappingFile.getUri().getSchemeSpecificPart());
+			fileNameMap.put(mapping.getId(), mappingFile.getPath());
 		}
 	}
+
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/TextFileTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/TextFileTest.java
@@ -1,0 +1,33 @@
+package com.github.tomakehurst.wiremock.common;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+public class TextFileTest {
+    @Test
+    public void returnsPathToFileOnLinuxSystems() throws Exception {
+        TextFile textFile = new TextFile(new URI("file://home/bob/myfile.txt"));
+
+        String path = textFile.getPath();
+
+        assertEquals("/home/bob/myfile.txt", path);
+    }
+
+    @Test
+    public void returnsPathToFileOnWindowsSystems() throws Exception {
+        assumeTrue("This test can only be run on Windows " +
+                "because File uses FileSystem in its constructor " +
+                "and its behaviour is OS specific", SystemUtils.IS_OS_WINDOWS);
+
+        TextFile textFile = new TextFile(new URI("file:/C:/Users/bob/myfile.txt"));
+
+        String path = textFile.getPath();
+
+        assertEquals("C:/Users/bob/myfile.txt", path);
+    }
+}


### PR DESCRIPTION
…/bob" on windows a call to uri.getSchemeSpecificPart() would have returned an incorrect Windows path /c:/bob which was then passed around Wiremock codebase and used as a filename, and resulted in file not found issues further down the line.