### PR TITLE
Fixed typo in _docs/extending-wiremock

### DIFF
--- a/docs-v2/_docs/extending-wiremock.md
+++ b/docs-v2/_docs/extending-wiremock.md
@@ -261,7 +261,7 @@ public class BodyLengthMatcher extends RequestMatcherExtension {
 Then define a stub with it:
 
 ```java
-stubFor(requestMatching("body-too-long", Parameters.one("maxLemgth", 2048))
+stubFor(requestMatching("body-too-long", Parameters.one("maxLength", 2048))
         .willReturn(aResponse().withStatus(422)));
 ```
 
@@ -273,7 +273,7 @@ or via JSON:
         "customMatcher" : {
             "name" : "body-too-long",
             "parameters" : {
-                "maxLemgth" : 2048
+                "maxLength" : 2048
             }
         }
     },


### PR DESCRIPTION
maxLemgth -> maxLength

Note: I don't know why Github is showing me this as well in the diff:
```
-you can use the ```CollectingNetworkTrafficListener```.
+you can use the ```CollectingNetworkTrafficListener```.
```
But it doesn't show in rich-diff view & made sure they're the same sentences. Conclusion: Safe to ignore.