### PR TITLE
Fix build (tests) for users having a non-English default locale

### DIFF
--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -27,6 +27,7 @@ import org.junit.BeforeClass;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Locale;
 
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
@@ -43,6 +44,10 @@ public class AcceptanceTestBase {
 	@BeforeClass
 	public static void setupServer() {
 		setupServerWithEmptyFileRoot();
+
+		// We assert English XML parser error messages in some tests. So we set our default locale to English to make
+		// those tests succeed even for users with non-English default locales.
+		Locale.setDefault(Locale.ENGLISH);
 	}
 
 	@AfterClass

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/EqualToXmlPatternTest.java
@@ -25,6 +25,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Locale;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.closeTo;
@@ -42,6 +44,10 @@ public class EqualToXmlPatternTest {
     public void init() {
         context = new Mockery();
         LocalNotifier.set(new ConsoleNotifier(true));
+
+        // We assert English XML parser error messages in this test. So we set our default locale to English to make
+        // this test succeed even for users with non-English default locales.
+        Locale.setDefault(Locale.ENGLISH);
     }
 
     @After


### PR DESCRIPTION
The tests AdminApiTest and EqualToXmlPatternTest assert English XML parser
error messages. To make those tests succeed for users having a non-English
default locale we set the default locale to English in those tests.

We refrain from setting the system property user.language in build.gradle
because that would only fix the tests when run from the command line, not when
run from some IDE.