### PR TITLE
Support HTTP2 by using Jetty 9.4.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def shouldPublishLocally = System.getProperty('LOCAL_PUBLISH')
 
 def versions = [
     jackson: '2.8.9',
-    jetty  : '9.2.22.v20170606',
+    jetty  : '9.4.8.v20171121',
     xmlUnit: '2.3.0'
 ]
 
@@ -48,6 +48,9 @@ dependencies {
     compile "org.eclipse.jetty:jetty-servlet:$versions.jetty"
     compile "org.eclipse.jetty:jetty-servlets:$versions.jetty"
     compile "org.eclipse.jetty:jetty-webapp:$versions.jetty"
+    compile "org.eclipse.jetty:jetty-alpn-conscrypt-server:$versions.jetty"
+    compile "org.eclipse.jetty.http2:http2-server:$versions.jetty"
+
     compile "com.google.guava:guava:20.0"
     compile "com.fasterxml.jackson.core:jackson-core:$versions.jackson",
         "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
@@ -67,6 +70,11 @@ dependencies {
         exclude group: 'org.mozilla', module: 'rhino'
     }
 
+
+    testCompile "org.eclipse.jetty.http2:http2-client:$versions.jetty"
+    testCompile "org.eclipse.jetty.http2:http2-http-client-transport:$versions.jetty"
+    testCompile "org.eclipse.jetty:jetty-client:$versions.jetty"
+    testCompile "org.eclipse.jetty:jetty-alpn-conscrypt-client:$versions.jetty"
     testCompile "org.hamcrest:hamcrest-all:1.3"
     testCompile("org.jmock:jmock:2.5.1") {
         exclude group: "junit", module: "junit-dep"

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -37,7 +37,7 @@ public interface Options {
 
     int DEFAULT_PORT = 8080;
     int DYNAMIC_PORT = 0;
-    int DEFAULT_CONTAINER_THREADS = 10;
+    int DEFAULT_CONTAINER_THREADS = 13;
     String DEFAULT_BIND_ADDRESS = "0.0.0.0";
 
     int portNumber();

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/CustomizedSslContextFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/CustomizedSslContextFactory.java
@@ -38,13 +38,12 @@ public class CustomizedSslContextFactory extends org.eclipse.jetty.util.ssl.SslC
         if (super.getNeedClientAuth())
             sslEngine.setNeedClientAuth(super.getNeedClientAuth());
 
-        sslEngine.setEnabledCipherSuites(super.selectCipherSuites(
-                sslEngine.getEnabledCipherSuites(),
-                sslEngine.getSupportedCipherSuites()));
+        super.selectCipherSuites(
+            sslEngine.getEnabledCipherSuites(),
+            sslEngine.getSupportedCipherSuites());
+        sslEngine.setEnabledCipherSuites(super.getSelectedCipherSuites());
 
-        sslEngine.setEnabledProtocols(super.selectProtocols(sslEngine.getEnabledProtocols(),sslEngine.getSupportedProtocols()));
+        super.selectProtocols(sslEngine.getEnabledProtocols(), sslEngine.getSupportedProtocols());
+        sslEngine.setEnabledProtocols(super.getSelectedProtocols());
     }
-
-
-
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -31,14 +31,15 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import org.apache.commons.lang3.ArrayUtils;
+import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.http.MimeTypes;
+import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.io.NetworkTrafficListener;
+import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.servlet.*;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
-import org.eclipse.jetty.servlets.GzipFilter;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import javax.servlet.DispatcherType;
 import java.net.Socket;
@@ -213,9 +214,18 @@ public class JettyHttpServer implements HttpServer {
             sslContextFactory.setTrustStoreType(httpsSettings.trustStoreType());
         }
         sslContextFactory.setNeedClientAuth(httpsSettings.needClientAuth());
+        sslContextFactory.setProvider("Conscrypt");
+        sslContextFactory.setExcludeCipherSuites(new String[]{}); // TLSv1, TLSv1.1 are no longer supported by default: https://www.eclipse.org/jetty/documentation/9.4.x/configuring-ssl.html
 
         HttpConfiguration httpConfig = createHttpConfig(jettySettings);
         httpConfig.addCustomizer(new SecureRequestCustomizer());
+
+        ALPNServerConnectionFactory alpn = new ALPNServerConnectionFactory("h2", "HTTP/1.1");
+        alpn.setDefaultProtocol("HTTP/1.1"); //"HTTP/1.1"
+
+        // HTTP/2 Connection Factory
+        HTTP2ServerConnectionFactory h2 = new HTTP2ServerConnectionFactory(httpConfig);
+
 
         final int port = httpsSettings.port();
 
@@ -225,10 +235,11 @@ public class JettyHttpServer implements HttpServer {
                 port,
                 listener,
                 new SslConnectionFactory(
-                        sslContextFactory,
-                        "http/1.1"
-                ),
-                new HttpConnectionFactory(httpConfig)
+                    sslContextFactory,
+                    alpn.getProtocol()),
+                new HttpConnectionFactory(httpConfig),
+                alpn,
+                h2
         );
     }
 
@@ -307,10 +318,13 @@ public class JettyHttpServer implements HttpServer {
 
         mockServiceContext.setErrorHandler(new NotFoundHandler());
 
-        mockServiceContext.addFilter(GzipFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD));
         mockServiceContext.addFilter(ContentTypeSettingFilter.class, FILES_URL_MATCH, EnumSet.of(DispatcherType.FORWARD));
         mockServiceContext.addFilter(TrailingSlashFilter.class, FILES_URL_MATCH, EnumSet.allOf(DispatcherType.class));
 
