### PR TITLE
Fix typos in documentation and API specs

### DIFF
--- a/docs-v2/_docs/record-playback.md
+++ b/docs-v2/_docs/record-playback.md
@@ -327,7 +327,7 @@ If you only require the IDs of captured stubs you can specify:
 By default generated stubs will be set to persistent, meaning that they will be saved to the file system
 (or other back-end if you've implemented your own `MappingsSource`) and will survive calls to reset mappings to default.
 
-Setting `persistent` to `false` means that stubs will not be saved and will be deleted on the next reset.
+Setting `persist` to `false` means that stubs will not be saved and will be deleted on the next reset.
 
 
 ### Repeats as scenarios

--- a/src/main/resources/raml/schemas/scenario.schema.json
+++ b/src/main/resources/raml/schemas/scenario.schema.json
@@ -2,7 +2,7 @@
     "properties": {
         "id": {
             "description": "The scenario ID",
-            "examples": [
+            "example": [
                 "c8d249ec-d86d-48b1-88a8-a660e6848042"
             ],
             "id": "/properties/id",
@@ -10,7 +10,7 @@
         },
         "name": {
             "description": "The scenario name",
-            "examples": [
+            "example": [
                 "my_scenario"
             ],
             "id": "/properties/name",
@@ -21,7 +21,7 @@
             "items": {
                 "default": "Started",
                 "description": "All the states this scenario can be in",
-                "examples": [
+                "example": [
                     "Started", "Step two", "step_3"
                 ],
                 "id": "/properties/possibleStates/items",
@@ -32,7 +32,7 @@
         "state": {
             "default": "Started",
             "description": "The current state of this scenario",
-            "examples": [
+            "example": [
                 "Started", "Step two", "step_3"
             ],
             "id": "/properties/state",

--- a/src/main/resources/raml/schemas/stub-mapping.schema.json
+++ b/src/main/resources/raml/schemas/stub-mapping.schema.json
@@ -15,19 +15,19 @@
             "type": "boolean"
         },
         "scenarioName": {
-            "descrption": "The name of the scenario that this stub mapping is part of",
+            "description": "The name of the scenario that this stub mapping is part of",
             "type": "string"
         },
         "requiredScenarioState": {
-            "descrption": "The required state of the scenario in order for this stub to be matched.",
+            "description": "The required state of the scenario in order for this stub to be matched.",
             "type": "string"
         },
         "newScenarioState": {
-            "descrption": "The new state for the scenario to be updated to after this stub is served.",
+            "description": "The new state for the scenario to be updated to after this stub is served.",
             "type": "string"
         },
         "postServeActions": {
-            "descrption": "A map of the names of post serve action extensions to trigger and their parameters.",
+            "description": "A map of the names of post serve action extensions to trigger and their parameters.",
             "type": "object"
         },
 


### PR DESCRIPTION
Split off from PR #888 to make it easier to review. This fixes a few mistakes in the docs and API specs:
1. The recording API takes a 'persist' parameter, not 'persistent'
2. The `stub-mapping.schema.json` spec used 'descrption' instead of 'description'
3. The `scenario.schema.json` spec used 'examples' instead of 'example'. While 'examples' is valid JSON Schema, everything else uses 'example', and this is what api-spec-converter looks for.

The latter 2 are required for OpenAPI 3 conversion to work