### PR TITLE
Adding isJson check for xpath matchers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,8 @@ def shouldPublishLocally = System.getProperty('LOCAL_PUBLISH')
 def versions = [
     jackson: '2.8.11',
     jetty  : '9.2.24.v20180105', // Please don't raise PRs upgrading this to the latest version as it drops Java 7 support. See https://github.com/tomakehurst/wiremock/issues/407 and https://github.com/tomakehurst/wiremock/pull/887 for details
-    xmlUnit: '2.5.1'
+    xmlUnit: '2.5.1',
+    json   : '20171018'
 ]
 
 repositories {
@@ -44,6 +45,7 @@ repositories {
 }
 
 dependencies {
+    compile "org.json:json:$versions.json"
     compile "org.eclipse.jetty:jetty-server:$versions.jetty"
     compile "org.eclipse.jetty:jetty-servlet:$versions.jetty"
     compile "org.eclipse.jetty:jetty-servlets:$versions.jetty"

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -120,6 +120,7 @@ public class MatchesXPathPattern extends PathPattern {
         return results.last();
     }
 
+    // Adapted from https://stackoverflow.com/a/10174938
     private boolean isJson(String value) {
         try {
             new JSONObject(value);

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesXPathPattern.java
@@ -27,6 +27,9 @@ import org.custommonkey.xmlunit.SimpleNamespaceContext;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.custommonkey.xmlunit.XpathEngine;
 import org.custommonkey.xmlunit.exceptions.XpathException;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -87,7 +90,7 @@ public class MatchesXPathPattern extends PathPattern {
 
     @Override
     protected MatchResult isSimpleJsonPathMatch(String value) {
-        if (value == null) {
+        if (value == null || isJson(value)) {
             return MatchResult.noMatch();
         }
 
@@ -98,7 +101,7 @@ public class MatchesXPathPattern extends PathPattern {
 
     @Override
     protected MatchResult isAdvancedJsonPathMatch(String value) {
-        if (value == null) {
+        if (value == null || isJson(value)) {
             return MatchResult.noMatch();
         }
 
@@ -115,6 +118,20 @@ public class MatchesXPathPattern extends PathPattern {
         }
 
         return results.last();
+    }
+
+    private boolean isJson(String value) {
+        try {
+            new JSONObject(value);
+        } catch (JSONException ex) {
+            // e.g. in case JSONArray is valid as well...
+            try {
+                new JSONArray(value);
+            } catch (JSONException ex1) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private NodeList findXmlNodesMatching(String value) {


### PR DESCRIPTION
- Adds dependency on json library.
- Adds `isJson` check in Xpath matcher that will prevent a sax parser error getting logged on json data.

Issue #595 

I cannot install locally to test this (I believe because #444 has not been resolved yet and it is not readily apparent how to do so).