### PR TITLE
Add more info to admin request log

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -72,7 +72,7 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
         stopwatch.stop();
 	}
 
-	private static String formatRequest(Request request) {
+	protected String formatRequest(Request request) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(request.getClientIp())
 				.append(" - ")

--- a/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
@@ -64,7 +64,7 @@ public class AdminRequestHandler extends AbstractRequestHandler {
             );
         }
 
-        notifier().info("Received request to " + request.getUrl() + " with body " + request.getBodyAsString());
+        notifier().info("Admin request received:\n" + formatRequest(request));
         String path = URI.create(withoutAdminRoot(request.getUrl())).getPath();
 
         try {


### PR DESCRIPTION
Since the mock server is shared by multiple people, and enterprise prefers to audit everything, need to add more info to the admin request logs, like client IP address, request method, headers and body.