### PR TITLE
docs: Fix testCompile -> testImplementation 

### DIFF
--- a/docs-v2/_docs/download-and-installation.md
+++ b/docs-v2/_docs/download-and-installation.md
@@ -69,25 +69,25 @@ Java 8 standalone:
 Java 7:
 
 ```groovy
-testCompile "com.github.tomakehurst:wiremock:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock:{{ site.wiremock_version }}"
 ```
 
 Java 7 standalone:
 
 ```groovy
-testCompile "com.github.tomakehurst:wiremock-standalone:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock-standalone:{{ site.wiremock_version }}"
 ```
 
 Java 8:
 
 ```groovy
-testCompile "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
 ```
 
 Java 8 standalone:
 
 ```groovy
-testCompile "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wiremock_version }}"
 ```
 
 ## Direct download

--- a/docs-v2/_docs/getting-started.md
+++ b/docs-v2/_docs/getting-started.md
@@ -26,7 +26,7 @@ To add the standard WireMock JAR as a project dependency, put the following in t
 ### Gradle
 
 ```groovy
-testCompile "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
+testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
 ```
 
 WireMock is also shipped in Java 7 and standalone versions, both of which work better in certain contexts.


### PR DESCRIPTION
Hi, I modified `testCompile` to `testImplementation`.
Because `testCompile` is deprecated.
Details: https://docs.gradle.org/4.10/userguide/java_plugin.html

Please check this pull request.
Thank you very much.