### PR TITLE
For performance reason, don't try to parse XML value in MatchesJsonPathPattern

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/matching/MatchesJsonPathPattern.java
@@ -43,6 +43,13 @@ public class MatchesJsonPathPattern extends PathPattern {
     }
 
     protected MatchResult isSimpleMatch(String value) {
+        // For performance reason, don't try to parse XML value
+        if (value != null && value.trim().startsWith("<")) {
+            notifier().info(String.format(
+                    "Warning: JSON path expression '%s' failed to match document '%s' because it's not JSON document",
+                    expectedValue, value));
+            return MatchResult.noMatch();
+        }
         try {
             Object obj = JsonPath.read(value, expectedValue);
 
@@ -77,6 +84,13 @@ public class MatchesJsonPathPattern extends PathPattern {
     }
 
     protected MatchResult isAdvancedMatch(String value) {
+        // For performance reason, don't try to parse XML value
+        if (value != null && value.trim().startsWith("<")) {
+            notifier().info(String.format(
+                    "Warning: JSON path expression '%s' failed to match document '%s' because it's not JSON document",
+                    expectedValue, value));
+            return MatchResult.noMatch();
+        }
         Object obj = null;
         try {
             obj = JsonPath.read(value, expectedValue);


### PR DESCRIPTION
We have a mix of XML and JSON stubs, and Wiremock try to parse XML request body in JSON.
So, if request body starts with a '<', don't try to parse it in JSON

**With this simple test case:**
```java
@Test
public void perfJsonTest() {
	perfRunJsonPath("matchingJsonPath on XML datas", " <perf-test>perf-data</perf-test> ");
	perfRunJsonPath("matchingJsonPath on JSON datas", " {\"perf-test\": \"perf-data\"} ");
}
private void perfRunJsonPath(String message, String value) {
	long ts = System.currentTimeMillis();
	for (int i = 0; i < 100000; i++) {
		WireMock.matchingJsonPath("$.perf-test").match(value);
	}
	System.out.println(message + ":\t" + (System.currentTimeMillis() - ts) + "ms");
}
```
**Without my merge request:**
matchingJsonPath on XML datas:	1411ms
matchingJsonPath on JSON datas:	487ms

**With my merge request:**
matchingJsonPath on XML datas:	291ms
matchingJsonPath on JSON datas:	481ms
