### PR TITLE
Updates and fixes for RAML API spec

### DIFF
--- a/docs-v2/_docs/record-playback.md
+++ b/docs-v2/_docs/record-playback.md
@@ -327,7 +327,7 @@ If you only require the IDs of captured stubs you can specify:
 By default generated stubs will be set to persistent, meaning that they will be saved to the file system
 (or other back-end if you've implemented your own `MappingsSource`) and will survive calls to reset mappings to default.
 
-Setting `persistent` to `false` means that stubs will not be saved and will be deleted on the next reset.
+Setting `persist` to `false` means that stubs will not be saved and will be deleted on the next reset.
 
 
 ### Repeats as scenarios

--- a/src/main/resources/raml/schemas/delay-distribution.schema.json
+++ b/src/main/resources/raml/schemas/delay-distribution.schema.json
@@ -1,0 +1,49 @@
+{
+    "type": "object",
+    "oneOf": [
+        {
+            "description": "Log normal randomly distributed response delay.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "lognormal"
+                    ]
+                },
+                "median": {
+                    "type": "integer"
+                },
+                "sigma": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "type",
+                "median",
+                "sigma"
+            ]
+        },
+        {
+            "description": "Uniformly distributed random response delay.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "uniform"
+                    ]
+                },
+                "upper": {
+                    "type": "integer"
+                },
+                "lower": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "type",
+                "upper",
+                "lower"
+            ]
+        }
+    ]
+}

--- a/src/main/resources/raml/schemas/global-settings.schema.json
+++ b/src/main/resources/raml/schemas/global-settings.schema.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "properties": {
+        "fixedDelay": {
+            "required": false,
+            "type": "number"
+        },
+        "delayDistribution": {
+            "required": false,
+            "$ref": "delay-distribution.schema.json"
+        }
+    }
+}

--- a/src/main/resources/raml/schemas/logged-request.schema.json
+++ b/src/main/resources/raml/schemas/logged-request.schema.json
@@ -1,0 +1,42 @@
+{
+    "type": "object",
+    "properties": {
+        "url": {
+            "description": "The path and query to match exactly against",
+            "type": "string"
+        },
+        "absoluteUrl": {
+            "description": "The full URL to match against",
+            "type": "string"
+        },
+        "method": {
+            "description": "The HTTP request method e.g. GET",
+            "type": "string"
+        },
+        "headers": {
+            "description": "Header patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+            "type": "object"
+        },
+        "cookies": {
+            "description": "Cookie patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+            "type": "object"
+        },
+        "body": {
+            "description": "Body string to match against",
+            "type": "string"
+        }
+    },
+
+    "example": {
+        "url": "/received-request/2",
+        "absoluteUrl": "http://localhost:56738/received-request/2",
+        "method": "GET",
+        "headers": {
+            "Connection" : "keep-alive",
+            "Host" : "localhost:56738",
+            "User-Agent" : "Apache-HttpClient/4.5.1 (Java/1.7.0_51)"
+        },
+        "cookies": { },
+        "body": "Hello world"
+    }
+}

