### PR TITLE
Add API schema for /_admin/settings

### DIFF
--- a/src/main/resources/raml/schemas/delay-distribution.schema.json
+++ b/src/main/resources/raml/schemas/delay-distribution.schema.json
@@ -1,0 +1,49 @@
+{
+    "type": "object",
+    "oneOf": [
+        {
+            "description": "Log normal randomly distributed response delay.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "lognormal"
+                    ]
+                },
+                "median": {
+                    "type": "integer"
+                },
+                "sigma": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "type",
+                "median",
+                "sigma"
+            ]
+        },
+        {
+            "description": "Uniformly distributed random response delay.",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "uniform"
+                    ]
+                },
+                "upper": {
+                    "type": "integer"
+                },
+                "lower": {
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "type",
+                "upper",
+                "lower"
+            ]
+        }
+    ]
+}

--- a/src/main/resources/raml/schemas/global-settings.schema.json
+++ b/src/main/resources/raml/schemas/global-settings.schema.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "properties": {
+        "fixedDelay": {
+            "required": false,
+            "type": "number"
+        },
+        "delayDistribution": {
+            "required": false,
+            "$ref": "delay-distribution.schema.json"
+        }
+    }
+}

--- a/src/main/resources/raml/schemas/response-definition.schema.json
+++ b/src/main/resources/raml/schemas/response-definition.schema.json
@@ -39,10 +39,7 @@
         },
         "delayDistribution": {
             "description": "Random delay settings.",
-            "oneOf": [
-                { "$ref": "#/definitions/logNormalDistribution" },
-                { "$ref": "#/definitions/uniformDistribution" }
-            ]
+            "$ref": "delay-distribution.schema.json"
         },
         "fault": {
             "type": "string",
@@ -72,55 +69,6 @@
         "fromConfiguredStub": {
             "description": "Read-only flag indicating false if this was the default, unmatched response. Not present otherwise.",
             "type": "boolean"
-        }
-    },
-
-    "definitions": {
-        "logNormalDistribution": {
-            "descrioption": "Log normal randomly distributed response delay.",
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "lognormal"
-                    ]
-                },
-                "median": {
-                    "type": "integer"
-                },
-                "sigma": {
-                    "type": "number"
-                }
-            },
-            "required": [
-                "type",
-                "median",
-                "sigma"
-            ]
-        },
-        "uniformDistribution": {
-            "descrioption": "Uniformly distributed random response delay.",
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "uniform"
-                    ]
-                },
-                "upper": {
-                    "type": "integer"
-                },
-                "lower": {
-                    "type": "integer"
-                }
-            },
-            "required": [
-                "type",
-                "upper",
-                "lower"
-            ]
         }
     }
 }

--- a/src/main/resources/raml/wiremock-admin-api.raml
+++ b/src/main/resources/raml/wiremock-admin-api.raml
@@ -16,6 +16,7 @@ schemas:
   - requestPattern: !include schemas/request-pattern.schema.json
   - recordSpec: !include schemas/record-spec.schema.json
   - scenarios: !include schemas/scenarios.schema.json
+  - globalSettings: !include schemas/global-settings.schema.json
 
 /__admin/mappings:
   description: Stub mappings
@@ -366,6 +367,7 @@ schemas:
     description: Update global settings
     body:
       application/json:
+        schema: globalSettings
         example: |
           {
               "fixedDelay": 500


### PR DESCRIPTION
Split off from PR #888 to make it easier to review. This adds an API schema for the `/__admin/settings` endpoint, which is required for OpenAPI 3 conversion to work, and splits off the delay distribution schema into a separate file, since it's now referenced by both the new schema and `response-definition.schema.json`.