### PR TITLE
Update zjsonpatch from 0.3.0 to 0.4.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
         exclude group: "org.hamcrest", module: "hamcrest-core"
     }
     compile 'org.apache.commons:commons-lang3:3.6'
-    compile 'com.flipkart.zjsonpatch:zjsonpatch:0.3.0'
+    compile 'com.flipkart.zjsonpatch:zjsonpatch:0.4.3'
     compile 'com.github.jknack:handlebars:4.0.6', {
         exclude group: 'org.mozilla', module: 'rhino'
     }


### PR DESCRIPTION
Version 0.3.0 came along with an outdated version of Guava (18.0) which
causes issues when used along newer Guava versions. 0.4.3 does not ship
with Guava at all.