### PR TITLE
Add ResponseDefinitionBuilder#withCookie

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -92,6 +92,14 @@ public class ResponseDefinitionBuilder {
 		return this;
 	}
 
+	/**
+	 * @since 2.14.1
+	 */
+	public ResponseDefinitionBuilder withCookie(String name, String value) {
+		return withHeader(com.google.common.net.HttpHeaders.SET_COOKIE,
+				String.format("%s=%s", name, value));
+	}
+
 	public ResponseDefinitionBuilder withHeader(String key, String... values) {
 		headers.add(new HttpHeader(key, values));
 		return this;


### PR DESCRIPTION
A convenience method to stub a *response* with a 'Set-Cookie' header.
(a withCookie method for request matching was already present: see RequestPatternBuilder)

PS. I see that you are not using `@since` in javadoc. I think it's a good habit to take, but if you don't like, I can remove it :)