### PR TITLE
Add base url method to wiremock server

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -189,7 +189,6 @@ public class WireMockServer implements Container, Stubbing, Admin {
         return httpServer.httpsPort();
     }
 
-
     public String url(String path) {
         if (!path.startsWith("/")) {
             path = "/" + path;

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -189,16 +189,21 @@ public class WireMockServer implements Container, Stubbing, Admin {
         return httpServer.httpsPort();
     }
 
-    public String url(String path) {
-        boolean https = options.httpsSettings().enabled();
-        String protocol = https ? "https" : "http";
-        int port = https ? httpsPort() : port();
 
+    public String url(String path) {
         if (!path.startsWith("/")) {
             path = "/" + path;
         }
 
-        return String.format("%s://localhost:%d%s", protocol, port, path);
+        return String.format("%s%s", baseUrl(), path);
+    }
+
+    public String baseUrl() {
+        boolean https = options.httpsSettings().enabled();
+        String protocol = https ? "https" : "http";
+        int port = https ? httpsPort() : port();
+
+        return String.format("%s://localhost:%d", protocol, port);
     }
 
     public boolean isRunning() {

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -87,6 +87,28 @@ public class WireMockServerTests {
         assertThat(wireMockServer.url("something"), is(String.format("https://localhost:%d/something", port)));
     }
 
+
+    @Test
+    public void buildsBaseHttpUrl() {
+        WireMockServer wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+        int port = wireMockServer.port();
+
+        assertThat(wireMockServer.baseUrl(), is(String.format("http://localhost:%d", port)));
+    }
+
+    @Test
+    public void buildsBaseHttpsUrl() {
+        WireMockServer wireMockServer = new WireMockServer(options()
+            .dynamicPort()
+            .dynamicHttpsPort()
+        );
+        wireMockServer.start();
+        int port = wireMockServer.httpsPort();
+
+        assertThat(wireMockServer.baseUrl(), is(String.format("https://localhost:%d", port)));
+    }
+
     // https://github.com/tomakehurst/wiremock/issues/193
     @Test
     public void supportsRecordingProgrammaticallyWithoutHeaderMatching() {

--- a/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WireMockServerTests.java
@@ -87,7 +87,6 @@ public class WireMockServerTests {
         assertThat(wireMockServer.url("something"), is(String.format("https://localhost:%d/something", port)));
     }
 
-
     @Test
     public void buildsBaseHttpUrl() {
         WireMockServer wireMockServer = new WireMockServer(options().dynamicPort());


### PR DESCRIPTION
I wanted to get url like `http://localhost:34567` but `url(String path)` method allowed only to get url  with a tailing slash (when I passed empty string), so I created method named `baseUrl()` that allows to get wiremock url without a slash at the end.