### PR TITLE
Fixes for OpenAPI 3.0 compatibility

### DIFF
--- a/src/main/resources/raml/schemas/scenario.schema.json
+++ b/src/main/resources/raml/schemas/scenario.schema.json
@@ -5,7 +5,6 @@
             "examples": [
                 "c8d249ec-d86d-48b1-88a8-a660e6848042"
             ],
-            "id": "/properties/id",
             "type": "string"
         },
         "name": {
@@ -13,18 +12,15 @@
             "examples": [
                 "my_scenario"
             ],
-            "id": "/properties/name",
             "type": "string"
         },
         "possibleStates": {
-            "id": "/properties/possibleStates",
             "items": {
                 "default": "Started",
                 "description": "All the states this scenario can be in",
                 "examples": [
                     "Started", "Step two", "step_3"
                 ],
-                "id": "/properties/possibleStates/items",
                 "type": "string"
             },
             "type": "array"
@@ -35,7 +31,6 @@
             "examples": [
                 "Started", "Step two", "step_3"
             ],
-            "id": "/properties/state",
             "type": "string"
         }
     },

--- a/src/main/resources/raml/wiremock-admin-api.raml
+++ b/src/main/resources/raml/wiremock-admin-api.raml
@@ -3,6 +3,7 @@
 title: WireMock
 version: 2.15.0
 mediaType: application/json
+baseUri: /__admin
 
 documentation:
   - title: WireMock admin
@@ -17,7 +18,7 @@ schemas:
   - recordSpec: !include schemas/record-spec.schema.json
   - scenarios: !include schemas/scenarios.schema.json
 
-/__admin/mappings:
+/mappings:
   description: Stub mappings
 
   get:
@@ -129,7 +130,7 @@ schemas:
           description: Successfully removed
 
 
-/__admin/requests:
+/requests:
   description: Logged requests and responses received by the mock service
 
   get:
@@ -241,7 +242,7 @@ schemas:
               application/json:
                 example: !include examples/near-misses.example.json
 
-/__admin/recordings:
+/recordings:
   description: Stub mapping record and snapshot functions
 
   /start:
@@ -301,7 +302,7 @@ schemas:
                 schema: stubMappings
                 example: !include examples/recorded-stub-mappings.example.json
 
-/__admin/scenarios:
+/scenarios:
   description: Scenarios support modelling of stateful behaviour
 
   get:
@@ -327,7 +328,7 @@ schemas:
               example: !include examples/empty.example.json
 
 
-/__admin/near-misses:
+/near-misses:
   description: Near misses allow querying of received requests or request patterns according to similarity
 
   /request:
@@ -360,7 +361,7 @@ schemas:
             application/json:
               example: !include examples/near-misses.example.json
 
-/__admin/settings:
+/settings:
   description: Global settings
   post:
     description: Update global settings
@@ -375,7 +376,7 @@ schemas:
       200:
         description: Settings successfully updated
 
-/__admin/shutdown:
+/shutdown:
   description: Shutdown function
   post:
     description: Shutdown the WireMock server


### PR DESCRIPTION
Split off from PR #888 to make it easier to review. This makes a couple minor backwards-compatible fixes for OpenAPI 3.0 compatibility:
1. Remove the "id" properties in `scenario.schema.json`, which aren't present in any of the other schema files, and cause validation errors.
2. Define the baseUri to be "/__admin". Besides simplifying all the other URLs, this gets translated to the server object URL, which is required in OpenAPI 3.0:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#serverObject