### PR TITLE
Update httpclient to fix hostname verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-core:$versions.jackson",
         "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",
         "com.fasterxml.jackson.core:jackson-databind:$versions.jackson"
-    compile "org.apache.httpcomponents:httpclient:4.5.3"
+    compile "org.apache.httpcomponents:httpclient:4.5.5"
     compile "org.xmlunit:xmlunit-core:$versions.xmlUnit"
     compile "org.xmlunit:xmlunit-legacy:$versions.xmlUnit"
     compile "com.jayway.jsonpath:json-path:2.4.0"


### PR DESCRIPTION
On some cases it's not possible to record using HTTPS, because of BUG
in httpclient, see https://issues.apache.org/jira/browse/HTTPCLIENT-1836