### PR TITLE
Remove temporal coupling between run() and isRunning()

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -112,7 +112,11 @@ public class WireMockServerRunner {
 	}
 
     public boolean isRunning() {
-        return wireMockServer.isRunning();
+		if (wireMockServer == null) {
+			return false;
+		} else {
+			return wireMockServer.isRunning();
+		}
     }
 
     public int port() { return wireMockServer.port(); }

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -402,10 +402,10 @@ public class StandaloneAcceptanceTest {
     }
 
     @Test
-	public void isRunningReturnsFalseBeforeRunMethodIsExecuted() {
-		runner = new WireMockServerRunner();
-		assertThat(runner.isRunning(), is(false));
-	}
+    public void isRunningReturnsFalseBeforeRunMethodIsExecuted() {
+        runner = new WireMockServerRunner();
+        assertThat(runner.isRunning(), is(false));
+    }
 
     private static final String BAD_MAPPING =
         "{ 													\n" +

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -401,6 +401,12 @@ public class StandaloneAcceptanceTest {
         fail("WireMock did not shut down");
     }
 
+    @Test
+	public void isRunningReturnsFalseBeforeRunMethodIsExecuted() {
+		runner = new WireMockServerRunner();
+		assertThat(runner.isRunning(), is(false));
+	}
+
     private static final String BAD_MAPPING =
         "{ 													\n" +
             "	\"requesttttt\": {      						\n" +


### PR DESCRIPTION
`isRunning()` no longer throws NPE if executed prior to `run()`.