### PR TITLE
Add API schema for /__admin/near-misses/request

### DIFF
--- a/src/main/resources/raml/schemas/logged-request.schema.json
+++ b/src/main/resources/raml/schemas/logged-request.schema.json
@@ -1,0 +1,42 @@
+{
+    "type": "object",
+    "properties": {
+        "url": {
+            "description": "The path and query to match exactly against",
+            "type": "string"
+        },
+        "absoluteUrl": {
+            "description": "The full URL to match against",
+            "type": "string"
+        },
+        "method": {
+            "description": "The HTTP request method e.g. GET",
+            "type": "string"
+        },
+        "headers": {
+            "description": "Header patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+            "type": "object"
+        },
+        "cookies": {
+            "description": "Cookie patterns to match against in the <key>: { \"<predicate>\": \"<value>\" } form",
+            "type": "object"
+        },
+        "body": {
+            "description": "Body string to match against",
+            "type": "string"
+        }
+    },
+
+    "example": {
+        "url": "/received-request/2",
+        "absoluteUrl": "http://localhost:56738/received-request/2",
+        "method": "GET",
+        "headers": {
+            "Connection" : "keep-alive",
+            "Host" : "localhost:56738",
+            "User-Agent" : "Apache-HttpClient/4.5.1 (Java/1.7.0_51)"
+        },
+        "cookies": { },
+        "body": "Hello world"
+    }
+}

--- a/src/main/resources/raml/wiremock-admin-api.raml
+++ b/src/main/resources/raml/wiremock-admin-api.raml
@@ -13,6 +13,7 @@ documentation:
 schemas:
   - stubMapping: !include schemas/stub-mapping.schema.json
   - stubMappings: !include schemas/stub-mappings.schema.json
+  - loggedRequest: !include schemas/logged-request.schema.json
   - requestPattern: !include schemas/request-pattern.schema.json
   - recordSpec: !include schemas/record-spec.schema.json
   - scenarios: !include schemas/scenarios.schema.json
@@ -335,6 +336,7 @@ schemas:
       description: Find at most 3 near misses for closest stub mappings to the specified request
       body:
         application/json:
+          schema: loggedRequest
           example: !include examples/logged-request.example.json
 
       responses:


### PR DESCRIPTION
Split off from PR #888 to make it easier to review. This adds an API schema for `/__admin/near-misses/request`, which is required for OpenAPI 3 conversion to work.