### PR TITLE
Access to system or environment variables in Handlebars templates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ allprojects {
             exclude group: "org.hamcrest", module: "hamcrest-core"
             exclude group: "org.hamcrest", module: "hamcrest-library"
         }
+        testCompile 'com.github.stefanbirkner:system-rules:1.19.0'
         testCompile "org.skyscreamer:jsonassert:1.2.3"
         testCompile 'com.toomuchcoding.jsonassert:jsonassert:0.4.12'
         testCompile 'org.awaitility:awaitility:2.0.0'

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -183,21 +183,28 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
             	// normalizing the key names
             	for (Map.Entry<String, String> entry : System.getenv().entrySet()){
             		
-            		envVarsWithVariations.putIfAbsent(entry.getKey().toLowerCase(), entry.getValue());
-            		envVarsWithVariations.putIfAbsent(entry.getKey().toUpperCase(), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().toLowerCase(), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().toUpperCase(), entry.getValue());
 
-            		envVarsWithVariations.putIfAbsent(entry.getKey().toLowerCase().replaceAll("_", "."), entry.getValue());
-            		envVarsWithVariations.putIfAbsent(entry.getKey().toLowerCase().replaceAll("_", "-"), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().toLowerCase().replaceAll("_", "."), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().toLowerCase().replaceAll("_", "-"), entry.getValue());
             		
-            		envVarsWithVariations.putIfAbsent(entry.getKey().replaceAll("_", "."), entry.getValue());
-            		envVarsWithVariations.putIfAbsent(entry.getKey().replaceAll("_", "-"), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().replaceAll("_", "."), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().replaceAll("_", "-"), entry.getValue());
             		
-            		envVarsWithVariations.putIfAbsent(entry.getKey().toUpperCase().replace("_", "."), entry.getValue());
-            		envVarsWithVariations.putIfAbsent(entry.getKey().toUpperCase().replace("_", "-"), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().toUpperCase().replace("_", "."), entry.getValue());
+            		putIfAbsent(envVarsWithVariations, entry.getKey().toUpperCase().replace("_", "-"), entry.getValue());
         		}
             	return envVarsWithVariations;
             }
         });
+    }
+    
+    private void putIfAbsent(Map<String, String> map, String key, String value) {
+        Object valueIfExist = map.get(key);
+        if (valueIfExist == null) {
+        	map.put(key, value);
+        }
     }
 
     private Map<String, Object> getConfig() {

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -43,10 +43,10 @@ public class ResponseTemplateTransformerTest {
 
     private ResponseTemplateTransformer transformer;
     
-    private String sysKey = "system.key";
-    private String sysValue = "system-value";
-    private String envKey = "ENV_KEY";
-    private String envValue = "env-value";
+    private String sysKey = "wire_mock.rocks";
+    private String sysValue = "wiremock rocks!";
+    private String envKey = "WIRE_MOCK.rocks";
+    private String envValue = "WIREMOCK ROCKS!";
 
     @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
@@ -211,32 +211,91 @@ public class ResponseTemplateTransformerTest {
             "Body: All of the body content"
         ));
     }
-    
+
     @Test
