### PR TITLE
Add user authentication for the Proxy via

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/ProxySettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ProxySettings.java
@@ -55,6 +55,7 @@ public class ProxySettings {
             if(!"http".equals(proxyUrl.getProtocol())){
                 throw new IllegalArgumentException("Proxy via does not support any other protocol than http");
             }
+            Preconditions.checkArgument(!proxyUrl.getHost().isEmpty(), "Host part of proxy must be specified");
             ProxySettings proxySettings = new ProxySettings(proxyUrl.getHost(), proxyUrl.getPort() == -1 ? DEFAULT_PORT : proxyUrl.getPort());
             if(!isEmpty(proxyUrl.getUserInfo())){
                 String[] userInfoArray = proxyUrl.getUserInfo().split(":");

--- a/src/main/java/com/github/tomakehurst/wiremock/common/ProxySettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/ProxySettings.java
@@ -15,11 +15,9 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import com.google.common.base.Preconditions;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import static com.google.common.base.Splitter.on;
-import static com.google.common.collect.Iterables.get;
-import static com.google.common.collect.Iterables.getFirst;
+import com.google.common.base.Preconditions;
 
 public class ProxySettings {
 
@@ -28,17 +26,26 @@ public class ProxySettings {
     private final String host;
     private final int port;
 
+    private String username;
+    private String password;
+
     public ProxySettings(String host, int port) {
         this.host = host;
         this.port = port;
     }
 
     public static ProxySettings fromString(String config) {
-        Iterable<String> parts = on(":").split(config);
-        String host = getFirst(parts, "");
+        int portPosition = config.lastIndexOf(":");
+        String host;
+        int port;
+        if(portPosition != -1){
+            host = config.substring(0, portPosition);
+            port = Integer.valueOf(config.substring(portPosition+1));
+        }else{
+            host = config;
+            port = 80;
+        }
         Preconditions.checkArgument(!host.isEmpty(), "Host part of proxy must be specified");
-
-        int port = Integer.valueOf(get(parts, 1, "80"));
         return new ProxySettings(host, port);
     }
 
@@ -50,12 +57,28 @@ public class ProxySettings {
         return port;
     }
 
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
     @Override
     public String toString() {
         if (this == NO_PROXY) {
             return "(no proxy)";
         }
 
-        return host() + ":" + port();
+        return String.format("%s:%s%s", host(), port(), (!isEmpty(this.username) ? " (with credentials)" : ""));
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -15,32 +15,19 @@
  */
 package com.github.tomakehurst.wiremock.standalone;
 
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
-import static com.github.tomakehurst.wiremock.core.WireMockApp.MAPPINGS_ROOT;
-import static com.github.tomakehurst.wiremock.extension.ExtensionLoader.valueAssignableFrom;
-import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.net.URI;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import com.github.tomakehurst.wiremock.common.*;
-import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
-import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
-import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
-import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.core.MappingsSaver;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionLoader;
+import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
+import com.github.tomakehurst.wiremock.http.ThreadPoolFactory;
 import com.github.tomakehurst.wiremock.http.trafficlistener.ConsoleNotifyingWiremockNetworkTrafficListener;
+import com.github.tomakehurst.wiremock.http.trafficlistener.DoNothingWiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.http.trafficlistener.WiremockNetworkTrafficListener;
 import com.github.tomakehurst.wiremock.jetty9.QueuedThreadPoolFactory;
 import com.github.tomakehurst.wiremock.security.Authenticator;
@@ -50,15 +37,23 @@ import com.github.tomakehurst.wiremock.verification.notmatched.NotMatchedRendere
 import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Maps;
-import com.google.common.collect.UnmodifiableIterator;
+import com.google.common.collect.*;
 import com.google.common.io.Resources;
-
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.MAPPINGS_ROOT;
+import static com.github.tomakehurst.wiremock.extension.ExtensionLoader.valueAssignableFrom;
+import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS;
 
 public class CommandLineOptions implements Options {
 
@@ -68,8 +63,6 @@ public class CommandLineOptions implements Options {
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PRESERVE_HOST_HEADER = "preserve-host-header";
     private static final String PROXY_VIA = "proxy-via";
-    private static final String PROXY_VIA_USERNAME = "proxy-via-username";
-    private static final String PROXY_VIA_PASSWORD = "proxy-via-password";
 	private static final String PORT = "port";
     private static final String BIND_ADDRESS = "bind-address";
     private static final String HTTPS_PORT = "https-port";
@@ -119,8 +112,6 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
-        optionParser.accepts(PROXY_VIA_USERNAME, "Specifies a proxy server username to use when routing proxy mapped requests").withRequiredArg();
-        optionParser.accepts(PROXY_VIA_PASSWORD, "Specifies a proxy server password to use when routing proxy mapped requests").withRequiredArg();
 		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
 		optionParser.accepts(MATCH_HEADERS, "Enable request header matching when recording through a proxy").withRequiredArg();
 		optionParser.accepts(ROOT_DIR, "Specifies path for storing recordings (parent for " + MAPPINGS_ROOT + " and " + WireMockApp.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
@@ -372,14 +363,7 @@ public class CommandLineOptions implements Options {
     public ProxySettings proxyVia() {
         if (optionSet.has(PROXY_VIA)) {
             String proxyVia = (String) optionSet.valueOf(PROXY_VIA);
-            ProxySettings proxySettings = ProxySettings.fromString(proxyVia);
-            if(optionSet.has(PROXY_VIA_USERNAME) && optionSet.has(PROXY_VIA_PASSWORD)){
-                proxySettings.setUsername((String) optionSet.valueOf(PROXY_VIA_USERNAME));
-                proxySettings.setPassword((String) optionSet.valueOf(PROXY_VIA_PASSWORD));
-            }else if(optionSet.has(PROXY_VIA_USERNAME) || optionSet.has(PROXY_VIA_PASSWORD)){
-                throw new IllegalArgumentException(String.format("Both %s and %s must be provided", PROXY_VIA_USERNAME, PROXY_VIA_PASSWORD));
-            }
-            return proxySettings;
+            return ProxySettings.fromString(proxyVia);
         }
         return NO_PROXY;
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -68,6 +68,8 @@ public class CommandLineOptions implements Options {
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PRESERVE_HOST_HEADER = "preserve-host-header";
     private static final String PROXY_VIA = "proxy-via";
+    private static final String PROXY_VIA_USERNAME = "proxy-via-username";
+    private static final String PROXY_VIA_PASSWORD = "proxy-via-password";
 	private static final String PORT = "port";
     private static final String BIND_ADDRESS = "bind-address";
     private static final String HTTPS_PORT = "https-port";
@@ -117,6 +119,8 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
+        optionParser.accepts(PROXY_VIA_USERNAME, "Specifies a proxy server username to use when routing proxy mapped requests").withRequiredArg();
+        optionParser.accepts(PROXY_VIA_PASSWORD, "Specifies a proxy server password to use when routing proxy mapped requests").withRequiredArg();
 		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
 		optionParser.accepts(MATCH_HEADERS, "Enable request header matching when recording through a proxy").withRequiredArg();
 		optionParser.accepts(ROOT_DIR, "Specifies path for storing recordings (parent for " + MAPPINGS_ROOT + " and " + WireMockApp.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
@@ -368,9 +372,15 @@ public class CommandLineOptions implements Options {
     public ProxySettings proxyVia() {
         if (optionSet.has(PROXY_VIA)) {
             String proxyVia = (String) optionSet.valueOf(PROXY_VIA);
-            return ProxySettings.fromString(proxyVia);
+            ProxySettings proxySettings = ProxySettings.fromString(proxyVia);
+            if(optionSet.has(PROXY_VIA_USERNAME) && optionSet.has(PROXY_VIA_PASSWORD)){
+                proxySettings.setUsername((String) optionSet.valueOf(PROXY_VIA_USERNAME));
+                proxySettings.setPassword((String) optionSet.valueOf(PROXY_VIA_PASSWORD));
+            }else if(optionSet.has(PROXY_VIA_USERNAME) || optionSet.has(PROXY_VIA_PASSWORD)){
+                throw new IllegalArgumentException(String.format("Both %s and %s must be provided", PROXY_VIA_USERNAME, PROXY_VIA_PASSWORD));
+            }
+            return proxySettings;
         }
-
         return NO_PROXY;
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/common/ProxySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/ProxySettingsTest.java
@@ -1,0 +1,89 @@
+package com.github.tomakehurst.wiremock.common;
+
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+
+public class ProxySettingsTest {
+
+    public static final String PROXYVIA_URL = "a.proxyvia.url";
+    public static final int PROXYVIA_PORT = 8080;
+    public static final String PROXYVIA_URL_WITH_PORT = PROXYVIA_URL + ":" + PROXYVIA_PORT;
+    public static final int DEFAULT_PORT = 80;
+    public static final String USER = "user";
+    public static final String PASSWORD = "pass";
+
+    @Test
+    public void shouldRetrieveProxySettingsFromString(){
+        ProxySettings proxySettings = ProxySettings.fromString(PROXYVIA_URL_WITH_PORT);
+        assertThat(proxySettings.host(), is(PROXYVIA_URL));
+        assertThat(proxySettings.port(), is(PROXYVIA_PORT));
+    }
+
+    @Test
+    public void shouldUse80AsDefaultPort(){
+        ProxySettings proxySettings = ProxySettings.fromString(PROXYVIA_URL);
+        assertThat(proxySettings.host(), is(PROXYVIA_URL));
+        assertThat(proxySettings.port(), is(DEFAULT_PORT));
+    }
+
+    @Test
+    public void shouldRecognizeUrlWithTrailingSlashIsPresent(){
+        ProxySettings proxySettings = ProxySettings.fromString(PROXYVIA_URL_WITH_PORT+"/");
+        assertThat(proxySettings.host(), is(PROXYVIA_URL));
+        assertThat(proxySettings.port(), is(PROXYVIA_PORT));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfPortIsNotRecognized(){
+        ProxySettings proxySettings = ProxySettings.fromString(PROXYVIA_URL+":80a");
+    }
+
+    @Test
+    public void shouldRetrieveProxyCredsFromUrl(){
+        ProxySettings proxySettings = ProxySettings.fromString(USER + ":" + PASSWORD + "@"+PROXYVIA_URL);
+        assertThat(proxySettings.host(), is(PROXYVIA_URL));
+        assertThat(proxySettings.port(), is(DEFAULT_PORT));
+        assertThat(proxySettings.getUsername(), is(USER));
+        assertThat(proxySettings.getPassword(), is(PASSWORD));
+    }
+
+    @Test
+    public void shouldRetrieveProxyCredsAndPortFromUrl(){
+        ProxySettings proxySettings = ProxySettings.fromString(USER + ":" + PASSWORD + "@"+PROXYVIA_URL_WITH_PORT);
+        assertThat(proxySettings.host(), is(PROXYVIA_URL));
+        assertThat(proxySettings.port(), is(PROXYVIA_PORT));
+        assertThat(proxySettings.getUsername(), is(USER));
+        assertThat(proxySettings.getPassword(), is(PASSWORD));
+    }
+
+    @Test
+    public void shouldRetrieveProxyCredsWithOnlyUserFromUrl(){
+        ProxySettings proxySettings = ProxySettings.fromString(USER + "@"+PROXYVIA_URL);
+        assertThat(proxySettings.host(), is(PROXYVIA_URL));
+        assertThat(proxySettings.port(), is(DEFAULT_PORT));
+        assertThat(proxySettings.getUsername(), is(USER));
+        assertThat(proxySettings.getPassword(), isEmptyOrNullString());
+    }
+
+    @Test
+    public void shouldAllowProtocol(){
+        ProxySettings proxySettings = ProxySettings.fromString("http://"+PROXYVIA_URL_WITH_PORT);
+        assertThat(proxySettings.host(), is(PROXYVIA_URL));
+        assertThat(proxySettings.port(), is(PROXYVIA_PORT));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowHttpsProtocol(){
+        ProxySettings proxySettings = ProxySettings.fromString("https://"+PROXYVIA_URL_WITH_PORT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfUrlIsInvalid(){
+        ProxySettings proxySettings = ProxySettings.fromString("ul:invalid:80");
+    }
+
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -41,6 +42,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.assertThat;
 
 public class CommandLineOptionsTest {
@@ -183,6 +185,33 @@ public class CommandLineOptionsTest {
         CommandLineOptions options = new CommandLineOptions("--proxy-via", "somehost.mysite.com:8080");
         assertThat(options.proxyVia().host(), is("somehost.mysite.com"));
         assertThat(options.proxyVia().port(), is(8080));
+        assertThat(options.proxyVia().getUsername(), isEmptyOrNullString());
+        assertThat(options.proxyVia().getPassword(), isEmptyOrNullString());
+    }
+
+    @Test
+    public void returnsCorrectlyParsedProxyViaCredentialsParameter() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-via", "somehost.mysite.com:8080", "--proxy-via-username", "user", "--proxy-via-password", "pwd");
+        assertThat(options.proxyVia().host(), is("somehost.mysite.com"));
+        assertThat(options.proxyVia().port(), is(8080));
+        assertThat(options.proxyVia().getUsername(), is("user"));
+        assertThat(options.proxyVia().getPassword(), is("pwd"));
+    }
+
+    @Test
+    public void shouldIgnoreProxyViaCredentialsIfNoProxyViaConfiguredParameter() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-via-username", "user", "--proxy-via-password", "pwd");
+        assertThat(options.proxyVia(), is(NO_PROXY));
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfOnlyProxyViaUsernameIsProvided() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-via", "somehost.mysite.com:8080", "--proxy-via-username", "user");
+        options.proxyVia();
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionIfOnlyProxyViaPasswordIsProvided() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-via", "somehost.mysite.com:8080", "--proxy-via-password", "pwd");
+        options.proxyVia();
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -190,29 +190,14 @@ public class CommandLineOptionsTest {
     }
 
     @Test
-    public void returnsCorrectlyParsedProxyViaCredentialsParameter() {
-        CommandLineOptions options = new CommandLineOptions("--proxy-via", "somehost.mysite.com:8080", "--proxy-via-username", "user", "--proxy-via-password", "pwd");
+    public void returnsCorrectlyParsedProxyViaParameterWithCredentials() {
+        CommandLineOptions options = new CommandLineOptions("--proxy-via", "user:password@somehost.mysite.com:8080");
         assertThat(options.proxyVia().host(), is("somehost.mysite.com"));
         assertThat(options.proxyVia().port(), is(8080));
         assertThat(options.proxyVia().getUsername(), is("user"));
-        assertThat(options.proxyVia().getPassword(), is("pwd"));
+        assertThat(options.proxyVia().getPassword(), is("password"));
     }
 
-    @Test
-    public void shouldIgnoreProxyViaCredentialsIfNoProxyViaConfiguredParameter() {
-        CommandLineOptions options = new CommandLineOptions("--proxy-via-username", "user", "--proxy-via-password", "pwd");
-        assertThat(options.proxyVia(), is(NO_PROXY));
-    }
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfOnlyProxyViaUsernameIsProvided() {
-        CommandLineOptions options = new CommandLineOptions("--proxy-via", "somehost.mysite.com:8080", "--proxy-via-username", "user");
-        options.proxyVia();
-    }
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldThrowExceptionIfOnlyProxyViaPasswordIsProvided() {
-        CommandLineOptions options = new CommandLineOptions("--proxy-via", "somehost.mysite.com:8080", "--proxy-via-password", "pwd");
-        options.proxyVia();
-    }
 
     @Test
     public void returnsNoProxyWhenNoProxyViaSpecified() {


### PR DESCRIPTION
Hi,
I added the support of proxy-via that needs a proxy with authentication.
ie: http://user:password@proxy.com

PS: I had 2 broken UT related to internationalization:
    Expected: is "Content is not allowed in prolog.; line 1; column 1"
         but: was "Contenu non autorisé dans le prologue.; line 1; column 1"

com.github.tomakehurst.wiremock.matching.EqualToXmlPatternTest > logsASensibleErrorMessageWhenActualXmlIsBadlyFormed FAILED

com.github.tomakehurst.wiremock.AdminApiTest > returnsBadEntityStatusWhenInvalidEqualToXmlSpecified FAILED

Kevin