### PR TITLE
Misleading error message

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
@@ -73,7 +73,7 @@ public class VerificationException extends AssertionError {
 
     public VerificationException(RequestPattern expected, int expectedCount, int actualCount) {
         super(String.format(
-            "Expected exactly %d requests matching the following pattern but received only %d:\n%s",
+            "Expected exactly %d requests matching the following pattern but received %d:\n%s",
             expectedCount,
             actualCount,
             expected.toString()));


### PR DESCRIPTION
If there were more  requests than expected, the error message is misleading:

    Expected exactly 1 requests [...] but received only 2