### PR TITLE
Set Response and ResponseDefinition transformers by instance

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -16,11 +16,14 @@
 package com.github.tomakehurst.wiremock.client;
 
 import com.github.tomakehurst.wiremock.common.Json;
+import com.github.tomakehurst.wiremock.extension.AbstractTransformer;
+import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +47,7 @@ public class ResponseDefinitionBuilder {
 	protected String proxyBaseUrl;
 	protected Fault fault;
 	protected List<String> responseTransformerNames;
+	protected List<AbstractTransformer> responseTransformers = new ArrayList<>();
 	protected Map<String, Object> transformerParameters = newHashMap();
 	protected Boolean wasConfigured = true;
 
@@ -64,6 +68,7 @@ public class ResponseDefinitionBuilder {
 		builder.proxyBaseUrl = responseDefinition.getProxyBaseUrl();
 		builder.fault = responseDefinition.getFault();
 		builder.responseTransformerNames = responseDefinition.getTransformers();
+		builder.responseTransformers = responseDefinition.getTransformerInstances(); //TODO: check where used
 		builder.transformerParameters = responseDefinition.getTransformerParameters() != null ?
 			Parameters.from(responseDefinition.getTransformerParameters()) :
 			Parameters.empty();
@@ -137,6 +142,11 @@ public class ResponseDefinitionBuilder {
 
 	public ResponseDefinitionBuilder withTransformers(String... responseTransformerNames) {
 		this.responseTransformerNames = asList(responseTransformerNames);
+		return this;
+	}
+
+	public ResponseDefinitionBuilder withTransformers(AbstractTransformer... responseTransformers) {
+		this.responseTransformers = asList(responseTransformers);
 		return this;
 	}
 
@@ -252,12 +262,12 @@ public class ResponseDefinitionBuilder {
 						fault,
 						responseTransformerNames,
 						transformerParameters,
-                        wasConfigured) :
+						responseTransformers,
+						wasConfigured) :
 				new ResponseDefinition(
 						status,
 						statusMessage,
 						stringBody,
-						null,
 						base64Body,
 						bodyFileName,
 						httpHeaders,
@@ -269,7 +279,8 @@ public class ResponseDefinitionBuilder {
 						fault,
 						responseTransformerNames,
 						transformerParameters,
-					    wasConfigured
+						responseTransformers,
+						wasConfigured
 				);
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
 
+import java.util.LinkedList;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
@@ -49,6 +50,8 @@ public class StubResponseRenderer implements ResponseRenderer {
 		}
 
 		Response response = buildResponse(responseDefinition);
+		LinkedList<ResponseTransformer> responseTransformers = new LinkedList<>(this.responseTransformers);
+		responseTransformers.addAll(responseDefinition.getResponseTransformers());
 		return applyTransformations(responseDefinition.getOriginalRequest(), responseDefinition, response, responseTransformers);
 	}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
@@ -26,10 +26,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
@@ -67,9 +64,10 @@ public class InMemoryStubMappings implements StubMappings {
 		
 		scenarios.onStubServed(matchingMapping);
 
-        ResponseDefinition responseDefinition = applyTransformations(request,
-            matchingMapping.getResponse(),
-            ImmutableList.copyOf(transformers.values()));
+        ResponseDefinition response = matchingMapping.getResponse();
+		List<ResponseDefinitionTransformer> transformers = new LinkedList<>(this.transformers.values());
+		transformers.addAll(response.getResponseDefinitionTransformers());
+		ResponseDefinition responseDefinition = applyTransformations(request, response, transformers);
 
 		return ServeEvent.of(
             LoggedRequest.createFrom(request),

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseDefinitionTransformerAcceptanceTest.java
@@ -119,6 +119,22 @@ public class ResponseDefinitionTransformerAcceptanceTest {
         assertThat(response.content(), is("Non-global transformed body"));
     }
 
+    @Test
+    public void appliesNonGlobalExtensionsWhenSpecifiedByStubAsInstance() {
+        wm = new WireMockServer(wireMockConfig()
+                .dynamicPort());
+        wm.start();
+        client = new WireMockTestClient(wm.port());
+
+        wm.stubFor(get(urlEqualTo("/local-transform-instance")).willReturn(aResponse()
+                .withStatus(200)
+                .withBody("Should not see this")
+                .withTransformers(new NonGlobalTransformer())));
+
+        WireMockResponse response = client.get("/local-transform-instance");
+        assertThat(response.content(), is("Non-global transformed body"));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     @SuppressWarnings("unchecked")
     public void preventsMoreThanOneExtensionWithTheSameNameFromBeingAdded() {


### PR DESCRIPTION
Closes #933 

The motivation behind this change is to make in-proc configuration of the transformers less cumbersome. One can simply pass the instances of their transformers to a `ResponseDefinitionBuilder`, e.g.: 

```java
stubFor(any(urlEqualTo("/stub1"))
            .willReturn(aResponse()
                    .withTransformers(new MyResponseOrResponseDefinitionTransformer())
            )
    );
```

#### Benefits

* No need to register the transformations up-front at the configuration of the `WireMockServer`. This makes the composition of the code that sets the transformations easier.  
* Setting up a local stub is much more straightforward, no need to worry about the `AbstractTransformer.applyGlobally` flag. (I've seem and made myself confusions like [here](https://stackoverflow.com/questions/50231111/how-to-create-multiple-response-transformers-on-wiremock))

#### Potential issues

* This would obviously not work with Wiremock running as a standalone process, although could be extended for class names, similarly to the `WireMockConfiguration#extensions()` of the server configuration. 
* It can be potentially confusing that this new stub configuration method accepts global transformers, maybe a check for `false == AbstractTransformer#applyGlobally` would be a better idea.

