### PR TITLE
Fix CPU Utilization Issues

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
@@ -35,7 +35,7 @@ public class CaseInsensitiveKey {
 
         CaseInsensitiveKey that = (CaseInsensitiveKey) o;
 
-        if (key != null ? !key.toLowerCase().equals(that.key.toLowerCase()) : that.key != null) return false;
+        if (key != null ? !key.equalsIgnoreCase(that.key) : that.key != null) return false;
 
         return true;
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/CaseInsensitiveKey.java
@@ -20,6 +20,10 @@ import com.google.common.base.Function;
 public class CaseInsensitiveKey {
 
     private final String key;
+
+    /** Cache the hash code for the key */
+    private int hash; // Default to 0
+
     public CaseInsensitiveKey(String key) {
         this.key = key;
     }
@@ -42,7 +46,15 @@ public class CaseInsensitiveKey {
 
     @Override
     public int hashCode() {
-        return key != null ? key.toLowerCase().hashCode() : 0;
+        int h = hash;
+        if (h == 0 && key.length() > 0) {
+            for (int i = 0; i < key.length(); i++) {
+                char c = Character.toLowerCase(key.charAt(i));
+                h = 31 * h + c;
+            }
+            hash = h;
+        }
+        return h;
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeader.java
@@ -71,7 +71,7 @@ public class HttpHeader extends MultiValue {
 
         HttpHeader that = (HttpHeader) o;
 
-        if (key != null ? !key.toLowerCase().equals(that.key.toLowerCase()) : that.key != null) return false;
+        if (key != null ? !key.equalsIgnoreCase(that.key) : that.key != null) return false;
         if (values != null ? !values.equals(that.values) : that.values != null) return false;
 
         return true;

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyUtils.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyUtils.java
@@ -15,20 +15,50 @@
  */
 package com.github.tomakehurst.wiremock.jetty9;
 
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+
+import java.lang.reflect.Method;
+import java.net.Socket;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
 import org.eclipse.jetty.io.ssl.SslConnection;
 import org.eclipse.jetty.server.HttpChannel;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
-import java.net.Socket;
-import java.net.URI;
-
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
-
 public class JettyUtils {
+
+    private static final Map<Class<?>, Method> URI_METHOD_BY_CLASS_CACHE = new HashMap<>();
+    private static final boolean IS_JETTY;
+    static {
+        // do the check only once per classloader / execution
+        IS_JETTY = isClassExist("org.eclipse.jetty.server.Request");
+    }
+
+    private JettyUtils() {
+        // Hide public constructor
+    }
+
+    public static boolean isJetty() {
+        return IS_JETTY;
+    }
+
+    private static boolean isClassExist(String type) {
+        try {
+            ClassLoader contextCL = Thread.currentThread().getContextClassLoader();
+            ClassLoader loader = contextCL == null ? JettyUtils.class.getClassLoader() : contextCL;
+            Class.forName(type, false, loader);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 
     public static Response unwrapResponse(HttpServletResponse httpServletResponse) {
         if (httpServletResponse instanceof HttpServletResponseWrapper) {
@@ -40,7 +70,7 @@ public class JettyUtils {
     }
 
     public static Socket getTlsSocket(Response response) {
-        HttpChannel httpChannel = response.getHttpOutput().getHttpChannel();
+        HttpChannel<?> httpChannel = response.getHttpOutput().getHttpChannel();
         SslConnection.DecryptedEndPoint sslEndpoint = (SslConnection.DecryptedEndPoint) httpChannel.getEndPoint();
         Object endpoint = sslEndpoint.getSslConnection().getEndPoint();
         try {
@@ -52,14 +82,24 @@ public class JettyUtils {
 
     public static URI getUri(Request request) {
         try {
-            return toUri(request.getClass().getDeclaredMethod("getUri").invoke(request));
-        } catch (Exception ignored) {
-            try {
-                return toUri(request.getClass().getDeclaredMethod("getHttpURI").invoke(request));
-            } catch (Exception ignored2) {
-                throw new IllegalArgumentException(request + " does not have a getUri or getHttpURI method");
-            }
+            return toUri(getURIMethodFromClass(request.getClass()).invoke(request));
+        } catch (Exception e) {
+            throw new IllegalArgumentException(request + " does not have a getUri or getHttpURI method");
         }
+    }
+    
+    private static Method getURIMethodFromClass(Class<?> requestClass) throws NoSuchMethodException {
+        if(URI_METHOD_BY_CLASS_CACHE.containsKey(requestClass)){
+            return URI_METHOD_BY_CLASS_CACHE.get(requestClass);
+        }
+        Method method;
+        try {
+            method = requestClass.getDeclaredMethod("getUri");
+        } catch (NoSuchMethodException ignored) {
+            method = requestClass.getDeclaredMethod("getHttpURI");
+        }
+        URI_METHOD_BY_CLASS_CACHE.put(requestClass, method);
+        return method;
     }
 
     private static URI toUri(Object httpURI) {

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -170,7 +170,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
     public String getHeader(String key) {
         List<String> headerNames = list(request.getHeaderNames());
         for (String currentKey : headerNames) {
-            if (currentKey.toLowerCase().equals(key.toLowerCase())) {
+            if (currentKey.equalsIgnoreCase(key)) {
                 return request.getHeader(currentKey);
             }
         }
@@ -183,7 +183,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
     public HttpHeader header(String key) {
         List<String> headerNames = list(request.getHeaderNames());
         for (String currentKey : headerNames) {
-            if (currentKey.toLowerCase().equals(key.toLowerCase())) {
+            if (currentKey.equalsIgnoreCase(key)) {
                 List<String> valueList = list(request.getHeaders(currentKey));
                 if (valueList.isEmpty()) {
                     return HttpHeader.empty(key);
@@ -219,7 +219,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
     @SuppressWarnings("unchecked")
     @Override
     public Set<String> getAllHeaderKeys() {
-        LinkedHashSet<String> headerKeys = new LinkedHashSet<String>();
+        LinkedHashSet<String> headerKeys = new LinkedHashSet<>();
         for (Enumeration<String> headerNames = request.getHeaderNames(); headerNames.hasMoreElements(); ) {
             headerKeys.add(headerNames.nextElement());
         }
@@ -253,7 +253,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
 
     @Override
     public boolean isBrowserProxyRequest() {
-        if (!isJetty()) {
+        if (!JettyUtils.isJetty()) {
             return false;
         }
         if (request instanceof org.eclipse.jetty.server.Request) {
@@ -334,22 +334,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
         Request originalRequest = (Request) request.getAttribute(ORIGINAL_REQUEST_KEY);
         return Optional.fromNullable(originalRequest);
     }
-
-    private boolean isJetty() {
-        try {
-            getClass("org.eclipse.jetty.server.Request");
-            return true;
-        } catch (Exception e) {
-        }
-        return false;
-    }
-
-    private void getClass(String type) throws ClassNotFoundException {
-        ClassLoader contextCL = Thread.currentThread().getContextClassLoader();
-        ClassLoader loader = contextCL == null ? WireMockHttpServletRequestAdapter.class.getClassLoader() : contextCL;
-        Class.forName(type, false, loader);
-    }
-
+    
     @Override
     public String toString() {
         return request.toString() + getBodyAsString();


### PR DESCRIPTION
With a performance test and this stub config:
```java
WireMockServer wireMockServer = new WireMockServer(options().port(0));
wireMockServer.start();
wireMockServer.stubFor(get(urlEqualTo("/something")).willReturn(aResponse().withStatus(200)));
```
CPU profile usage give this :
![cpu_waste](https://user-images.githubusercontent.com/5667657/51284946-9a689700-19ed-11e9-867e-ba2f03fe3359.png)

**java.lang.String.toLowerCase():** 7% of CPU time
**java.lang.Class.forName():** 11% of CPU time
**java.lang.Class.getDeclaredMethod():** 1% of CPU time

This PR fixes these problems:
- Replace [string].toLowerCase().equals([string].toLowerCase()) by [string].equalsIgnoreCase([string]), it is more efficient
- detect if we are in Jetty server only once at startup
- optimize JettyUtils.getUri() method by caching getDeclaredMethod

