### PR TITLE
Add ThreadPoolFactory to enable custom ThreadPool for Jetty.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -15,10 +15,15 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
-import com.github.tomakehurst.wiremock.common.*;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.HttpsSettings;
+import com.github.tomakehurst.wiremock.common.JettySettings;
+import com.github.tomakehurst.wiremock.common.Notifier;
+import com.github.tomakehurst.wiremock.common.ProxySettings;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.github.tomakehurst.wiremock.standalone.MappingsLoader;
@@ -52,6 +57,7 @@ public interface Options {
     boolean shouldPreserveHostHeader();
     String proxyHostHeader();
     HttpServerFactory httpServerFactory();
+    ThreadPoolFactory threadPoolFactory();
     <T extends Extension> Map<String, T> extensionsOfType(Class<T> extensionType);
     WiremockNetworkTrafficListener networkTrafficListener();
     Authenticator getAdminAuthenticator();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -15,15 +15,16 @@
  */
 package com.github.tomakehurst.wiremock.core;
 
-import com.github.tomakehurst.wiremock.admin.AdminTask;
 import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionLoader;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.jetty9.JettyHttpServerFactory;
+import com.github.tomakehurst.wiremock.jetty9.QueuedThreadPoolFactory;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.github.tomakehurst.wiremock.security.BasicAuthenticator;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
@@ -75,6 +76,7 @@ public class WireMockConfiguration implements Options {
     private boolean preserveHostHeader;
     private String proxyHostHeader;
     private HttpServerFactory httpServerFactory = new JettyHttpServerFactory();
+    private ThreadPoolFactory threadPoolFactory = new QueuedThreadPoolFactory();
     private Integer jettyAcceptors;
     private Integer jettyAcceptQueueSize;
     private Integer jettyHeaderBufferSize;
@@ -287,6 +289,11 @@ public class WireMockConfiguration implements Options {
         return this;
     }
 
+    public WireMockConfiguration threadPoolFactory(ThreadPoolFactory threadPoolFactory) {
+        this.threadPoolFactory = threadPoolFactory;
+        return this;
+    }
+
     public WireMockConfiguration networkTrafficListener(WiremockNetworkTrafficListener networkTrafficListener) {
         this.networkTrafficListener = networkTrafficListener;
         return this;
@@ -398,6 +405,11 @@ public class WireMockConfiguration implements Options {
     @Override
     public HttpServerFactory httpServerFactory() {
         return httpServerFactory;
+    }
+
+    @Override
+    public ThreadPoolFactory threadPoolFactory() {
+        return threadPoolFactory;
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ThreadPoolFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ThreadPoolFactory.java
@@ -1,0 +1,9 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import org.eclipse.jetty.util.thread.ThreadPool;
+
+public interface ThreadPoolFactory {
+
+    ThreadPool buildThreadPool(Options options);
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -111,7 +111,7 @@ public class JettyHttpServer implements HttpServer {
     }
 
     protected Server createServer(Options options) {
-        final Server server = new Server(new QueuedThreadPool(options.containerThreads()));
+        final Server server = new Server(options.threadPoolFactory().buildThreadPool(options));
         final JettySettings jettySettings = options.jettySettings();
         final Optional<Long> stopTimeout = jettySettings.getStopTimeout();
         if(stopTimeout.isPresent()) {

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/QueuedThreadPoolFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/QueuedThreadPoolFactory.java
@@ -1,0 +1,14 @@
+package com.github.tomakehurst.wiremock.jetty9;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+
+public class QueuedThreadPoolFactory implements ThreadPoolFactory {
+
+    @Override
+    public ThreadPool buildThreadPool(Options options) {
+        return new QueuedThreadPool(options.containerThreads());
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.security.Authenticator;
@@ -133,6 +134,11 @@ public class WarConfiguration implements Options {
 
     @Override
     public HttpServerFactory httpServerFactory() {
+        return null;
+    }
+
+    @Override
+    public ThreadPoolFactory threadPoolFactory() {
         return null;
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -28,10 +28,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import com.github.tomakehurst.wiremock.admin.AdminTask;
 import com.github.tomakehurst.wiremock.common.*;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.core.MappingsSaver;
 import com.github.tomakehurst.wiremock.core.Options;
@@ -190,6 +190,19 @@ public class CommandLineOptions implements Options {
                     "com.github.tomakehurst.wiremock.jetty9.JettyHttpServerFactory"
             );
             return (HttpServerFactory) cls.newInstance();
+        } catch (Exception e) {
+            return throwUnchecked(e, null);
+        }
+    }
+
+    @Override
+    public ThreadPoolFactory threadPoolFactory() {
+        try {
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            Class<?> cls = loader.loadClass(
+                    "com.github.tomakehurst.wiremock.jetty9.QueuedThreadPoolFactory"
+            );
+            return (ThreadPoolFactory) cls.newInstance();
         } catch (Exception e) {
             return throwUnchecked(e, null);
         }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -42,6 +42,7 @@ import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.ConsoleNotifyingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
+import com.github.tomakehurst.wiremock.jetty9.QueuedThreadPoolFactory;
 import com.github.tomakehurst.wiremock.security.Authenticator;
 import com.github.tomakehurst.wiremock.security.BasicAuthenticator;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
@@ -197,15 +198,7 @@ public class CommandLineOptions implements Options {
 
     @Override
     public ThreadPoolFactory threadPoolFactory() {
-        try {
-            ClassLoader loader = Thread.currentThread().getContextClassLoader();
-            Class<?> cls = loader.loadClass(
-                    "com.github.tomakehurst.wiremock.jetty9.QueuedThreadPoolFactory"
-            );
-            return (ThreadPoolFactory) cls.newInstance();
-        } catch (Exception e) {
-            return throwUnchecked(e, null);
-        }
+        return new QueuedThreadPoolFactory();
     }
 
     private boolean specifiesPortNumber() {
@@ -274,7 +267,7 @@ public class CommandLineOptions implements Options {
     public boolean help() {
 		return optionSet.has(HELP);
 	}
-	
+
 	public String helpText() {
 		return helpText;
 	}

--- a/src/test/java/com/github/tomakehurst/wiremock/QueuedThreadPoolAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/QueuedThreadPoolAcceptanceTest.java
@@ -1,0 +1,59 @@
+package com.github.tomakehurst.wiremock;
+
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.thread.ThreadPool;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class QueuedThreadPoolAcceptanceTest extends AcceptanceTestBase {
+
+    @BeforeClass
+    public static void setupServer() {
+        setupServer(new WireMockConfiguration().threadPoolFactory(new InstrumentedThreadPoolFactory()));
+    }
+
+    @Test
+    public void serverUseCustomInstrumentedQueuedThreadPool() {
+        assertThat(InstrumentedQueuedThreadPool.flag, is(true));
+    }
+
+    public static class InstrumentedQueuedThreadPool extends QueuedThreadPool {
+        public static boolean flag = false;
+
+        public InstrumentedQueuedThreadPool(int maxThreads) {
+            this(maxThreads, 8);
+        }
+
+        public InstrumentedQueuedThreadPool(
+                int maxThreads,
+                int minThreads) {
+            this(maxThreads, minThreads, 60000);
+        }
+
+        public InstrumentedQueuedThreadPool(
+                int maxThreads,
+                int minThreads,
+                int idleTimeout) {
+            super(maxThreads, minThreads, idleTimeout, null);
+        }
+
+        @Override
+        protected void doStart() throws Exception {
+            super.doStart();
+            flag = true;
+        }
+    }
+
+    public static class InstrumentedThreadPoolFactory implements ThreadPoolFactory {
+        @Override
+        public ThreadPool buildThreadPool(Options options) {
+            return new InstrumentedQueuedThreadPool(options.containerThreads());
+        }
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -1,6 +1,7 @@
 package com.github.tomakehurst.wiremock.core;
 
 import com.google.common.base.Optional;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -23,5 +24,15 @@ public class WireMockConfigurationTest {
         WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig();
         Optional<Long> jettyStopTimeout = wireMockConfiguration.jettySettings().getStopTimeout();
         assertThat(jettyStopTimeout.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldUseQueuedThreadPoolByDefault() {
+        int maxThreads = 20;
+        WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig().containerThreads(maxThreads);
+
+        QueuedThreadPool threadPool = (QueuedThreadPool) wireMockConfiguration.threadPoolFactory().buildThreadPool(wireMockConfiguration);
+
+        assertThat(threadPool.getMaxThreads(), is(maxThreads));
     }
 }


### PR DESCRIPTION
Allow setting a ThreadPool for Jetty server.

Useful when needs to use a InstrumentedQueuedThreadPool.