### PR TITLE
Use a InheritableThreadLocal for WireMock 

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -59,7 +59,7 @@ public class WireMock {
 	private final Admin admin;
 	private final GlobalSettingsHolder globalSettingsHolder = new GlobalSettingsHolder();
 
-	private static ThreadLocal<WireMock> defaultInstance = new ThreadLocal<WireMock>(){
+	private static InheritableThreadLocal<WireMock> defaultInstance = new InheritableThreadLocal<WireMock>(){
             @Override
             protected WireMock initialValue() {
             	return WireMock.create().build();

--- a/src/test/java/com/github/tomakehurst/wiremock/MultithreadConfigurationInheritanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MultithreadConfigurationInheritanceTest.java
@@ -1,0 +1,39 @@
+package com.github.tomakehurst.wiremock;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.Assert.assertEquals;
+
+public class MultithreadConfigurationInheritanceTest {
+
+    private static WireMockServer wireMockServer;
+
+    @BeforeClass
+    public static void setup(){
+        wireMockServer = new WireMockServer(8082);
+        wireMockServer.start();
+        WireMock.configureFor(8082);
+    }
+
+
+    @AfterClass
+    public static void shutdown(){
+        wireMockServer.shutdown();
+    }
+
+
+    @Test(timeout = 5000) //Add a timeout so the test will execute in a new thread
+    public void verifyConfigurationInherited(){
+        //Make a call to the wiremock server. If this doesn't call to 8082 this will fail
+        //with an exception
+        stubFor(any(urlEqualTo("/foo/bar")).willReturn(aResponse().withStatus(200)));
+    }
+}


### PR DESCRIPTION
After upgrading from 1.x to 2.x I saw an issue where tests that used a timeout were failing due to the configuration set in a before class being lost. This change moves the WireMock from a ThreadLocal to an InheritableThreadLocal so that configuration is preserved but can still be overriden by new threads.