### PR TITLE
Don't try to parse non XML value in XPath matcher

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
@@ -42,7 +42,7 @@ public class MatchesJsonPathPattern extends PathPattern {
         return expectedValue;
     }
 
-    protected MatchResult isSimpleJsonPathMatch(String value) {
+    protected MatchResult isSimpleMatch(String value) {
         try {
             Object obj = JsonPath.read(value, expectedValue);
 
@@ -76,7 +76,7 @@ public class MatchesJsonPathPattern extends PathPattern {
 
     }
 
-    protected MatchResult isAdvancedJsonPathMatch(String value) {
+    protected MatchResult isAdvancedMatch(String value) {
         Object obj = null;
         try {
             obj = JsonPath.read(value, expectedValue);

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/PathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/PathPattern.java
@@ -38,12 +38,12 @@ public abstract class PathPattern extends StringValuePattern {
     @Override
     public MatchResult match(String value) {
         if (isSimple()) {
-            return isSimpleJsonPathMatch(value);
+            return isSimpleMatch(value);
         }
 
-        return isAdvancedJsonPathMatch(value);
+        return isAdvancedMatch(value);
     }
 
-    protected abstract MatchResult isSimpleJsonPathMatch(String value);
-    protected abstract MatchResult isAdvancedJsonPathMatch(String value);
+    protected abstract MatchResult isSimpleMatch(String value);
+    protected abstract MatchResult isAdvancedMatch(String value);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -78,10 +78,14 @@ public class RequestPattern implements NamedValueMatcher<Request> {
         this.matcher = new RequestMatcher() {
             @Override
             public MatchResult match(Request request) {
-                List<WeightedMatchResult> matchResults = new ArrayList<>(asList(
-                        weight(RequestPattern.this.url.match(request.getUrl()), 10.0),
-                        weight(RequestPattern.this.method.match(request.getMethod()), 3.0),
+                if (!RequestPattern.this.method.match(request.getMethod()).isExactMatch()) {
+                    return MatchResult.noMatch();
+                }
+                if (!RequestPattern.this.url.match(request.getUrl()).isExactMatch()) {
+                    return MatchResult.noMatch();
+                }
 
+                List<WeightedMatchResult> matchResults = new ArrayList<>(asList(
                         weight(allHeadersMatchResult(request)),
                         weight(allQueryParamsMatch(request)),
                         weight(allCookiesMatch(request)),

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -78,14 +78,10 @@ public class RequestPattern implements NamedValueMatcher<Request> {
         this.matcher = new RequestMatcher() {
             @Override
             public MatchResult match(Request request) {
-                if (!RequestPattern.this.method.match(request.getMethod()).isExactMatch()) {
-                    return MatchResult.noMatch();
-                }
-                if (!RequestPattern.this.url.match(request.getUrl()).isExactMatch()) {
-                    return MatchResult.noMatch();
-                }
-
                 List<WeightedMatchResult> matchResults = new ArrayList<>(asList(
+                        weight(RequestPattern.this.url.match(request.getUrl()), 10.0),
+                        weight(RequestPattern.this.method.match(request.getMethod()), 3.0),
+
                         weight(allHeadersMatchResult(request)),
                         weight(allQueryParamsMatch(request)),
                         weight(allCookiesMatch(request)),

--- a/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/RequestPattern.java
@@ -78,17 +78,14 @@ public class RequestPattern implements NamedValueMatcher<Request> {
         this.matcher = new RequestMatcher() {
             @Override
             public MatchResult match(Request request) {
-                MatchResult methodMatchResult = RequestPattern.this.method.match(request.getMethod());
-                MatchResult urlMatchResult = RequestPattern.this.url.match(request.getUrl());
-                if (!methodMatchResult.isExactMatch() || !urlMatchResult.isExactMatch()) {
-                    return MatchResult.aggregateWeighted(new ArrayList<>(asList(
-                            weight(urlMatchResult, 10.0),
-                            weight(methodMatchResult, 3.0)
-                    )));
+                if (!RequestPattern.this.method.match(request.getMethod()).isExactMatch()) {
+                    return MatchResult.noMatch();
                 }
+                if (!RequestPattern.this.url.match(request.getUrl()).isExactMatch()) {
+                    return MatchResult.noMatch();
+                }
+
                 List<WeightedMatchResult> matchResults = new ArrayList<>(asList(
-                        weight(urlMatchResult, 10.0),
-                        weight(methodMatchResult, 3.0),
                         weight(allHeadersMatchResult(request)),
                         weight(allQueryParamsMatch(request)),
                         weight(allCookiesMatch(request)),


### PR DESCRIPTION
We try to use Wiremock for performance tests, but there is a bottleneck.
We have a mix of XML and Json stubs, and Wiremock try to parse json request in XML (see issue #776 and #652).
Or parsing data in XML is a heavy operation (CPU intensive, generate exception, ...), so don't try to parse non XML value in XPath matcher

**With this simple test case:**
```java
@Test
public void perfXmlTest() {
	perfRunXPath("matchingXPath on XML datas", "<perf-test>perf-data</perf-test>");
	perfRunXPath("matchingXPath on JSON datas", "{\"perf-test\": \"perf-data\"}");
}
private void perfRunXPath(String message, String value) {
	long ts = System.currentTimeMillis();
	for (int i = 0; i < 100000; i++) {
		WireMock.matchingXPath("//perf-test").match(value);
	}
	System.out.println(message + ":\t" + (System.currentTimeMillis() - ts) + "ms");
}
```
**Without my merge request:**
matchingXPath on XML datas:	19137ms
matchingXPath on JSON datas:	10376ms

**With my merge request:**
matchingXPath on XML datas:	19278ms
matchingXPath on JSON datas:	197ms
