### PR TITLE
SSL truststore tries to load from classpath

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/KeyStoreSettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/KeyStoreSettings.java
@@ -15,8 +15,11 @@
  */
 package com.github.tomakehurst.wiremock.common;
 
-import java.io.FileInputStream;
-import java.io.IOException;
+import com.google.common.io.Resources;
+
+import java.io.*;
+import java.net.URL;
+import java.rmi.server.ExportException;
 import java.security.KeyStore;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
@@ -42,10 +45,10 @@ public class KeyStoreSettings {
     }
 
     public KeyStore loadStore() {
-        FileInputStream instream = null;
+        InputStream instream = null;
         try {
             KeyStore trustStore  = KeyStore.getInstance(KeyStore.getDefaultType());
-            instream = new FileInputStream(path);
+            instream = createInputStream();
             trustStore.load(instream, password.toCharArray());
             return trustStore;
         } catch (Exception e) {
@@ -58,6 +61,14 @@ public class KeyStoreSettings {
                     throwUnchecked(ioe);
                 }
             }
+        }
+    }
+
+    private InputStream createInputStream() throws IOException {
+        if (new File(path).isFile()) {
+            return new FileInputStream(path);
+        } else {
+            return Resources.getResource(path).openStream();
         }
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/KeyStoreSettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/KeyStoreSettings.java
@@ -17,9 +17,10 @@ package com.github.tomakehurst.wiremock.common;
 
 import com.google.common.io.Resources;
 
-import java.io.*;
-import java.net.URL;
-import java.rmi.server.ExportException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyStore;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;

--- a/src/test/java/com/github/tomakehurst/wiremock/common/KeyStoreSettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/KeyStoreSettingsTest.java
@@ -2,7 +2,6 @@ package com.github.tomakehurst.wiremock.common;
 
 import org.junit.Test;
 
-import java.io.FileNotFoundException;
 import java.security.KeyStore;
 
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/github/tomakehurst/wiremock/common/KeyStoreSettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/KeyStoreSettingsTest.java
@@ -1,0 +1,36 @@
+package com.github.tomakehurst.wiremock.common;
+
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.security.KeyStore;
+
+import static org.junit.Assert.assertNotNull;
+
+public class KeyStoreSettingsTest {
+
+    private final static String TRUSTSTORE_PASSWORD = "mytruststorepassword";
+
+    @Test
+    public void loadsTrustStoreFromClasspath() {
+        KeyStoreSettings trustStoreSettings = new KeyStoreSettings("test-clientstore", TRUSTSTORE_PASSWORD);
+
+        KeyStore keyStore = trustStoreSettings.loadStore();
+        assertNotNull(keyStore);
+    }
+
+    @Test
+    public void loadsTrustStoreFromFilesystem() {
+        KeyStoreSettings trustStoreSettings = new KeyStoreSettings("src/test/resources/test-clientstore", TRUSTSTORE_PASSWORD);
+
+        KeyStore keyStore = trustStoreSettings.loadStore();
+        assertNotNull(keyStore);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void failsWhenTrustStoreNotFound() {
+        KeyStoreSettings trustStoreSettings = new KeyStoreSettings("test-unknownstore", "");
+        trustStoreSettings.loadStore();
+    }
+
+}


### PR DESCRIPTION
Fix for #475 
Added a fallback in `KeyStoreSettings` to try loading the truststore from classpath if not found as file.
Added relevant test cases