### PR TITLE
#898 Show the resulting port number instead of 0

### DIFF
--- a/docs-v2/_docs/running-standalone.md
+++ b/docs-v2/_docs/running-standalone.md
@@ -26,7 +26,7 @@ $ java -jar wiremock-standalone-{{ site.wiremock_version }}.jar
 
 The following can optionally be specified on the command line:
 
-`--port`: Set the HTTP port number e.g. `--port 9999`
+`--port`: Set the HTTP port number e.g. `--port 9999`. Use `--port 0` to dynamically determine a port.
 
 `--https-port`: If specified, enables HTTPS on the supplied port.
 

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -74,6 +74,7 @@ public class WireMockServerRunner {
 
         try {
             wireMockServer.start();
+            options.setResultingPort(wireMockServer.port());
             out.println(BANNER);
             out.println();
             out.println(options);

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -379,6 +379,15 @@ public class CommandLineOptionsTest {
         assertThat(options.getAsynchronousResponseSettings().getThreads(), is(10));
     }
 
+    @Test
+    public void usesPortInToString() {
+        CommandLineOptions options = new CommandLineOptions("--port", "1337");
+        assertThat(options.toString(), allOf(containsString("1337")));
+
+        options.setResultingPort(1338);
+        assertThat(options.toString(), allOf(containsString("1338")));
+    }
+
     public static class ResponseDefinitionTransformerExt1 extends ResponseDefinitionTransformer {
         @Override
         public ResponseDefinition transform(Request request, ResponseDefinition responseDefinition, FileSource files, Parameters parameters) { return null; }


### PR DESCRIPTION
Fixes #898

Starting WireMock with `--port 0` will denote the correct port in the output

Also, to prevent further questions like mine, added some documentation of the possibility of running with `--port 0` at
* the [running standalone page](http://wiremock.org/docs/running-standalone/#command-line-options)
* and when running with `--help`.

Feedback always welcome. Wasn't sure about tabs vs spaces, current file contains both... lemme know what you prefer.