### PR TITLE
issue-965 - fix issue with swagger-ui and https

### DIFF
--- a/src/main/resources/raml/wiremock-admin-api.raml
+++ b/src/main/resources/raml/wiremock-admin-api.raml
@@ -5,6 +5,10 @@ version: 2.18.0
 mediaType: application/json
 baseUri: /__admin
 
+protocols:
+  - HTTPS
+  - HTTP
+
 documentation:
   - title: WireMock admin
     content: |


### PR DESCRIPTION
This adds https support explicitly for swagger.  The root issue appears to be in swagger, but if you list https and then http explicitly as supported schemes it will function correctly in the UI and follow the base protocol in the URL

Fix worked locally for me.