### PR TITLE
Fixed #574 - Move delay logic so that request is received by RequestJ…

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -31,6 +31,7 @@ public class Response {
 	private final boolean configured;
 	private final Fault fault;
 	private final boolean fromProxy;
+	private final long initialDelay;
     private final ChunkedDribbleDelay chunkedDribbleDelay;
 
 	public static Response notConfigured() {
@@ -41,6 +42,7 @@ public class Response {
                 noHeaders(),
                 false,
                 null,
+                0,
                 null,
                 false
         );
@@ -50,24 +52,26 @@ public class Response {
         return new Builder();
     }
 
-	public Response(int status, String statusMessage, byte[] body, HttpHeaders headers, boolean configured, Fault fault, ChunkedDribbleDelay chunkedDribbleDelay, boolean fromProxy) {
+	public Response(int status, String statusMessage, byte[] body, HttpHeaders headers, boolean configured, Fault fault, long initialDelay, ChunkedDribbleDelay chunkedDribbleDelay, boolean fromProxy) {
 		this.status = status;
         this.statusMessage = statusMessage;
         this.body = body;
         this.headers = headers;
         this.configured = configured;
         this.fault = fault;
+        this.initialDelay = initialDelay;
         this.chunkedDribbleDelay = chunkedDribbleDelay;
         this.fromProxy = fromProxy;
     }
 
-    public Response(int status, String statusMessage, String body, HttpHeaders headers, boolean configured, Fault fault, ChunkedDribbleDelay chunkedDribbleDelay, boolean fromProxy) {
+    public Response(int status, String statusMessage, String body, HttpHeaders headers, boolean configured, Fault fault, long initialDelay, ChunkedDribbleDelay chunkedDribbleDelay, boolean fromProxy) {
         this.status = status;
         this.statusMessage = statusMessage;
         this.headers = headers;
         this.body = body == null ? null : Strings.bytesFromString(body, headers.getContentTypeHeader().charset());
         this.configured = configured;
         this.fault = fault;
+        this.initialDelay = initialDelay;
         this.chunkedDribbleDelay = chunkedDribbleDelay;
         this.fromProxy = fromProxy;
     }
@@ -95,6 +99,10 @@ public class Response {
     public Fault getFault() {
         return fault;
     }
+
+    public long getInitialDelay() {
+	    return initialDelay;
+	}
 
     public ChunkedDribbleDelay getChunkedDribbleDelay() {
         return chunkedDribbleDelay;
@@ -134,6 +142,7 @@ public class Response {
         private Fault fault;
         private boolean fromProxy;
         private Optional<ResponseDefinition> renderedFromDefinition;
+        private long initialDelay;
         private ChunkedDribbleDelay chunkedDribbleDelay;
 
         public static Builder like(Response response) {
@@ -143,6 +152,7 @@ public class Response {
             responseBuilder.headers = response.getHeaders();
             responseBuilder.configured = response.wasConfigured();
             responseBuilder.fault = response.getFault();
+            responseBuilder.initialDelay = response.getInitialDelay();
             responseBuilder.chunkedDribbleDelay = response.getChunkedDribbleDelay();
             responseBuilder.fromProxy = response.isFromProxy();
             return responseBuilder;
@@ -197,6 +207,11 @@ public class Response {
             return this;
         }
 
+        public Builder incrementInitialDelay(long amountMillis) {
+            this.initialDelay += amountMillis;
+            return this;
+        }
+
         public Builder chunkedDribbleDelay(ChunkedDribbleDelay chunkedDribbleDelay) {
             this.chunkedDribbleDelay = chunkedDribbleDelay;
             return this;
@@ -209,11 +224,11 @@ public class Response {
 
         public Response build() {
             if (body != null) {
-                return new Response(status, statusMessage, body, headers, configured, fault, chunkedDribbleDelay, fromProxy);
+                return new Response(status, statusMessage, body, headers, configured, fault, initialDelay, chunkedDribbleDelay, fromProxy);
             } else if (bodyString != null) {
-                return new Response(status, statusMessage, bodyString, headers, configured, fault, chunkedDribbleDelay, fromProxy);
+                return new Response(status, statusMessage, bodyString, headers, configured, fault, initialDelay, chunkedDribbleDelay, fromProxy);
             } else {
-                return new Response(status, statusMessage, new byte[0], headers, configured, fault, chunkedDribbleDelay, fromProxy);
+                return new Response(status, statusMessage, new byte[0], headers, configured, fault, initialDelay, chunkedDribbleDelay, fromProxy);
             }
         }
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -56,13 +56,13 @@ public class StubResponseRenderer implements ResponseRenderer {
 	}
 
 	private Response buildResponse(ResponseDefinition responseDefinition) {
-		addDelayIfSpecifiedGloballyOrIn(responseDefinition);
-		addRandomDelayIfSpecifiedGloballyOrIn(responseDefinition);
-
 		if (responseDefinition.isProxyResponse()) {
 			return proxyResponseRenderer.render(responseDefinition);
 		} else {
-			return renderDirectly(responseDefinition);
+			Response.Builder responseBuilder = renderDirectly(responseDefinition);
+			addDelayIfSpecifiedGloballyOrIn(responseDefinition, responseBuilder);
+			addRandomDelayIfSpecifiedGloballyOrIn(responseDefinition, responseBuilder);
+			return responseBuilder.build();
 		}
 	}
 
@@ -83,7 +83,7 @@ public class StubResponseRenderer implements ResponseRenderer {
 		return applyTransformations(request, responseDefinition, newResponse, transformers.subList(1, transformers.size()));
 	}
 
-	private Response renderDirectly(ResponseDefinition responseDefinition) {
+	private Response.Builder renderDirectly(ResponseDefinition responseDefinition) {
         Response.Builder responseBuilder = response()
                 .status(responseDefinition.getStatus())
 				.statusMessage(responseDefinition.getStatusMessage())
@@ -102,44 +102,35 @@ public class StubResponseRenderer implements ResponseRenderer {
             }
 		}
 
-        return responseBuilder.build();
+        return responseBuilder;
 	}
 	
-    private void addDelayIfSpecifiedGloballyOrIn(ResponseDefinition response) {
-    	Optional<Integer> optionalDelay = getDelayFromResponseOrGlobalSetting(response);
+    private void addDelayIfSpecifiedGloballyOrIn(ResponseDefinition responseDefinition, Response.Builder responseBuilder) {
+    	Optional<Integer> optionalDelay = getDelayFromResponseOrGlobalSetting(responseDefinition);
         if (optionalDelay.isPresent()) {
-	        try {
-	            Thread.sleep(optionalDelay.get());
-	        } catch (InterruptedException e) {
-	            Thread.currentThread().interrupt();
-	        }
+        	responseBuilder.incrementInitialDelay(optionalDelay.get());
 	    }
     }
     
-    private Optional<Integer> getDelayFromResponseOrGlobalSetting(ResponseDefinition response) {
-    	Integer delay = response.getFixedDelayMilliseconds() != null ?
-    			response.getFixedDelayMilliseconds() :
+    private Optional<Integer> getDelayFromResponseOrGlobalSetting(ResponseDefinition responseDefinition) {
+    	Integer delay = responseDefinition.getFixedDelayMilliseconds() != null ?
+    			responseDefinition.getFixedDelayMilliseconds() :
     			globalSettingsHolder.get().getFixedDelay();
     	
     	return Optional.fromNullable(delay);
     }
 
-    private void addRandomDelayIfSpecifiedGloballyOrIn(ResponseDefinition response) {
-		if (response.getDelayDistribution() != null) {
-			addRandomDelayIn(response.getDelayDistribution());
+    private void addRandomDelayIfSpecifiedGloballyOrIn(ResponseDefinition responseDefinition, Response.Builder responseBuilder) {
+		DelayDistribution delayDistribution;
+
+		if (responseDefinition.getDelayDistribution() != null) {
+			delayDistribution = responseDefinition.getDelayDistribution();
 		} else {
-			addRandomDelayIn(globalSettingsHolder.get().getDelayDistribution());
+			delayDistribution = globalSettingsHolder.get().getDelayDistribution();
+		}
+
+		if (delayDistribution != null) {
+			responseBuilder.incrementInitialDelay(delayDistribution.sampleMillis());
 		}
     }
-
-	private void addRandomDelayIn(DelayDistribution delayDistribution) {
-		if (delayDistribution == null) return;
-
-		long delay = delayDistribution.sampleMillis();
-		try {
-           TimeUnit.MILLISECONDS.sleep(delay);
-        } catch (InterruptedException e) {
-           Thread.currentThread().interrupt();
-        }
-	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
@@ -120,6 +121,8 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
 
             httpServletRequest.setAttribute(ORIGINAL_REQUEST_KEY, LoggedRequest.createFrom(request));
 
+            delayIfRequired(response.getInitialDelay());
+
             try {
                 if (response.wasConfigured()) {
                     applyResponse(response, httpServletRequest, httpServletResponse);
@@ -132,6 +135,14 @@ public class WireMockHandlerDispatchingServlet extends HttpServlet {
                 throwUnchecked(e);
             }
         }
+
+		private void delayIfRequired(long delayMillis) {
+			try {
+				TimeUnit.MILLISECONDS.sleep(delayMillis);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
 	}
 
     public void applyResponse(Response response, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
@@ -1,0 +1,117 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
+import org.jmock.Mockery;
+import org.jmock.integration.junit4.JMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(JMock.class)
+public class StubResponseRendererTest {
+    private static final int EXECUTE_WITHOUT_SLEEP_MILLIS = 100;
+
+    private Mockery context;
+    private FileSource fileSource;
+    private GlobalSettingsHolder globalSettingsHolder;
+    private List<ResponseTransformer> responseTransformers;
+    private StubResponseRenderer stubResponseRenderer;
+
+    @Before
+    public void init() {
+        context = new Mockery();
+        fileSource = context.mock(FileSource.class);
+        globalSettingsHolder = new GlobalSettingsHolder();
+        responseTransformers = new ArrayList<>();
+        stubResponseRenderer = new StubResponseRenderer(fileSource, globalSettingsHolder, null, responseTransformers);
+    }
+
+    @Test(timeout = EXECUTE_WITHOUT_SLEEP_MILLIS)
+    public void endpointFixedDelayShouldOverrideGlobalDelay() throws Exception {
+        globalSettingsHolder.get().setFixedDelay(1000);
+
+        Response response = stubResponseRenderer.render(createResponseDefinition(100));
+
+        assertThat(response.getInitialDelay(), is(100L));
+    }
+
+    @Test(timeout = EXECUTE_WITHOUT_SLEEP_MILLIS)
+    public void globalFixedDelayShouldNotBeOverriddenIfNoEndpointDelaySpecified() throws Exception {
+        globalSettingsHolder.get().setFixedDelay(1000);
+
+        Response response = stubResponseRenderer.render(createResponseDefinition(null));
+
+        assertThat(response.getInitialDelay(), is(1000L));
+    }
+
+    @Test(timeout = EXECUTE_WITHOUT_SLEEP_MILLIS)
+    public void shouldSetGlobalFixedDelayOnResponse() throws Exception {
+        globalSettingsHolder.get().setFixedDelay(1000);
+
+        Response response = stubResponseRenderer.render(createResponseDefinition(null));
+
+        assertThat(response.getInitialDelay(), is(1000L));
+    }
+
+    @Test(timeout = EXECUTE_WITHOUT_SLEEP_MILLIS)
+    public void shouldSetEndpointFixedDelayOnResponse() throws Exception {
+        Response response = stubResponseRenderer.render(createResponseDefinition(2000));
+
+        assertThat(response.getInitialDelay(), is(2000L));
+    }
+
+    @Test(timeout = EXECUTE_WITHOUT_SLEEP_MILLIS)
+    public void shouldSetEndpointDistributionDelayOnResponse() throws Exception {
+        globalSettingsHolder.get().setDelayDistribution(new DelayDistribution() {
+            @Override
+            public long sampleMillis() {
+                return 123;
+            }
+        });
+
+        Response response = stubResponseRenderer.render(createResponseDefinition(null));
+
+        assertThat(response.getInitialDelay(), is(123L));
+    }
+
+    @Test(timeout = EXECUTE_WITHOUT_SLEEP_MILLIS)
+    public void shouldCombineFixedDelayDistributionDelay() throws Exception {
+        globalSettingsHolder.get().setDelayDistribution(new DelayDistribution() {
+            @Override
+            public long sampleMillis() {
+                return 123;
+            }
+        });
+        Response response = stubResponseRenderer.render(createResponseDefinition(2000));
+        assertThat(response.getInitialDelay(), is(2123L));
+    }
+
+    private ResponseDefinition createResponseDefinition(Integer fixedDelayMillis) {
+        return new ResponseDefinition(
+                0,
+                "",
+                "",
+                null,
+                "",
+                "",
+                null,
+                null,
+                fixedDelayMillis,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                true
+        );
+    }
+}


### PR DESCRIPTION
…ournal before delay happens.

We noticed this issue when we upgraded to latest wiremock. We noticed the chunked delay happens as part of the servlet and thought moving the fixed delays there would also be a good strategy and fix our issue.  Let us know if you'd like to see other changes.

Regards, Paul & Howard. 

