### PR TITLE
Adds cache support for body response template.

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -46,6 +46,7 @@ public class ResponseDefinitionBuilder {
 	protected List<String> responseTransformerNames;
 	protected Map<String, Object> transformerParameters = newHashMap();
 	protected Boolean wasConfigured = true;
+	protected CacheStrategy cacheStrategy;
 
 	public static ResponseDefinitionBuilder like(ResponseDefinition responseDefinition) {
 		ResponseDefinitionBuilder builder = new ResponseDefinitionBuilder();
@@ -68,6 +69,7 @@ public class ResponseDefinitionBuilder {
 			Parameters.from(responseDefinition.getTransformerParameters()) :
 			Parameters.empty();
 		builder.wasConfigured = responseDefinition.isFromConfiguredStub();
+		builder.cacheStrategy = responseDefinition.getCacheStrategy();
 		return builder;
 	}
 
@@ -148,6 +150,11 @@ public class ResponseDefinitionBuilder {
 	public ResponseDefinitionBuilder withTransformer(String transformerName, String parameterKey, Object parameterValue) {
 		withTransformers(transformerName);
 		withTransformerParameter(parameterKey, parameterValue);
+		return this;
+	}
+
+	public ResponseDefinitionBuilder withCacheStrategy(CacheStrategy cacheStrategy) {
+		this.cacheStrategy = cacheStrategy;
 		return this;
 	}
 
@@ -256,7 +263,8 @@ public class ResponseDefinitionBuilder {
 						fault,
 						responseTransformerNames,
 						transformerParameters,
-                        wasConfigured) :
+                        wasConfigured,
+                        cacheStrategy) :
 				new ResponseDefinition(
 						status,
 						statusMessage,
@@ -273,7 +281,8 @@ public class ResponseDefinitionBuilder {
 						fault,
 						responseTransformerNames,
 						transformerParameters,
-					    wasConfigured
+					    wasConfigured,
+					    cacheStrategy
 				);
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseDefinitionTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/ResponseDefinitionTransformer.java
@@ -18,6 +18,7 @@ package com.github.tomakehurst.wiremock.extension;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
 public abstract class ResponseDefinitionTransformer extends AbstractTransformer<ResponseDefinition> {
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/StubMappingContext.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/StubMappingContext.java
@@ -1,0 +1,16 @@
+package com.github.tomakehurst.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.common.FileSource;
+
+public class StubMappingContext {
+    private FileSource files;
+
+    public FileSource getFiles() {
+        return files;
+    }
+
+    public StubMappingContext setFiles(FileSource files) {
+        this.files = files;
+        return this;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/StubMappingListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/StubMappingListener.java
@@ -1,0 +1,11 @@
+package com.github.tomakehurst.wiremock.extension;
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+
+public interface StubMappingListener {
+
+    void onStubMappingReset(StubMappingContext context);
+    void onStubMappingAdded(StubMappingContext context, StubMapping added);
+    void onStubMappingRemoved(StubMappingContext context, StubMapping removed);
+    void onStubMappingUpdated(StubMappingContext context, StubMapping before, StubMapping after);
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/DefinitionBasedTemplateCache.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/DefinitionBasedTemplateCache.java
@@ -1,0 +1,144 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.github.jknack.handlebars.Parser;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.cache.HighConcurrencyTemplateCache;
+import com.github.jknack.handlebars.cache.TemplateCache;
+import com.github.jknack.handlebars.io.StringTemplateSource;
+import com.github.jknack.handlebars.io.TemplateSource;
+import com.github.tomakehurst.wiremock.http.CacheStrategy;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+
+public class DefinitionBasedTemplateCache implements TemplateCache {
+
+    static class CacheEntry {
+        private DefinitionBasedTemplateSource source;
+        private long lastModified;
+        private Template template;
+        private Set<UUID> mappings = new HashSet<>();
+
+        CacheEntry(DefinitionBasedTemplateSource source, CacheEntry existing) {
+            this.source = source;
+            this.lastModified = source.lastModified();
+            if (existing != null) {
+                this.mappings = new HashSet<>(existing.mappings);
+            }
+        }
+
+        public DefinitionBasedTemplateSource getSource() {
+            return source;
+        }
+        public Template getTemplate() {
+            return template;
+        }
+        public boolean hasMappings() {
+            return !mappings.isEmpty();
+        }
+
+        public CacheEntry setTemplate(Template template) {
+            this.template = template;
+            return this;
+        }
+        public boolean addMapping(UUID id) {
+            return this.mappings.add(id);
+        }
+        public boolean removeMapping(UUID id) {
+            return this.mappings.remove(id);
+        }
+
+        public boolean isOutdated() {
+            return lastModified < source.lastModified();
+        }
+    }
+    
+    private HashMap<UUID                         , Set<DefinitionBasedTemplateSource>> mappings = new HashMap<>();
+    private HashMap<DefinitionBasedTemplateSource, CacheEntry                        > entries  = new HashMap<>();
+    private boolean reload = false;
+
+    public Map<DefinitionBasedTemplateSource, Template> getCachedTemplates() {
+        synchronized (mappings) {
+            Map<DefinitionBasedTemplateSource, Template> templates = new HashMap<>(entries.size());
+            for (CacheEntry entry : entries.values()) {
+                templates.put(entry.getSource(), entry.getTemplate());
+            }
+            return templates;
+        }
+    }
+
+    @Override
+    public void clear() {
+        synchronized (mappings) {
+            mappings.clear();
+            entries.clear();
+        }
+    }
+
+    @Override
+    public void evict(TemplateSource ref) {
+        if (ref instanceof MappingBasedTemplateSource) {
+            UUID id = ((MappingBasedTemplateSource)ref).getId();
+            synchronized (mappings) {
+                Set<DefinitionBasedTemplateSource> sources = mappings.remove(id);
+                if (sources != null) {
+                    for (DefinitionBasedTemplateSource source : sources) {
+                        CacheEntry entry = entries.get(source);
+                        entry.removeMapping(id);
+                        if (!entry.hasMappings()) {
+                            entries.remove(source);
+                        }
+                    }
+                }
+            }
+            return;
+        }
+    }
+
+    @Override
+    public Template get(TemplateSource raw, Parser parser) throws IOException {
+        if (raw instanceof DefinitionBasedTemplateSource && ((DefinitionBasedTemplateSource)raw).isCacheable()) {
+            DefinitionBasedTemplateSource source = ((DefinitionBasedTemplateSource)raw);
+            UUID id = source.getStubMappingId();
+            CacheEntry entry;
+            synchronized (mappings) {
+                Set<DefinitionBasedTemplateSource> sources = mappings.get(id);
+                if (sources == null) {
+                    sources = new HashSet<>();
+                    mappings.put(id, sources);
+                }
+                sources.add(source);
+                entry = entries.get(source);
+                if (entry == null || entry.isOutdated()) {
+                    entry = new CacheEntry(source, entry);
+                    entries.put(source, entry);
+                }
+                entry.addMapping(id);
+            }
+            synchronized (entry) {
+                if (entry.getTemplate() == null) {
+                    entry.setTemplate(parser.parse(source));
+                }
+            }
+            return entry.getTemplate();
+        }
+        return parser.parse(raw);
+    }
+
+    @Override
+    public DefinitionBasedTemplateCache setReload(boolean reload) {
+        this.reload = reload;
+        return this;
+    }
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/DefinitionBasedTemplateSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/DefinitionBasedTemplateSource.java
@@ -1,0 +1,126 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.UUID;
+
+import com.github.jknack.handlebars.io.ReloadableTemplateSource;
+import com.github.jknack.handlebars.io.StringTemplateSource;
+import com.github.jknack.handlebars.io.TemplateSource;
+import com.github.jknack.handlebars.io.URLTemplateSource;
+import com.github.tomakehurst.wiremock.common.Exceptions;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.TextFile;
+import com.github.tomakehurst.wiremock.http.CacheStrategy;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static java.lang.String.format;
+
+public abstract class DefinitionBasedTemplateSource implements TemplateSource {
+
+    private UUID stubMappingId;
+    private CacheStrategy cacheStrategy;
+    private String filename;
+    private String id;
+
+    public static class BodyFile extends DefinitionBasedTemplateSource {
+
+        public BodyFile(UUID stubMappingId, CacheStrategy cacheStrategy, String path) {
+            super(stubMappingId, cacheStrategy, path, path);
+        }
+
+
+        @Override
+        public String content(Charset charset) throws IOException {
+            return new String(Files.readAllBytes(Paths.get(getId())), charset);
+        }
+
+        @Override
+        public long lastModified() {
+            try {
+                return Files.getLastModifiedTime(Paths.get(getId())).toMillis();
+            } catch (IOException e) {
+                throwUnchecked(e);
+                return 0;
+            }
+        }
+    }
+
+    public static class BodyContent extends DefinitionBasedTemplateSource {
+        public BodyContent(UUID stubMappingId, CacheStrategy cacheStrategy, String content) {
+            super(stubMappingId, cacheStrategy, content, format("inline@%h", content));
+        }
+
+        @Override
+        public String content(Charset charset) {
+            return getId();
+        }
+
+        @Override
+        public long lastModified() {
+            return 0;
+        }
+    }
+
+    public static DefinitionBasedTemplateSource fromString(UUID stubMappingId, String content, CacheStrategy cacheStrategy) {
+        return new BodyContent(stubMappingId, cacheStrategy, content);
+    }
+
+    public static DefinitionBasedTemplateSource fromTextFile(UUID stubMappingId, TextFile textfile, CacheStrategy cacheStrategy) {
+        return new BodyFile(stubMappingId, cacheStrategy, textfile.getPath());
+    }
+
+    private DefinitionBasedTemplateSource(UUID stubMappingId, CacheStrategy cacheStrategy, String id, String filename) {
+        this.stubMappingId = stubMappingId;
+        this.cacheStrategy = cacheStrategy;
+        this.id            = id;
+        this.filename      = filename;
+    }
+
+    @Override
+    public String filename() {
+        return filename;
+    }
+
+    public UUID getStubMappingId() {
+        return stubMappingId;
+    }
+
+    public CacheStrategy getCacheStrategy() {
+        return this.cacheStrategy;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public boolean isCacheable() {
+        return !CacheStrategy.isNever(getCacheStrategy());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || !this.getClass().isAssignableFrom(obj.getClass())) return false;
+
+        DefinitionBasedTemplateSource that = (DefinitionBasedTemplateSource) obj;
+        return Objects.equals(this.id, that.id);
+    }
+
+    @Override
+    public String toString() {
+        return format("%s(%s)", getClass().getSimpleName(), getId());
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/MappingBasedTemplateSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/MappingBasedTemplateSource.java
@@ -1,0 +1,40 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import com.github.jknack.handlebars.io.TemplateSource;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.UUID;
+
+public class MappingBasedTemplateSource implements TemplateSource {
+
+    public static MappingBasedTemplateSource fromMapping(StubMapping mapping) {
+        return new MappingBasedTemplateSource(mapping.getId());
+    }
+
+    private UUID id;
+
+    public MappingBasedTemplateSource(UUID id) {
+        this.id = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public String content(Charset charset) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String filename() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long lastModified() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/CacheStrategy.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/CacheStrategy.java
@@ -1,0 +1,13 @@
+package com.github.tomakehurst.wiremock.http;
+
+public enum CacheStrategy {
+    Never, OnCall, Always;
+
+    public static boolean isNever(CacheStrategy cacheStrategy) {
+        return cacheStrategy == null || cacheStrategy == CacheStrategy.Never;
+    }
+
+    public static boolean isAlways(CacheStrategy cacheStrategy) {
+        return cacheStrategy == Always;
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappings.java
@@ -15,10 +15,26 @@
  */
 package com.github.tomakehurst.wiremock.stubbing;
 
+import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
+import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
+import static com.github.tomakehurst.wiremock.http.ResponseDefinition.copyOf;
+import static com.google.common.collect.FluentIterable.from;
+import static com.google.common.collect.Iterables.find;
+import static com.google.common.collect.Iterables.tryFind;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.extension.StubMappingContext;
+import com.github.tomakehurst.wiremock.extension.StubMappingListener;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
@@ -26,22 +42,11 @@ import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
-
-import java.util.*;
-
-import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
-import static com.github.tomakehurst.wiremock.core.WireMockApp.FILES_ROOT;
-import static com.github.tomakehurst.wiremock.http.ResponseDefinition.copyOf;
-import static com.google.common.collect.FluentIterable.from;
-import static com.google.common.collect.Iterables.filter;
-import static com.google.common.collect.Iterables.find;
-import static com.google.common.collect.Iterables.tryFind;
 
 
 public class InMemoryStubMappings implements StubMappings {
-	
+
 	private final SortedConcurrentMappingSet mappings = new SortedConcurrentMappingSet();
 	private final Scenarios scenarios = new Scenarios();
 	private final Map<String, RequestMatcherExtension> customMatchers;
@@ -66,12 +71,10 @@ public class InMemoryStubMappings implements StubMappings {
 				mappings,
 				mappingMatchingAndInCorrectScenarioState(request),
 				StubMapping.NOT_CONFIGURED);
-		
+
 		scenarios.onStubServed(matchingMapping);
 
-        ResponseDefinition responseDefinition = applyTransformations(request,
-            matchingMapping.getResponse(),
-            ImmutableList.copyOf(transformers.values()));
+        ResponseDefinition responseDefinition = applyTransformations(request, matchingMapping, transformers.values());
 
 		return ServeEvent.of(
             LoggedRequest.createFrom(request),
@@ -81,31 +84,67 @@ public class InMemoryStubMappings implements StubMappings {
 	}
 
     private ResponseDefinition applyTransformations(Request request,
-                                                    ResponseDefinition responseDefinition,
-                                                    List<ResponseDefinitionTransformer> transformers) {
-        if (transformers.isEmpty()) {
-            return responseDefinition;
+                                                    StubMapping mapping,
+                                                    Collection<ResponseDefinitionTransformer> transformers) {
+
+		ResponseDefinition response = mapping.getResponse();
+        for (ResponseDefinitionTransformer transformer : transformers) {
+	        if (transformer.applyGlobally() || response.hasTransformer(transformer)) {
+	        	response.setStubMappingId(mapping.getId());
+		        response = transformer.transform(request, response, getFilesRoot(), response.getTransformerParameters());
+		        response.setStubMappingId(null);
+	        }
         }
 
-        ResponseDefinitionTransformer transformer = transformers.get(0);
-        ResponseDefinition newResponseDef =
-            transformer.applyGlobally() || responseDefinition.hasTransformer(transformer) ?
-                transformer.transform(request, responseDefinition, rootFileSource.child(FILES_ROOT), responseDefinition.getTransformerParameters()) :
-                responseDefinition;
+        return response;
+    }
 
-        return applyTransformations(request, newResponseDef, transformers.subList(1, transformers.size()));
+    private FileSource getFilesRoot() {
+        return rootFileSource.child(FILES_ROOT);
+    }
+
+    protected List<StubMappingListener> getStubMappingListeners(StubMapping... mappings) {
+		List<StubMappingListener> listeners = new ArrayList<>();
+		for (ResponseDefinitionTransformer tx : transformers.values()) {
+			if (!(tx instanceof StubMappingListener)) continue;
+
+			if (mappings.length == 0 || tx.applyGlobally()) {
+				listeners.add((StubMappingListener) tx);
+				continue;
+			}
+
+			for (StubMapping mapping : mappings) {
+				if (mapping.getResponse().hasTransformer(tx)) {
+					listeners.add((StubMappingListener) tx);
+					break;
+				}
+			}
+		}
+		return listeners;
     }
 
 	@Override
 	public void addMapping(StubMapping mapping) {
 		mappings.add(mapping);
 		scenarios.onStubMappingAdded(mapping);
+		StubMappingContext stubMappingContext = new StubMappingContext().setFiles(getFilesRoot());
+		mapping.getResponse().setStubMappingId(mapping.getId());
+		for (StubMappingListener listener : getStubMappingListeners(mapping)) {
+		    listener.onStubMappingAdded(stubMappingContext, mapping);
+		}
+		mapping.getResponse().setStubMappingId(null);
 	}
 
 	@Override
 	public void removeMapping(StubMapping mapping) {
 		mappings.remove(mapping);
 		scenarios.onStubMappingRemoved(mapping);
+		StubMappingContext stubMappingContext = new StubMappingContext().setFiles(getFilesRoot());
+		mapping.getResponse().setStubMappingId(mapping.getId());
+		for (StubMappingListener listener : getStubMappingListeners(mapping)) {
+			listener.onStubMappingRemoved(stubMappingContext, mapping);
+		}
+		mapping.getResponse().setStubMappingId(null);
 	}
 
 	@Override
@@ -128,6 +167,14 @@ public class InMemoryStubMappings implements StubMappings {
 
 		mappings.replace(existingMapping, stubMapping);
 		scenarios.onStubMappingUpdated(existingMapping, stubMapping);
+		StubMappingContext stubMappingContext = new StubMappingContext().setFiles(getFilesRoot());
+		existingMapping.getResponse().setStubMappingId(existingMapping.getId());
+		stubMapping.getResponse().setStubMappingId(stubMapping.getId());
+		for (StubMappingListener listener : getStubMappingListeners(existingMapping, stubMapping)) {
+			listener.onStubMappingUpdated(stubMappingContext, existingMapping, stubMapping);
+		}
+		existingMapping.getResponse().setStubMappingId(null);
+		stubMapping.getResponse().setStubMappingId(null);
 	}
 
 
@@ -135,8 +182,12 @@ public class InMemoryStubMappings implements StubMappings {
 	public void reset() {
 		mappings.clear();
         scenarios.clear();
+		StubMappingContext stubMappingContext = new StubMappingContext().setFiles(getFilesRoot());
+        for (StubMappingListener listener : getStubMappingListeners()) {
+        	listener.onStubMappingReset(stubMappingContext);
+        }
 	}
-	
+
 	@Override
 	public void resetScenarios() {
 		scenarios.reset();
@@ -179,7 +230,8 @@ public class InMemoryStubMappings implements StubMappings {
 
     private Predicate<StubMapping> mappingMatchingAndInCorrectScenarioStateNew(final Request request) {
 		return new Predicate<StubMapping>() {
-			public boolean apply(StubMapping mapping) {
+			@Override
+            public boolean apply(StubMapping mapping) {
 				return mapping.getRequest().match(request, customMatchers).isExactMatch() &&
 				(mapping.isIndependentOfScenarioState() || scenarios.mappingMatchesScenarioState(mapping));
 			}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
@@ -130,7 +130,8 @@ public class StubResponseRendererTest {
                     null,
                     null,
                     null,
-                    true
+                    true,
+                    null
             )
         );
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsCacheTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsCacheTest.java
@@ -1,0 +1,546 @@
+package com.github.tomakehurst.wiremock.stubbing;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Template;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
+import com.github.tomakehurst.wiremock.core.WireMockApp;
+import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.DefinitionBasedTemplateCache;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.DefinitionBasedTemplateSource;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.http.CacheStrategy;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.responseDefinition;
+import static com.github.tomakehurst.wiremock.extension.responsetemplating.DefinitionBasedTemplateSource.fromString;
+import static com.github.tomakehurst.wiremock.extension.responsetemplating.DefinitionBasedTemplateSource.fromTextFile;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+public class InMemoryStubMappingsCacheTest {
+
+    @Rule
+    public final TemporaryFolder tempDir = new TemporaryFolder();
+    private InMemoryStubMappings mappings = null;
+    private FileSource files = null;
+    private DefinitionBasedTemplateCache cache = null;
+    private Map<DefinitionBasedTemplateSource, Template> cacheSnapshot = null;
+
+
+    @Test
+    public void addEmptyMappingDontUpdateTemplateCache() {
+        mappings.addMapping(mapping(1, null));
+        assertContent();
+    }
+
+    @Test
+    public void addNeverCachedResponseMappingDontUpdateTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        assertContent();
+    }
+
+    @Test
+    public void addOnCallCacheResponseMappingDontUpdateTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.OnCall)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAddItToTemplateCache() {
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping);
+        assertContent(mapping);
+    }
+
+    @Test
+    public void addTwoAlwaysCacheResponseMappingAddItOnceToTemplateCache() {
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping);
+        snapshot();
+        mappings.addMapping(mapping(2, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addAndRemoveAlwaysCacheResponseMappingLeftEmptyTemplateCache() {
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping);
+        mappings.removeMapping(mapping);
+        assertContent();
+    }
+
+    @Test
+    public void addAndRemoveOnCallCacheResponseMappingDontUpdateTemplateCache() {
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.OnCall));
+        mappings.addMapping(mapping);
+        mappings.removeMapping(mapping);
+        assertContent();
+    }
+
+    @Test
+    public void addTwiceAndRemoveAlwaysCacheResponseMappingLeftOneEntryInTemplateCache() {
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping);
+        snapshot();
+        mappings.addMapping(mapping(2, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.removeMapping(mapping);
+        assertUnchanged();
+    }
+
+    @Test
+    public void addAndUpdateNeverCacheResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Never));
+        mappings.addMapping(mapping);
+        assertUnchanged();
+        mappings.editMapping(mapping);
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateOnCallCacheResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        assertUnchanged();
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.OnCall)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateAlwaysCacheResponseMappingUpdateTemplateCacheOnce() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        assertUnchanged();
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.editMapping(mapping);
+        assertContent(mapping);
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateNeverCacheResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBodyFile("body-001.txt")
+                                                .withCacheStrategy(CacheStrategy.Never)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateOnCallCacheResponseMappingUpdateTemplateCacheOnce() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        snapshot();
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBodyFile("body-001.txt")
+                                                .withCacheStrategy(CacheStrategy.OnCall)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateAlwaysCacheResponseMappingUpdateTemplateCacheOnce() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        snapshot();
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBodyFile("body-001.txt")
+                                                .withCacheStrategy(CacheStrategy.Always)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateNeverCacheWithDifferentPathResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBodyFile("body-002.txt")
+                                                .withCacheStrategy(CacheStrategy.Never)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateNeverCacheWithTextContentResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody("")
+                                                .withCacheStrategy(CacheStrategy.Never)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateNeverCacheWithBinaryContentResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody(new byte[0])
+                                                .withCacheStrategy(CacheStrategy.Never)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateOnCallCacheWithDifferentPathResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBodyFile("body-002.txt")
+                                                .withCacheStrategy(CacheStrategy.OnCall)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateOnCallCacheWithTextContentResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody("")
+                                                .withCacheStrategy(CacheStrategy.OnCall)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateOnCallCacheWithBinaryContentResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody(new byte[0])
+                                                .withCacheStrategy(CacheStrategy.OnCall)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateAlwaysCacheWithDifferentPathResponseMappingUpdateTemplateCacheOnce() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-002.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.editMapping(mapping);
+        assertContent(mapping);
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateAlwaysCacheWithTextContentResponseMappingUpdateTemplateCacheOnce() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBody("")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.editMapping(mapping);
+        assertContent(mapping);
+    }
+
+    @Test
+    public void addNeverCacheResponseMappingAndUpdateAlwaysCacheWithBinaryContentResponseMappingDontUpdateTemplateCache() {
+        snapshot();
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Never)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody(new byte[0])
+                                                .withCacheStrategy(CacheStrategy.Always)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateNeverCacheWithDifferentPathResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBodyFile("body-002.txt")
+                                                .withCacheStrategy(CacheStrategy.Never)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateNeverCacheWithTextContentResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody("")
+                                                .withCacheStrategy(CacheStrategy.Never)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateNeverCacheWithBinaryContentResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody(new byte[0])
+                                                .withCacheStrategy(CacheStrategy.Never)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateOnCallCacheWithDifferentPathResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBodyFile("body-002.txt")
+                                                .withCacheStrategy(CacheStrategy.OnCall)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateOnCallCacheWithTextContentResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody("")
+                                                .withCacheStrategy(CacheStrategy.OnCall)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateOnCallCacheWithBinaryContentResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody(new byte[0])
+                                                .withCacheStrategy(CacheStrategy.OnCall)));
+        assertContent();
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateAlwaysCacheWithDifferentPathResponseMappingUpdateTemplateCacheTwice() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-002.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.editMapping(mapping);
+        assertContent(mapping);
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateAlwaysCacheWithTextContentResponseMappingUpdateTemplateCacheTwice() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBody("")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.editMapping(mapping);
+        assertContent(mapping);
+    }
+
+    @Test
+    public void addAlwaysCacheResponseMappingAndUpdateAlwaysCacheWithBinaryContentResponseMappingLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.editMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                .withBody(new byte[0])
+                                                .withCacheStrategy(CacheStrategy.Always)));
+        assertContent();
+    }
+
+    @Test
+    public void resetDontUpdateCache() {
+        snapshot();
+        mappings.reset();
+        assertUnchanged();
+    }
+
+    @Test
+    public void addAndResetLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.reset();
+        assertContent();
+    }
+
+    @Test
+    public void addTwiceAndResetLeftEmptyTemplateCache() {
+        mappings.addMapping(mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.addMapping(mapping(2, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        mappings.reset();
+        assertContent();
+    }
+
+    @Test
+    public void updateFileContentAfterBetweenTwoAddAlwaysCacheBodyFileStubMappingUpdateCache() throws InterruptedException {
+        Thread.sleep(1_000);
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping);
+        snapshot();
+        files.writeTextFile("body-001.txt", "update");
+        mappings.addMapping(mapping(2, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        assertTemplateChanged(mapping);
+    }
+
+    @Test
+    public void addTwiceAlwaysCacheStubMappingDontUpdateCache() {
+        StubMapping mapping = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping);
+        snapshot();
+        mappings.addMapping(mapping(2, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                               .withBodyFile("body-001.txt")
+                                               .withCacheStrategy(CacheStrategy.Always)));
+        assertUnchanged();
+    }
+
+    @Test
+    public void addContentMatchingExistingCachedFileAddNewCacheEntry() {
+        StubMapping mapping01 = mapping(1, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBodyFile("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping01);
+        StubMapping mapping02 = mapping(2, responseDefinition().withTransformers(ResponseTemplateTransformer.NAME)
+                                                 .withBody("body-001.txt")
+                                                 .withCacheStrategy(CacheStrategy.Always));
+        mappings.addMapping(mapping02);
+        assertContent(mapping01, mapping02);
+
+        Map<DefinitionBasedTemplateSource, Template> templates = cache.getCachedTemplates();
+        Template template01 = templates.get(mappingToSource(mapping01));
+        Template template02 = templates.get(mappingToSource(mapping02));
+        assertThat(template01, allOf(notNullValue(), not(sameInstance(template02))));
+    }
+
+    @Before
+    public void init() {
+        Handlebars handlebars = new Handlebars();
+        ResponseDefinitionTransformer transformer = new ResponseTemplateTransformer(false, handlebars, Collections.<String, Helper>emptyMap());
+        Map<String, ResponseDefinitionTransformer> transformers = ImmutableMap.of(ResponseTemplateTransformer.NAME, transformer);
+        FileSource workingDirectory = new SingleRootFileSource(tempDir.getRoot());
+        mappings = new InMemoryStubMappings(Collections.<String, RequestMatcherExtension>emptyMap(), transformers, workingDirectory);
+        cache = (DefinitionBasedTemplateCache) handlebars.getCache();
+        files = workingDirectory.child(WireMockApp.FILES_ROOT);
+        files.createIfNecessary();
+        files.writeTextFile("body-001.txt", "");
+        files.writeTextFile("body-002.txt", "");
+    }
+
+    private StubMapping mapping(int id, ResponseDefinitionBuilder response) {
+        StubMapping mapping = new StubMapping();
+        mapping.setId(UUID.fromString(format("0-0-0-0-%03d", id)));
+        if (response != null) {
+            mapping.setResponse(response.build());
+        }
+        return mapping;
+    }
+
+    private void assertContent(StubMapping... mappings) {
+        Set<DefinitionBasedTemplateSource> sources = new HashSet<>(mappings.length);
+        for (StubMapping mapping : mappings) {
+            DefinitionBasedTemplateSource source;
+            source = mappingToSource(mapping);
+            sources.add(source);
+        }
+        assertThat("cached sources", cache.getCachedTemplates().keySet(), equalTo(sources));
+    }
+
+    private DefinitionBasedTemplateSource mappingToSource(StubMapping mapping) {
+        DefinitionBasedTemplateSource source;
+        UUID id = mapping.getId();
+        ResponseDefinition res = mapping.getResponse();
+        if (res.specifiesTextBodyContent()) {
+            source = fromString(id, res.getBody(), res.getCacheStrategy());
+        } else if (res.specifiesBodyFile()) {
+            source = fromTextFile(id, files.getTextFileNamed(res.getBodyFileName()), res.getCacheStrategy());
+        } else {
+            throw new UnsupportedOperationException();
+        }
+        return source;
+    }
+
+    private void snapshot() {
+        cacheSnapshot = cache.getCachedTemplates();
+    }
+    private void assertUnchanged() {
+        Map<DefinitionBasedTemplateSource, Template> actual = cache.getCachedTemplates();
+        assertThat("cached sources", actual.keySet(), equalTo(cacheSnapshot.keySet()));
+        for (Map.Entry<DefinitionBasedTemplateSource, Template> pair : actual.entrySet()) {
+            assertThat(format("%s template", pair.getKey()), pair.getValue(), sameInstance(cacheSnapshot.get(pair.getKey())));
+        }
+    }
+    private void assertTemplateChanged(StubMapping mapping) {
+        DefinitionBasedTemplateSource source = mappingToSource(mapping);
+        assertThat(source.toString(), cache.getCachedTemplates().get(source), allOf(notNullValue(), not(sameInstance(cacheSnapshot.get(source)))));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -52,7 +52,8 @@ public class ResponseDefinitionTest {
                 Fault.EMPTY_RESPONSE,
                 ImmutableList.of("transformer-1"),
                 Parameters.one("name", "Jeff"),
-                true
+                true,
+                null
         );
 
         ResponseDefinition copiedResponse = copyOf(response);


### PR DESCRIPTION
Only text or external file body template are cached.

When always cached, it is done synchronously (increase startup time and
REST API call).

Refresh only apply to modification done on external files.

To activate cache, adds "cache" property to mapping response object with
values:

* "Always": cache when mapping is added/replaced
* "OnCall": cache only after first call
* "Never" (default): no cache