### PR TITLE
Added ability to capture all headers while recording

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/recording/CaptureAllHeadersRequestTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/CaptureAllHeadersRequestTransformer.java
@@ -1,0 +1,30 @@
+package com.github.tomakehurst.wiremock.recording;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.google.common.base.Function;
+
+public class CaptureAllHeadersRequestTransformer implements Function<Request, RequestPatternBuilder> {
+    private final RequestBodyPatternFactory bodyPatternFactory;
+
+    public CaptureAllHeadersRequestTransformer(RequestBodyPatternFactory bodyPatternFactory) {
+        this.bodyPatternFactory = bodyPatternFactory;
+    }
+
+    @Override
+    public RequestPatternBuilder apply(Request request) {
+        RequestPatternBuilder builder =
+            new RequestPatternBuilder(request.getMethod(), WireMock.urlEqualTo(request.getUrl()));
+
+        for (String header : request.getAllHeaderKeys()) {
+            builder.withHeader(header, new EqualToPattern(request.getHeader(header), true));
+        }
+        byte[] body = request.getBody();
+        if (bodyPatternFactory != null && body != null && body.length > 0) {
+            builder.withRequestBody(bodyPatternFactory.forRequest(request));
+        }
+        return builder;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpec.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpec.java
@@ -58,6 +58,9 @@ public class RecordSpec {
     // Parameters for stub mapping transformers
     private final Parameters transformerParameters;
 
+    // if this is set to true, all headers will be captured for each request and must match exactly to be replayed
+    private final Boolean captureAllHeaders;
+
     @JsonCreator
     public RecordSpec(
         @JsonProperty("targetBaseUrl") String targetBaseUrl,
@@ -69,7 +72,8 @@ public class RecordSpec {
         @JsonProperty("persist") Boolean persist,
         @JsonProperty("repeatsAsScenarios") Boolean repeatsAsScenarios,
         @JsonProperty("transformers") List<String> transformers,
-        @JsonProperty("transformerParameters") Parameters transformerParameters) {
+        @JsonProperty("transformerParameters") Parameters transformerParameters,
+        @JsonProperty("captureAllHeaders") Boolean captureAllHeaders) {
         this.targetBaseUrl = targetBaseUrl;
         this.filters = filters == null ? new ProxiedServeEventFilters() : filters;
         this.captureHeaders = captureHeaders;
@@ -80,16 +84,17 @@ public class RecordSpec {
         this.repeatsAsScenarios = repeatsAsScenarios;
         this.transformers = transformers;
         this.transformerParameters = transformerParameters;
+        this.captureAllHeaders = captureAllHeaders  == null ? false: captureAllHeaders;
     }
 
     private RecordSpec() {
-        this(null, null, null, null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null, null, null,null);
     }
 
     public static final RecordSpec DEFAULTS = new RecordSpec();
 
     public static RecordSpec forBaseUrl(String targetBaseUrl) {
-        return new RecordSpec(targetBaseUrl, null, null, null, null, null, null, true, null, null);
+        return new RecordSpec(targetBaseUrl, null, null, null, null, null, null, true, null, null, null);
     }
 
     public String getTargetBaseUrl() {
@@ -122,4 +127,7 @@ public class RecordSpec {
 
     public RequestBodyPatternFactory getRequestBodyPatternFactory() { return requestBodyPatternFactory; }
 
+    public Boolean getCaptureAllHeaders() {
+        return captureAllHeaders;
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/RecordSpecBuilder.java
@@ -40,6 +40,7 @@ public class RecordSpecBuilder {
     private List<String> transformerNames;
     private Parameters transformerParameters;
     private boolean allowNonProxied;
+    private boolean captureAllHeaders = false;
 
     public RecordSpecBuilder forTarget(String targetBaseUrl) {
         this.targetBaseUrl = targetBaseUrl;
@@ -136,6 +137,11 @@ public class RecordSpecBuilder {
         return this;
     }
 
+    public RecordSpecBuilder captureAllRequestHeaders(boolean captureAllHeaders){
+        this.captureAllHeaders = captureAllHeaders;
+        return this;
+    }
+
     public RecordSpec build() {
         RequestPattern filterRequestPattern = filterRequestPatternBuilder != null ?
             filterRequestPatternBuilder.build() :
@@ -156,7 +162,8 @@ public class RecordSpecBuilder {
             persistentStubs,
             repeatsAsScenarios,
             transformerNames,
-            transformerParameters
+            transformerParameters,
+            captureAllHeaders
         );
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/Recorder.java
@@ -105,7 +105,7 @@ public class Recorder {
         final List<StubMapping> stubMappings = serveEventsToStubMappings(
             Lists.reverse(serveEvents),
             recordSpec.getFilters(),
-            new SnapshotStubMappingGenerator(recordSpec.getCaptureHeaders(), recordSpec.getRequestBodyPatternFactory()),
+            getSnapshotStubMappingGenerator(recordSpec),
             getStubMappingPostProcessor(admin.getOptions(), recordSpec)
         );
 
@@ -130,6 +130,17 @@ public class Recorder {
             .transform(stubMappingGenerator);
 
         return stubMappingPostProcessor.process(stubMappings);
+    }
+
+    public SnapshotStubMappingGenerator getSnapshotStubMappingGenerator(RecordSpec recordSpec) {
+        if (recordSpec.getCaptureAllHeaders()) {
+            return new SnapshotStubMappingGenerator(
+                new CaptureAllHeadersRequestTransformer(recordSpec.getRequestBodyPatternFactory()),
+                new LoggedResponseDefinitionTransformer());
+        } else {
+            return new SnapshotStubMappingGenerator(recordSpec.getCaptureHeaders(),
+                recordSpec.getRequestBodyPatternFactory());
+        }
     }
 
     public SnapshotStubMappingPostProcessor getStubMappingPostProcessor(Options options, RecordSpec recordSpec) {

--- a/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGenerator.java
@@ -16,8 +16,10 @@
 package com.github.tomakehurst.wiremock.recording;
 
 import com.github.tomakehurst.wiremock.common.SafeNames;
+import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.google.common.base.Function;
@@ -29,11 +31,11 @@ import java.util.Map;
  * Transforms ServeEvents to StubMappings using RequestPatternTransformer and LoggedResponseDefinitionTransformer
  */
 public class SnapshotStubMappingGenerator implements Function<ServeEvent, StubMapping> {
-    private final RequestPatternTransformer requestTransformer;
+    private final Function<Request, RequestPatternBuilder> requestTransformer;
     private final LoggedResponseDefinitionTransformer responseTransformer;
 
     public SnapshotStubMappingGenerator(
-        RequestPatternTransformer requestTransformer,
+        Function<Request, RequestPatternBuilder> requestTransformer,
         LoggedResponseDefinitionTransformer responseTransformer
     ) {
         this.requestTransformer = requestTransformer;

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingGeneratorTest.java
@@ -20,10 +20,14 @@ import com.github.tomakehurst.wiremock.http.LoggedResponse;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.Response;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.matching.EqualToPattern;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.testsupport.MockRequestBuilder;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import java.util.HashMap;
+import java.util.Map;
 import org.jmock.Mockery;
 import org.junit.Test;
 
@@ -46,8 +50,54 @@ public class SnapshotStubMappingGeneratorTest {
         StubMapping actual = stubMappingTransformer.apply(serveEvent());
         StubMapping expected = new StubMapping(requestPatternBuilder.build(), responseDefinition);
         expected.setId(actual.getId());
-
         assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void applyCaptureHeadersTest() {
+        Map<String,String> testRequestHeaders = new HashMap<>();
+        testRequestHeaders.put("capture", "test");
+        testRequestHeaders.put("noCapture", "test");
+
+        Map<String,CaptureHeadersSpec> headersToCapture = new HashMap<>();
+        headersToCapture.put("capture",new CaptureHeadersSpec(true));
+
+        final RequestPatternBuilder expectedRequestPatternBuilder = newRequestPattern().withHeader("capture",new EqualToPattern("test",true));
+        final ResponseDefinition responseDefinition = ResponseDefinition.ok();
+
+        SnapshotStubMappingGenerator stubMappingTransformer = new SnapshotStubMappingGenerator(
+            new RequestPatternTransformer(headersToCapture,null),
+            responseDefinitionTransformer(responseDefinition)
+        );
+
+        StubMapping actual = stubMappingTransformer.apply(serveEventWithRequestHeaders(testRequestHeaders));
+        StubMapping expected = new StubMapping(expectedRequestPatternBuilder.build(), responseDefinition);
+
+        assertThat(actual.getRequest().getHeaders(), is(expected.getRequest().getHeaders()));
+    }
+
+    @Test
+    public void applyCaptureAllHeadersTest() {
+        Map<String,String> testRequestHeaders = new HashMap<>();
+        testRequestHeaders.put("capture", "test");
+        testRequestHeaders.put("alsoCapture", "test");
+
+        final RequestPatternBuilder expectedRequestPatternBuilder = newRequestPattern();
+        for(String s : testRequestHeaders.keySet()){
+            expectedRequestPatternBuilder.withHeader(s, new EqualToPattern(testRequestHeaders.get(s),true));
+        }
+
+        final ResponseDefinition responseDefinition = ResponseDefinition.ok();
+
+        SnapshotStubMappingGenerator stubMappingTransformer = new SnapshotStubMappingGenerator(
+            new CaptureAllHeadersRequestTransformer(null),
+            responseDefinitionTransformer(responseDefinition)
+        );
+
+        StubMapping actual = stubMappingTransformer.apply(serveEventWithRequestHeaders(testRequestHeaders));
+        StubMapping expected = new StubMapping(expectedRequestPatternBuilder.build(), responseDefinition);
+
+        assertThat(actual.getRequest().getHeaders(), is(expected.getRequest().getHeaders()));
     }
 
     private static RequestPatternTransformer requestPatternTransformer(final RequestPatternBuilder requestPatternBuilder) {
@@ -72,6 +122,20 @@ public class SnapshotStubMappingGeneratorTest {
         return new ServeEvent(
             null,
             LoggedRequest.createFrom(aRequest(new Mockery()).build()),
+            null,
+            null,
+            LoggedResponse.from(Response.notConfigured()),
+            false,
+            Timing.UNTIMED);
+    }
+    private static ServeEvent serveEventWithRequestHeaders(Map<String,String> headers) {
+        MockRequestBuilder request = aRequest(new Mockery());
+        for(String s : headers.keySet()){
+            request.withHeader(s, headers.get(s));
+        }
+        return new ServeEvent(
+            null,
+            LoggedRequest.createFrom(request.build()),
             null,
             null,
             LoggedResponse.from(Response.notConfigured()),


### PR DESCRIPTION
Added the ability to capture all headers while recording by setting a parameter in the RecordSpec class. Useful when you want to simply see what calls are coming in or for very specific request matching