### PR TITLE
[docs] junit-rule: fix wrong info about @ClassRule

### DIFF
--- a/docs-v2/_docs/junit-rule.md
+++ b/docs-v2/_docs/junit-rule.md
@@ -40,28 +40,15 @@ a `VerificationException` is thrown, failing the test. This behaviour can be dis
 public WireMockRule wireMockRule = new WireMockRule(options().port(8888), false);
 ```
 
-## Other @Rule configurations
+## @ClassRule configuration
 
-With a bit more effort you can make the WireMock server continue to run
-between test cases. This is easiest in JUnit 4.10:
-
-```java
-@ClassRule
-@Rule
-public static WireMockClassRule wireMockRule = new WireMockClassRule(8089);
-```
-
-Unfortunately JUnit 4.11 and above prohibits `@Rule` on static members so a
-slightly more verbose form is required:
+Thanks to `@ClassRule`, you can make the WireMock server continue to run
+between test cases:
 
 ```java
 @ClassRule
-public static WireMockClassRule wireMockRule = new WireMockClassRule(8089);
-
-@Rule
-public WireMockClassRule instanceRule = wireMockRule;
+public static WireMockRule wireMockRule = new WireMockRule(8089);
 ```
-
 
 ## Accessing the stubbing and verification DSL from the rule
 


### PR DESCRIPTION
Any TestRule can have ClassRule semantics by just annotating it with @ClassRule instead of @Rule, and by declaring it as static.
See also http://junit.org/junit4/javadoc/4.12/org/junit/ClassRule.html.

I made a sample test class to demonstrate. Please see the following gist:
https://gist.github.com/alb-i986/f58756e4a34bc6e1ccea60b4846e62ef

Please note that in the snippet in the docs I changed WireMockClassRule to be WireMockRule: as far as I can tell they are exactly the same. Actually WireMockClassRule seems to have fewer features than WireMockRule (e.g. checkForUnmatchedRequests). Sounds like it has been forgotten. If this is true, I'd suggest to deprecate it and remove it in a future major version.

Please also note that it looks like there's no difference between JUnit 4.10 and 4.12 (tested), so I kept only one snippet.