### PR TITLE
Fix Binary File Templatization

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -118,9 +118,18 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
         } else if (responseDefinition.specifiesBodyFile()) {
             Template filePathTemplate = uncheckedCompileTemplate(responseDefinition.getBodyFileName());
             String compiledFilePath = uncheckedApplyTemplate(filePathTemplate, model);
-            TextFile file = files.getTextFileNamed(compiledFilePath);
-            Template bodyTemplate = uncheckedCompileTemplate(file.readContentsAsString());
-            applyTemplatedResponseBody(newResponseDefBuilder, model, bodyTemplate);
+
+            // do not apply handlebars templating on binary files
+            if (parameters != null && parameters.containsKey("binary") && parameters.getBoolean("binary"))
+            {
+                newResponseDefBuilder.withBodyFile(compiledFilePath);
+            }
+            else
+            {
+                TextFile file = files.getTextFileNamed(compiledFilePath);
+                Template bodyTemplate = uncheckedCompileTemplate(file.readContentsAsString());
+                applyTemplatedResponseBody(newResponseDefBuilder, model, bodyTemplate);
+            }
         }
 
         if (responseDefinition.getHeaders() != null) {


### PR DESCRIPTION
**bodyFileName** can be templatized while the contents of the binary file can be left as is.   Not only is it slow to try to compile and apply handlebars to binary files, handlebars also fails with an exception on some binary files because of badly formed templates.  By adding a transformer parameter **binary** 

`        "transformers": ["response-template"],
        "transformerParameters" : {
            "binary" : true
        } ` 

The **bodyFileName** can be transformed without transforming the binary file.