--- a/src/main/resources/raml/schemas/record-spec.schema.json
+++ b/src/main/resources/raml/schemas/record-spec.schema.json
@@ -1,83 +1,162 @@
 {
     "type": "object",
     "properties": {
-        "targetBaseUrl": {
-            "type": "string"
-        },
         "captureHeaders": {
-            "type": "object"
+            "description": "Headers from the request to include in the generated stub mappings, mapped to parameter objects. The only parameter available is \"caseInsensitive\", which defaults to false",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "caseInsensitive": {
+                        "type": "boolean"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "example": [
+                {
+                    "Accept": {}
+                },
+                {
+                    "Accept": {},
+                    "Content-Type": {
+                        "caseInsensitive": true
+                    }
+                }
+            ]
         },
         "extractBodyCriteria": {
+            "description": "Criteria for extracting response bodies to a separate file instead of including it in the stub mapping",
             "type": "object",
             "properties": {
                 "binarySizeThreshold": {
-                    "type": "string"
-                },
-                "textSizeThreshold": {
-                    "type": "string"
-                }
-            }
-        },
-        "requestBodyPattern": {
-            "type": "object",
-            "properties": {
-                "matcher": {
+                    "description": "Size threshold for extracting binary response bodies. Default unit is bytes",
                     "type": "string",
-                    "enum": [
-                        "equalTo",
-                        "equalToJson",
-                        "equalToXml",
-                        "auto"
+                    "default": "0",
+                    "example": [
+                        "56 kb",
+                        "10 Mb",
+                        "18.2 GB",
+                        "255"
                     ]
                 },
-                "ignoreArrayOrder": {
-                    "type": "boolean"
-                },
-                "ignoreExtraElements": {
-                    "type": "boolean"
-                },
-                "caseInsensitive": {
-                    "type": "boolean"
+                "textSizeThreshold": {
+                    "description": "Size threshold for extracting text response bodies. Default unit is bytes",
+                    "type": "string",
+                    "default": "0",
+                    "example": [
+                        "56 kb",
+                        "10 Mb",
+                        "18.2 GB",
+                        "255"
+                    ]
                 }
-            }
+            },
+            "example": [{
+                "textSizeThreshold" : "2 kb",
+                "binarySizeThreshold" : "1 Mb"
+            }]
         },
-        "filters": {
+        "requestBodyPattern": {
+            "description": "Control the request body matcher used in generated stub mappings",
             "type": "object",
-            "properties": {
-                "ids": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
+            "oneOf": [
+                {
+                    "description": "Automatically determine matcher based on content type (the default)",
+                    "properties": {
+                        "matcher": {
+                            "type": "string",
+                            "enum": [
+                                "auto"
+                            ]
+                        },
+                        "ignoreArrayOrder": {
+                            "description": "If equalToJson is used, ignore order of array elements",
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "ignoreExtraElements": {
+                            "description": "If equalToJson is used, matcher ignores extra elements in objects",
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "caseInsensitive": {
+                            "description": "If equalTo is used, match body use case-insensitive string comparison",
+                            "type": "boolean",
+                            "default": false
+                        }
                     }
                 },
-                "method": {
-                    "type": "string"
+                {
+                    "description": "Always match request bodies using equalTo",
+                    "properties": {
+                        "matcher": {
+                            "type": "string",
+                            "enum": [
+                                "equalTo"
+                            ]
+                        },
+                        "caseInsensitive": {
+                            "description": "Match body using case-insensitive string comparison",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
                 },
-                "urlPathPattern": {
-                    "type": "string"
+                {
+                    "description": "Always match request bodies using equalToJson",
+                    "properties": {
+                        "matcher": {
+                            "type": "string",
+                            "enum": [
+                                "equalToJson"
+                            ]
+                        },
+                        "ignoreArrayOrder": {
+                            "description": "Ignore order of array elements",
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "ignoreExtraElements": {
+                            "description": "Ignore extra elements in objects",
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                },
+                {
+                    "description": "Always match request bodies using equalToXml",
+                    "properties": {
+                        "matcher": {
+                            "type": "string",
+                            "enum": [
+                                "equalToXml"
+                            ]
+                        }
+                    }
                 }
-            }
+            ]
         },
         "persist": {
-            "type": "boolean"
+            "description": "Whether to save stub mappings to the file system or just return them",
+            "type": "boolean",
+            "default": true
         },
         "repeatsAsScenarios": {
-            "type": "boolean"
+            "description": "When true, duplicate requests will be added to a Scenario. When false, duplicates are discarded",
+            "type": "boolean",
+            "default": true
         },
         "transformerParameters": {
-            "type": "object",
-            "properties": {
-                "headerValue": {
-                    "type": "string"
-                }
-            }
+            "description": "List of names of stub mappings transformers to apply to generated stubs",
+            "type": "object"
         },
         "transformers": {
+            "description": "Parameters to pass to stub mapping transformers",
             "type": "array",
             "items": {
                 "type": "string"
             }
         }
     }
-
 }

--- a/src/main/resources/raml/schemas/response-definition.schema.json
+++ b/src/main/resources/raml/schemas/response-definition.schema.json
@@ -39,10 +39,7 @@
         },
         "delayDistribution": {
             "description": "Random delay settings.",
-            "oneOf": [
-                { "$ref": "#/definitions/logNormalDistribution" },
-                { "$ref": "#/definitions/uniformDistribution" }
-            ]
+            "$ref": "delay-distribution.schema.json"
         },
         "fault": {
             "type": "string",
@@ -72,55 +69,6 @@
         "fromConfiguredStub": {
             "description": "Read-only flag indicating false if this was the default, unmatched response. Not present otherwise.",
             "type": "boolean"
-        }
-    },
-
-    "definitions": {
-        "logNormalDistribution": {
-            "descrioption": "Log normal randomly distributed response delay.",
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "lognormal"
-                    ]
-                },
-                "median": {
-                    "type": "integer"
-                },
-                "sigma": {
-                    "type": "number"
-                }
-            },
-            "required": [
-                "type",
-                "median",
-                "sigma"
-            ]
-        },
-        "uniformDistribution": {
-            "descrioption": "Uniformly distributed random response delay.",
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "uniform"
-                    ]
-                },
-                "upper": {
-                    "type": "integer"
-                },
-                "lower": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "type",
-                "upper",
-                "lower"
-            ]
         }
     }
 }

--- a/src/main/resources/raml/schemas/scenario.schema.json
+++ b/src/main/resources/raml/schemas/scenario.schema.json
@@ -2,29 +2,25 @@
     "properties": {
         "id": {
             "description": "The scenario ID",
-            "examples": [
+            "example": [
                 "c8d249ec-d86d-48b1-88a8-a660e6848042"
             ],
-            "id": "/properties/id",
             "type": "string"
         },
         "name": {
             "description": "The scenario name",
-            "examples": [
+            "example": [
                 "my_scenario"
             ],
-            "id": "/properties/name",
             "type": "string"
         },
         "possibleStates": {
-            "id": "/properties/possibleStates",
             "items": {
                 "default": "Started",
                 "description": "All the states this scenario can be in",
-                "examples": [
+                "example": [
                     "Started", "Step two", "step_3"
                 ],
-                "id": "/properties/possibleStates/items",
                 "type": "string"
             },
             "type": "array"
@@ -32,10 +28,9 @@
         "state": {
             "default": "Started",
             "description": "The current state of this scenario",
-            "examples": [
+            "example": [
                 "Started", "Step two", "step_3"
             ],
-            "id": "/properties/state",
             "type": "string"
         }
     },

--- a/src/main/resources/raml/schemas/snapshot.schema.json
+++ b/src/main/resources/raml/schemas/snapshot.schema.json
@@ -1,0 +1,27 @@
+{
+    "type": "object",
+    "allOf": [
+        { "$ref": "record-spec.schema.json" },
+        {
+            "properties": {
+                "filters": {
+                    "description": "Filter requests for which to create stub mapping",
+                    "type": "object",
+                    "allOf": [
+                        {
+                            "properties": {
+                                "ids": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        { "$ref": "request-pattern.schema.json" }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/raml/schemas/start-recording.schema.json
+++ b/src/main/resources/raml/schemas/start-recording.schema.json
@@ -1,0 +1,22 @@
+{
+    "type": "object",
+    "allOf": [
+        { "$ref": "record-spec.schema.json" },
+        {
+            "type": "object",
+            "properties": {
+                "targetBaseUrl": {
+                    "description": "Target URL when using the record and playback API",
+                    "type": "string",
+                    "example": [
+                        "http://example.mocklab.io"
+                    ]
+                },
+                "filters": {
+                    "description": "Filter requests for which to create stub mapping",
+                    "$ref": "request-pattern.schema.json"
+                }
+            }
+        }
+    ]
+}

--- a/src/main/resources/raml/schemas/stub-mapping.schema.json
+++ b/src/main/resources/raml/schemas/stub-mapping.schema.json
@@ -15,19 +15,19 @@
             "type": "boolean"
         },
         "scenarioName": {
-            "descrption": "The name of the scenario that this stub mapping is part of",
+            "description": "The name of the scenario that this stub mapping is part of",
             "type": "string"
         },
         "requiredScenarioState": {
-            "descrption": "The required state of the scenario in order for this stub to be matched.",
+            "description": "The required state of the scenario in order for this stub to be matched.",
             "type": "string"
         },
         "newScenarioState": {
-            "descrption": "The new state for the scenario to be updated to after this stub is served.",
+            "description": "The new state for the scenario to be updated to after this stub is served.",
             "type": "string"
         },
         "postServeActions": {
-            "descrption": "A map of the names of post serve action extensions to trigger and their parameters.",
+            "description": "A map of the names of post serve action extensions to trigger and their parameters.",
             "type": "object"
         },
 

--- a/src/main/resources/raml/wiremock-admin-api.raml
+++ b/src/main/resources/raml/wiremock-admin-api.raml
@@ -13,9 +13,12 @@ documentation:
 schemas:
   - stubMapping: !include schemas/stub-mapping.schema.json
   - stubMappings: !include schemas/stub-mappings.schema.json
+  - loggedRequest: !include schemas/logged-request.schema.json
   - requestPattern: !include schemas/request-pattern.schema.json
-  - recordSpec: !include schemas/record-spec.schema.json
+  - snapshot: !include schemas/snapshot.schema.json
+  - startRecording: !include schemas/start-recording.schema.json
   - scenarios: !include schemas/scenarios.schema.json
+  - globalSettings: !include schemas/global-settings.schema.json
 
 /__admin/mappings:
   description: Stub mappings
@@ -250,7 +253,7 @@ schemas:
       description: Start recording stub mappings
       body:
         application/json:
-          schema: recordSpec
+          schema: startRecording
           example: !include examples/record-spec.example.json
 
       responses:
@@ -290,7 +293,7 @@ schemas:
       description: Take a snapshot recording
       body:
         application/json:
-          schema: recordSpec
+          schema: snapshot
           example: !include examples/snapshot-spec.example.json
 
       responses:
@@ -335,6 +338,7 @@ schemas:
       description: Find at most 3 near misses for closest stub mappings to the specified request
       body:
         application/json:
+          schema: loggedRequest
           example: !include examples/logged-request.example.json
 
       responses:
@@ -366,6 +370,7 @@ schemas:
     description: Update global settings
     body:
       application/json:
+        schema: globalSettings
         example: |
           {
               "fixedDelay": 500


### PR DESCRIPTION
This makes some updates to the RAML specs, mainly to flesh out the recording API. I also made a few fixes so that running `api-spec-converter -f raml -t openapi_3 tmp/raml/wiremock-admin-api.raml` generates a valid OpenAPI 3.0 (aka Swagger 3) spec file: https://gist.github.com/MasonM/f70fc9feaf0c3cc4b49d337673c3b3f7. This requires upgrading [api-spec-converter](https://github.com/LucyBot-Inc/api-spec-converter) to get OpenAPI 3.0 support.

It's not valid Swagger 2, but that was already the case due to the use of `oneOf` for `delayDistribution`, which is not supported in Swagger 2. There isn't a good workaround for that.

The [latest version of Swagger UI supports OpenAPI 3](https://github.com/swagger-api/swagger-ui#compatibility), so I think it'd be a good idea to upgrade, but I didn't do that here.