### PR TITLE
Support other keystore types when running from the command line.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -68,8 +68,10 @@ public class CommandLineOptions implements Options {
     private static final String HTTPS_PORT = "https-port";
     private static final String HTTPS_KEYSTORE = "https-keystore";
     private static final String HTTPS_KEYSTORE_PASSWORD = "keystore-password";
+    private static final String HTTPS_KEYSTORE_TYPE = "keystore-type";
     private static final String HTTPS_TRUSTSTORE = "https-truststore";
     private static final String HTTPS_TRUSTSTORE_PASSWORD = "truststore-password";
+    private static final String HTTPS_TRUSTSTORE_TYPE = "truststore-type";
     private static final String REQUIRE_CLIENT_CERT = "https-require-client-cert";
     private static final String VERBOSE = "verbose";
     private static final String ENABLE_BROWSER_PROXYING = "enable-browser-proxying";
@@ -107,8 +109,10 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(REQUIRE_CLIENT_CERT, "Make the server require a trusted client certificate to enable a connection");
         optionParser.accepts(HTTPS_TRUSTSTORE_PASSWORD, "Password for the trust store").withRequiredArg();
         optionParser.accepts(HTTPS_TRUSTSTORE, "Path to an alternative truststore for HTTPS client certificates. Must have a password of \"password\".").requiredIf(REQUIRE_CLIENT_CERT).withRequiredArg();
+        optionParser.accepts(HTTPS_TRUSTSTORE_TYPE, "The type of the keystore used for the alternative truststore.").withRequiredArg().defaultsTo("JKS");
         optionParser.accepts(HTTPS_KEYSTORE_PASSWORD, "Password for the alternative keystore.").withRequiredArg().defaultsTo("password");
         optionParser.accepts(HTTPS_KEYSTORE, "Path to an alternative keystore for HTTPS. Password is assumed to be \"password\" if not specified.").requiredIf(HTTPS_TRUSTSTORE).requiredIf(HTTPS_KEYSTORE_PASSWORD).withRequiredArg().defaultsTo(Resources.getResource("keystore").toString());
+        optionParser.accepts(HTTPS_KEYSTORE_TYPE, "The type of the keystore used for the alternative keystore.").withRequiredArg().defaultsTo("JKS");
         optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
@@ -237,8 +241,10 @@ public class CommandLineOptions implements Options {
                 .port(httpsPortNumber())
                 .keyStorePath((String) optionSet.valueOf(HTTPS_KEYSTORE))
                 .keyStorePassword((String) optionSet.valueOf(HTTPS_KEYSTORE_PASSWORD))
+                .keyStoreType((String) optionSet.valueOf(HTTPS_KEYSTORE_TYPE))
                 .trustStorePath((String) optionSet.valueOf(HTTPS_TRUSTSTORE))
                 .trustStorePassword((String) optionSet.valueOf(HTTPS_TRUSTSTORE_PASSWORD))
+                .trustStoreType((String) optionSet.valueOf(HTTPS_TRUSTSTORE_TYPE))
                 .needClientAuth(optionSet.has(REQUIRE_CLIENT_CERT)).build();
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -111,16 +111,22 @@ public class CommandLineOptionsTest {
         CommandLineOptions options = new CommandLineOptions("--https-port", "8443",
                 "--https-keystore", "/my/keystore",
                 "--https-truststore", "/my/truststore",
-                "--truststore-password", "sometrustpwd");
+                "--truststore-password", "sometrustpwd",
+                "--truststore-type", "PKCS12");
         assertThat(options.httpsSettings().trustStorePath(), is("/my/truststore"));
         assertThat(options.httpsSettings().trustStorePassword(), is("sometrustpwd"));
+        assertThat(options.httpsSettings().trustStoreType(), is("PKCS12"));
     }
 
     @Test
     public void setsKeyStorePathAndPassword() {
-        CommandLineOptions options = new CommandLineOptions("--https-port", "8443", "--https-keystore", "/my/keystore", "--keystore-password", "someotherpwd");
+        CommandLineOptions options = new CommandLineOptions("--https-port", "8443",
+            "--https-keystore", "/my/keystore",
+            "--keystore-password", "someotherpwd",
+            "--keystore-type", "PKCS12");
         assertThat(options.httpsSettings().keyStorePath(), is("/my/keystore"));
         assertThat(options.httpsSettings().keyStorePassword(), is("someotherpwd"));
+        assertThat(options.httpsSettings().keyStoreType(), is("PKCS12"));
     }
 
     @Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
This is possible with the API; but not when invoking standalone so this just added the extra command line parameters. The default changed in JDK 9 to PKCS12 so having the option to override it is useful.

https://blogs.oracle.com/jtc/jdk9-keytool-transitions-default-keystore-to-pkcs12