### PR TITLE
Added stubbing for multiple query parameters

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -85,6 +85,13 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
         return this;
     }
 
+    @Override
+    public BasicMappingBuilder withQueryParams(Map<String, StringValuePattern> queryParams) {
+        for (Map.Entry<String, StringValuePattern> queryParam : queryParams.entrySet())
+            requestPatternBuilder.withQueryParam(queryParam.getKey(), queryParam.getValue());
+        return this;
+    }
+
 	@Override
 	public BasicMappingBuilder withRequestBody(ContentPattern<?> bodyPattern) {
         requestPatternBuilder.withRequestBody(bodyPattern);

--- a/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/MappingBuilder.java
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.matching.MultipartValuePatternBuilder;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
+import java.util.Map;
 import java.util.UUID;
 
 public interface MappingBuilder {
@@ -27,6 +28,7 @@ public interface MappingBuilder {
     MappingBuilder atPriority(Integer priority);
     MappingBuilder withHeader(String key, StringValuePattern headerPattern);
     MappingBuilder withQueryParam(String key, StringValuePattern queryParamPattern);
+    MappingBuilder withQueryParams(Map<String, StringValuePattern> queryParams);
     MappingBuilder withRequestBody(ContentPattern<?> bodyPattern);
     MappingBuilder withMultipartRequestBody(MultipartValuePatternBuilder multipartPatternBuilder);
     ScenarioMappingBuilder inScenario(String scenarioName);

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ScenarioMappingBuilder.java
@@ -19,6 +19,7 @@ import com.github.tomakehurst.wiremock.matching.ContentPattern;
 import com.github.tomakehurst.wiremock.matching.MultipartValuePatternBuilder;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 
+import java.util.Map;
 import java.util.UUID;
 
 public interface ScenarioMappingBuilder extends MappingBuilder {
@@ -29,6 +30,7 @@ public interface ScenarioMappingBuilder extends MappingBuilder {
     ScenarioMappingBuilder atPriority(Integer priority);
     ScenarioMappingBuilder withHeader(String key, StringValuePattern headerPattern);
     ScenarioMappingBuilder withQueryParam(String key, StringValuePattern queryParamPattern);
+    ScenarioMappingBuilder withQueryParams(Map<String, StringValuePattern> queryParams);
     ScenarioMappingBuilder withRequestBody(ContentPattern<?> bodyPattern);
     ScenarioMappingBuilder withMultipartRequestBody(MultipartValuePatternBuilder multipartPatternBuilder);
     ScenarioMappingBuilder inScenario(String scenarioName);

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -17,6 +17,7 @@ package com.github.tomakehurst.wiremock;
 
 import com.github.tomakehurst.wiremock.admin.model.ListStubMappingsResult;
 import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.testsupport.MultipartBody;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.github.tomakehurst.wiremock.testsupport.WireMockResponse;
@@ -35,6 +36,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.net.SocketException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -154,6 +157,19 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(testClient.get("/path-and-query/match?since=2014-10-14&search=WireMock%20stubbing").statusCode(), is(200));
     }
 
+    @Test
+    public void matchesOnUrlPathAndMultipleQueryParameters() {
+        Map<String, StringValuePattern> queryParameters = new HashMap<>();
+        queryParameters.put("search", containing("WireMock"));
+        queryParameters.put("since", equalTo("2018-03-02"));
+
+        stubFor(get(urlPathEqualTo("/path-and-query/match"))
+                .withQueryParams(queryParameters)
+                .willReturn(aResponse().withStatus(200)));
+
+        assertThat(testClient.get("/path-and-query/match?since=2018-03-02&search=WireMock%20stubbing").statusCode(), is(200));
+    }
+
 	@Test
 	public void doesNotMatchOnUrlPathWhenExtraPathElementsPresent() {
 		stubFor(get(urlPathEqualTo("/matching-path")).willReturn(aResponse().withStatus(200)));
@@ -177,6 +193,19 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 
 		assertThat(testClient.get("/path-and-query/match?since=2014-10-14&search=WireMock%20stubbing").statusCode(), is(200));
 	}
+
+    @Test
+    public void matchesOnUrlPathPatternAndMultipleQueryParameters() {
+        Map<String, StringValuePattern> queryParameters = new HashMap<>();
+        queryParameters.put("search", containing("WireMock"));
+        queryParameters.put("since", equalTo("2018-03-02"));
+
+        stubFor(get(urlPathMatching("/path(.*)/match"))
+                .withQueryParams(queryParameters)
+                .willReturn(aResponse().withStatus(200)));
+
+        assertThat(testClient.get("/path-and-query/match?since=2018-03-02&search=WireMock%20stubbing").statusCode(), is(200));
+    }
 
 	@Test
 	public void doesNotMatchOnUrlPathPatternWhenPathShorter() {


### PR DESCRIPTION
I came across difficulties when wanting to create stubs for an unknown amount of query parameters to achieve parameter invariance. This addition will allow stubbing for multiple query parameters with a single method call.

I used existing test cases that had multiple `withQueryParam` as templates to test `withQueryParams`, and they seem to check out fine. Feedback is appreciated.

Somewhat relates to https://github.com/tomakehurst/wiremock/issues/511