-    public void requestSystemVariable() {
-        ResponseDefinition transformedResponseDef = transform(mockRequest()
-                .url("/things"),
+    public void requestConfigVariable() {
+        ResponseDefinition transformedResponseDef = transform(mockRequest().url("/things"),
             aResponse().withBody(
-                sysKey+"={{sys.["+sysKey+"]}}"
+                "{{config.["+envKey+"]}}\n"
+                + "{{config.["+envKey.toLowerCase()+"]}}\n"
+                + "{{config.["+envKey.toUpperCase()+"]}}\n"
+                + "{{config.["+envKey.toLowerCase().replaceAll("_", ".")+"]}}\n"
+                + "{{config.["+envKey.toLowerCase().replaceAll("_", "-")+"]}}\n"
+                + "{{config.["+envKey.replaceAll("_", ".")+"]}}\n"
+                + "{{config.["+envKey.replaceAll("_", "-")+"]}}\n"
+                + "{{config.["+envKey.toUpperCase().replaceAll("_", ".")+"]}}\n"
+                + "{{config.["+envKey.toUpperCase().replaceAll("_", "-")+"]}}\n"
             )
         );
 
         assertThat(transformedResponseDef.getBody(), is(
-            sysKey+"="+sysValue
+                envValue+"\n"
+                    + sysValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+        ));
+    }
+
+    @Test
+    public void requestSystemVariable() {
+        ResponseDefinition transformedResponseDef = transform(mockRequest().url("/things"),
+            aResponse().withBody(
+                "{{config.sys.["+sysKey+"]}}\n"
+                + "{{config.sys.["+sysKey.toLowerCase()+"]}}\n"
+                + "{{config.sys.["+sysKey.toUpperCase()+"]}}\n"
+                + "{{config.sys.["+sysKey.toLowerCase().replaceAll("_", ".")+"]}}\n"
+                + "{{config.sys.["+sysKey.toLowerCase().replaceAll("_", "-")+"]}}\n"
+                + "{{config.sys.["+sysKey.replaceAll("_", ".")+"]}}\n"
+                + "{{config.sys.["+sysKey.replaceAll("_", "-")+"]}}\n"
+                + "{{config.sys.["+sysKey.toUpperCase().replaceAll("_", ".")+"]}}\n"
+                + "{{config.sys.["+sysKey.toUpperCase().replaceAll("_", "-")+"]}}\n"
+            )
+        );
+
+        assertThat(transformedResponseDef.getBody(), is(
+        		sysValue+"\n"
+                    + sysValue+"\n"
+                    + "\n"
+                    + "\n"
+                    + "\n"
+                    + "\n"
+                    + "\n"
+                    + "\n"
+                    + "\n"
         ));
     }
 
     @Test
     public void requestEnvVariable() {
-        ResponseDefinition transformedResponseDef = transform(mockRequest()
-                .url("/things"),
+        ResponseDefinition transformedResponseDef = transform(mockRequest().url("/things"),
             aResponse().withBody(
-                envKey+"={{env."+envKey+"}}"
+                "{{config.env.["+envKey+"]}}\n"
+                + "{{config.env.["+envKey.toLowerCase()+"]}}\n"
+                + "{{config.env.["+envKey.toUpperCase()+"]}}\n"
+                + "{{config.env.["+envKey.toLowerCase().replaceAll("_", ".")+"]}}\n"
+                + "{{config.env.["+envKey.toLowerCase().replaceAll("_", "-")+"]}}\n"
+                + "{{config.env.["+envKey.replaceAll("_", ".")+"]}}\n"
+                + "{{config.env.["+envKey.replaceAll("_", "-")+"]}}\n"
+                + "{{config.env.["+envKey.toUpperCase().replaceAll("_", ".")+"]}}\n"
+                + "{{config.env.["+envKey.toUpperCase().replaceAll("_", "-")+"]}}\n"
             )
         );
 
         assertThat(transformedResponseDef.getBody(), is(
-            envKey+"="+envValue
+                envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
+                    + envValue+"\n"
         ));
     }
 


### PR DESCRIPTION
See #1000

This PR enables system or environment variables to be used in generating the response or in proxy URLs.

Usage in Handlebars templates:
```
{{config.[java.home]}} when you want the value to come from any config source
{{config.env.JAVA_HOME}} when you want to target just the environment
{{config.sys.[java.home}} when you want to target just the system props
```
`config` lookup in the system variables first, followed by environment variables.  
Any . or - in the key will be converted to a _ in `config.env`, as well as uppercased.  
For example, key=wire-mock.rocks will be converted to WIRE_MOCK_ROCKS.  
No such translation will be performed for `config.sys`.