### PR TITLE
docs(README): Fix maven-central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ WireMock - a web service test double for all occasions
 ======================================================
 
 [![Build Status](https://travis-ci.org/tomakehurst/wiremock.svg?branch=master)](https://travis-ci.org/tomakehurst/wiremock)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.tomakehurst/wiremock/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.tomakehurst/wiremock)
+[![Maven Central](https://img.shields.io/maven-central/v/com.github.tomakehurst/wiremock.svg)](https://search.maven.org/artifact/com.github.tomakehurst/wiremock)
+
 
 Key Features
 ------------


### PR DESCRIPTION
The current badge link `https://maven-badges.herokuapp.com/maven-central/com.github.tomakehurst/wiremock` is redirecting to `https://search.maven.org`.