### PR TITLE
add runtime switch for base64 encoder

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/Base64Encoder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Base64Encoder.java
@@ -1,0 +1,6 @@
+package com.github.tomakehurst.wiremock.common;
+
+interface Base64Encoder {
+    String encode(byte[] content);
+    byte[] decode(String base64);
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/DatatypeConverterBase64Encoder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/DatatypeConverterBase64Encoder.java
@@ -1,0 +1,15 @@
+package com.github.tomakehurst.wiremock.common;
+
+import javax.xml.bind.DatatypeConverter;
+
+class DatatypeConverterBase64Encoder implements Base64Encoder {
+    @Override
+    public String encode(byte[] content) {
+        return DatatypeConverter.printBase64Binary(content);
+    }
+
+    @Override
+    public byte[] decode(String base64) {
+        return DatatypeConverter.parseBase64Binary(base64);
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Encoding.java
@@ -15,19 +15,32 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import javax.xml.bind.DatatypeConverter;
-
 public class Encoding {
+
+    private static Base64Encoder encoder = null;
+
+    private static Base64Encoder getInstance() {
+        if (encoder == null) {
+            try {
+                Class.forName("javax.xml.bind.DatatypeConverter");
+                encoder = new DatatypeConverterBase64Encoder();
+            } catch (ClassNotFoundException e) {
+                encoder = new GuavaBase64Encoder();
+            }
+        }
+
+        return encoder;
+    }
 
     public static byte[] decodeBase64(String base64) {
         return base64 != null ?
-            DatatypeConverter.parseBase64Binary(base64) :
-            null;
+               getInstance().decode(base64) :
+               null;
     }
 
     public static String encodeBase64(byte[] content) {
         return content != null ?
-            DatatypeConverter.printBase64Binary(content) :
-            null;
+               getInstance().encode(content) :
+               null;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/GuavaBase64Encoder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/GuavaBase64Encoder.java
@@ -1,0 +1,15 @@
+package com.github.tomakehurst.wiremock.common;
+
+import com.google.common.io.BaseEncoding;
+
+public class GuavaBase64Encoder implements Base64Encoder {
+    @Override
+    public String encode(byte[] content) {
+        return BaseEncoding.base64().encode(content);
+    }
+
+    @Override
+    public byte[] decode(String base64) {
+        return BaseEncoding.base64().decode(base64);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/Base64EncoderTest.java
@@ -1,0 +1,33 @@
+package com.github.tomakehurst.wiremock.common;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class Base64EncoderTest {
+    public static final String INPUT = "1234";
+    public static final String OUTPUT = "MTIzNA==";
+
+    @Test
+    public void testDatatypeConverterEncoder() {
+        Base64Encoder encoder = new DatatypeConverterBase64Encoder();
+
+        String encoded = encoder.encode(INPUT.getBytes());
+        assertThat(encoded, is(OUTPUT));
+
+        String decoded = new String(encoder.decode(encoded));
+        assertThat(decoded, is(INPUT));
+    }
+
+    @Test
+    public void testGuavaEncoder() {
+        Base64Encoder encoder = new GuavaBase64Encoder();
+
+        String encoded = encoder.encode(INPUT.getBytes());
+        assertThat(encoded, is(OUTPUT));
+
+        String decoded = new String(encoder.decode(encoded));
+        assertThat(decoded, is(INPUT));
+    }
+}


### PR DESCRIPTION
Resolves #840 

As discussed in the Issue this PR adds a runtime check if the `DatatypeConverter` class is available and otherwise falls back to the previous Guava implementation. 