### PR TITLE
return unzipped string body when it is zipped

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -17,13 +17,15 @@ package com.github.tomakehurst.wiremock.http;
 
 import com.github.tomakehurst.wiremock.common.InputStreamSource;
 import com.github.tomakehurst.wiremock.common.StreamSources;
-import com.github.tomakehurst.wiremock.common.Strings;
 import com.google.common.base.Optional;
 import com.google.common.io.ByteStreams;
 
 import java.io.IOException;
 import java.io.InputStream;
 
+import static com.github.tomakehurst.wiremock.common.Gzip.isGzipped;
+import static com.github.tomakehurst.wiremock.common.Gzip.unGzip;
+import static com.github.tomakehurst.wiremock.common.Strings.stringFromBytes;
 import static com.github.tomakehurst.wiremock.http.HttpHeaders.noHeaders;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -113,7 +115,7 @@ public class Response {
     }
 
 	public String getBodyAsString() {
-        return Strings.stringFromBytes(getBody(), headers.getContentTypeHeader().charset());
+        return stringFromBytes(isGzipped(getBody()) ? unGzip(getBody()) : getBody(), headers.getContentTypeHeader().charset());
 	}
 
     public InputStream getBodyStream() {

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ResponseTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ResponseTest.java
@@ -1,0 +1,20 @@
+package com.github.tomakehurst.wiremock.http;
+
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.common.Gzip.gzip;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ResponseTest {
+
+    private static final String BODY = "zipped body";
+
+    @Test
+    public void returnsUnzippedStringBodyWhenResponseBodyIsZipped() {
+        Response responseWithZippedBody = new Response.Builder().body(gzip(BODY)).build();
+
+        assertThat(responseWithZippedBody.getBodyAsString(), is(BODY));
+    }
+
+}


### PR DESCRIPTION
I am getting zipped body for a proxied request in a listener. As WireMockHttpServletRequestAdapter is doing it already I thought would be nice to have it in the response as well for consistency.