+        GzipHandler gzipHandler = new GzipHandler();
+        gzipHandler.addIncludedPaths("/*");
+        gzipHandler.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.FORWARD);
+        mockServiceContext.setGzipHandler(new GzipHandler());
         return mockServiceContext;
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/Http2AcceptanceTest.java
@@ -1,0 +1,142 @@
+package com.github.tomakehurst.wiremock;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.http.HttpClientFactory;
+import com.google.common.io.Resources;
+import org.eclipse.jetty.client.HttpClientTransport;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.After;
+import org.junit.Test;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class Http2AcceptanceTest {
+    private static final String TRUST_STORE_PATH = toPath("test-clientstore");
+    private static final String KEY_STORE_PATH = toPath("test-keystore");
+    private static final String TRUST_STORE_PASSWORD = "mytruststorepassword";
+
+    private WireMockServer wireMockServer;
+    private WireMockServer proxy;
+    private org.apache.http.client.HttpClient httpClient;
+
+    @After
+    public void serverShutdown() {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
+
+        if (proxy != null) {
+            proxy.shutdown();
+        }
+    }
+
+
+    private static String toPath(String resourcePath) {
+        try {
+            return new File(Resources.getResource(resourcePath).toURI()).getCanonicalPath();
+        } catch (Exception e) {
+            return throwUnchecked(e, String.class);
+        }
+    }
+
+    @Test
+    public void shouldReturnStubOnSpecifiedPortHttp2() throws Exception {
+        String testTrustStorePath = TRUST_STORE_PATH;
+        String testClientCertPath = TRUST_STORE_PATH;
+
+        startServerEnforcingClientCert(KEY_STORE_PATH, testTrustStorePath, TRUST_STORE_PASSWORD);
+        wireMockServer.stubFor(get(urlEqualTo("/http2-test")).willReturn(aResponse().withStatus(200).withBody("HTTP2 content")));
+
+        assertThat(http2ContentFor(url("/http2-test"), testClientCertPath, TRUST_STORE_PASSWORD), is("HTTP2 content"));
+    }
+
+    @SuppressWarnings("Duplicates")
+    private void startServerEnforcingClientCert(String keystorePath, String truststorePath, String trustStorePassword) {
+        WireMockConfiguration config = wireMockConfig().dynamicPort().dynamicHttpsPort();
+        if (keystorePath != null) {
+            config.keystorePath(keystorePath);
+        }
+        if (truststorePath != null) {
+            config.trustStorePath(truststorePath);
+            config.trustStorePassword(trustStorePassword);
+            config.needClientAuth(true);
+        }
+        config.bindAddress("localhost");
+
+        wireMockServer = new WireMockServer(config);
+        wireMockServer.start();
+        WireMock.configureFor("https", "localhost", wireMockServer.httpsPort());
+
+        httpClient = HttpClientFactory.createClient();
+    }
+
+    private String url(String path) {
+        return String.format("https://localhost:%d%s", wireMockServer.httpsPort(), path);
+    }
+
+    private String http2ContentFor(String url, String clientTrustStore, String trustStorePassword) throws Exception {
+        KeyStore trustStore = readKeyStore(clientTrustStore, trustStorePassword);
+
+        final KeyManagerFactory kmfactory = KeyManagerFactory.getInstance(
+            KeyManagerFactory.getDefaultAlgorithm());
+        final Set<KeyManager> keymanagers = new HashSet<>();
+
+        kmfactory.init(trustStore, trustStorePassword.toCharArray());
+        final KeyManager[] kms =  kmfactory.getKeyManagers();
+        if (kms != null) {
+            for (final KeyManager km : kms) {
+                keymanagers.add(km);
+            }
+        }
+
+        SSLContext sslContext = SSLContext.getInstance("TLS", "Conscrypt");
+        sslContext.init(keymanagers.toArray(new KeyManager[0]), SslContextFactory.TRUST_ALL_CERTS, null);
+
+        HttpClientTransport transport = new HttpClientTransportOverHTTP2(
+            new HTTP2Client());
+
+        SslContextFactory sslContextFactory = new SslContextFactory();
+        sslContextFactory.setProvider("Conscrypt");
+        sslContextFactory.setSslContext(sslContext);
+        org.eclipse.jetty.client.HttpClient httpClient = new org.eclipse.jetty.client.HttpClient(transport, sslContextFactory);
+        httpClient.setFollowRedirects(false);
+        httpClient.start();
+
+        ContentResponse response = httpClient.GET(url);
+        return response.getContentAsString();
+    }
+
+    static KeyStore readKeyStore(String path, String password) throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
+        KeyStore trustStore  = KeyStore.getInstance(KeyStore.getDefaultType());
+        FileInputStream instream = new FileInputStream(path);
+        try {
+            trustStore.load(instream, password.toCharArray());
+        } finally {
+            instream.close();
+        }
+        return trustStore;
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -224,9 +224,9 @@ public class CommandLineOptionsTest {
     }
 
     @Test
-    public void defaultsContainerThreadsTo10() {
+    public void defaultsContainerThreadsTo13() {
         CommandLineOptions options = new CommandLineOptions();
-        assertThat(options.containerThreads(), is(10));
+        assertThat(options.containerThreads(), is(13));
     }
 
     @Test


### PR DESCRIPTION
- Increase number of default thread in the pool to 13
- Add a connector for http2
- Use Conscrypt for ALPN Processor