### PR TITLE
Only template datas between first '{{' and last '}}'

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
@@ -1,0 +1,103 @@
+package com.github.tomakehurst.wiremock.extension.responsetemplating;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.TagType;
+import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.TypeSafeTemplate;
+
+public class HandlebarsOptimizedTemplate implements Template {
+
+	private static final String NOT_IMPLEMENTED = "not implemented";
+
+	private final Template template;
+
+	private String startContent;
+	private String templateContent;
+	private String endContent;
+
+	public HandlebarsOptimizedTemplate(final Handlebars handlebars, final String content) throws IOException {
+		startContent = content;
+		templateContent = "";
+		endContent = "";
+
+		int firstDelimStartPosition = content.indexOf(Handlebars.DELIM_START);
+		if (firstDelimStartPosition != -1) {
+			int lastDelimEndPosition = content.lastIndexOf(Handlebars.DELIM_END);
+			if (lastDelimEndPosition != -1) {
+				startContent = content.substring(0, firstDelimStartPosition);
+				templateContent = content.substring(firstDelimStartPosition,
+					lastDelimEndPosition + Handlebars.DELIM_END.length());
+				endContent = content.substring(lastDelimEndPosition + Handlebars.DELIM_END.length(), content.length());
+			}
+		}
+		this.template = handlebars.compileInline(templateContent);
+	}
+
+	@Override
+	public void apply(Object context, Writer writer) throws IOException {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+	
+	@Override
+	public String apply(Object context) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		return sb.append(startContent).append(template.apply(context)).append(endContent).toString();
+	}
+
+	@Override
+	public void apply(Context context, Writer writer) throws IOException {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public String apply(Context context) throws IOException {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public String text() {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public String toJavaScript() {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public <T, S extends TypeSafeTemplate<T>> S as(Class<S> type) {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public <T> TypeSafeTemplate<T> as() {
+		return template.as();
+	}
+
+	@Override
+	public List<String> collect(TagType... tagType) {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public List<String> collectReferenceParameters() {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public String filename() {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+
+	@Override
+	public int[] position() {
+		throw new NotImplementedException(NOT_IMPLEMENTED);
+	}
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
@@ -1,20 +1,11 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import java.io.IOException;
-import java.io.Writer;
-import java.util.List;
 
-import org.apache.commons.lang3.NotImplementedException;
-
-import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
-import com.github.jknack.handlebars.TagType;
 import com.github.jknack.handlebars.Template;
-import com.github.jknack.handlebars.TypeSafeTemplate;
 
-public class HandlebarsOptimizedTemplate implements Template {
-
-	private static final String NOT_IMPLEMENTED = "not implemented";
+public class HandlebarsOptimizedTemplate {
 
 	private final Template template;
 
@@ -33,71 +24,15 @@ public class HandlebarsOptimizedTemplate implements Template {
 			if (lastDelimEndPosition != -1) {
 				startContent = content.substring(0, firstDelimStartPosition);
 				templateContent = content.substring(firstDelimStartPosition,
-					lastDelimEndPosition + Handlebars.DELIM_END.length());
+						lastDelimEndPosition + Handlebars.DELIM_END.length());
 				endContent = content.substring(lastDelimEndPosition + Handlebars.DELIM_END.length(), content.length());
 			}
 		}
 		this.template = handlebars.compileInline(templateContent);
 	}
 
-	@Override
-	public void apply(Object context, Writer writer) throws IOException {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-	
-	@Override
 	public String apply(Object context) throws IOException {
 		StringBuilder sb = new StringBuilder();
 		return sb.append(startContent).append(template.apply(context)).append(endContent).toString();
-	}
-
-	@Override
-	public void apply(Context context, Writer writer) throws IOException {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public String apply(Context context) throws IOException {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public String text() {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public String toJavaScript() {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public <T, S extends TypeSafeTemplate<T>> S as(Class<S> type) {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public <T> TypeSafeTemplate<T> as() {
-		return template.as();
-	}
-
-	@Override
-	public List<String> collect(TagType... tagType) {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public List<String> collectReferenceParameters() {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public String filename() {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
-	}
-
-	@Override
-	public int[] position() {
-		throw new NotImplementedException(NOT_IMPLEMENTED);
 	}
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -17,7 +17,6 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
-import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.helper.AssignHelper;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.helper.NumberHelper;
@@ -113,13 +112,13 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
                 .put("request", RequestTemplateModel.from(request)).build();
 
         if (responseDefinition.specifiesTextBodyContent()) {
-            Template bodyTemplate = uncheckedCompileTemplate(responseDefinition.getBody());
+            HandlebarsOptimizedTemplate bodyTemplate = uncheckedCompileTemplate(responseDefinition.getBody());
             applyTemplatedResponseBody(newResponseDefBuilder, model, bodyTemplate);
         } else if (responseDefinition.specifiesBodyFile()) {
-            Template filePathTemplate = uncheckedCompileTemplate(responseDefinition.getBodyFileName());
+            HandlebarsOptimizedTemplate filePathTemplate = uncheckedCompileTemplate(responseDefinition.getBodyFileName());
             String compiledFilePath = uncheckedApplyTemplate(filePathTemplate, model);
             TextFile file = files.getTextFileNamed(compiledFilePath);
-            Template bodyTemplate = uncheckedCompileTemplate(file.readContentsAsString());
+            HandlebarsOptimizedTemplate bodyTemplate = uncheckedCompileTemplate(file.readContentsAsString());
             applyTemplatedResponseBody(newResponseDefBuilder, model, bodyTemplate);
         }
 
@@ -130,7 +129,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
                     List<String> newValues = Lists.transform(input.values(), new Function<String, String>() {
                         @Override
                         public String apply(String input) {
-                            Template template = uncheckedCompileTemplate(input);
+                            HandlebarsOptimizedTemplate template = uncheckedCompileTemplate(input);
                             return uncheckedApplyTemplate(template, model);
                         }
                     });
@@ -142,7 +141,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
         }
 
         if (responseDefinition.getProxyBaseUrl() != null) {
-            Template proxyBaseUrlTemplate = uncheckedCompileTemplate(responseDefinition.getProxyBaseUrl());
+            HandlebarsOptimizedTemplate proxyBaseUrlTemplate = uncheckedCompileTemplate(responseDefinition.getProxyBaseUrl());
             String newProxyBaseUrl = uncheckedApplyTemplate(proxyBaseUrlTemplate, model);
             newResponseDefBuilder.proxiedFrom(newProxyBaseUrl);
         }
@@ -150,12 +149,12 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
         return newResponseDefBuilder.build();
     }
 
-    private void applyTemplatedResponseBody(ResponseDefinitionBuilder newResponseDefBuilder, ImmutableMap<String, Object> model, Template bodyTemplate) {
+    private void applyTemplatedResponseBody(ResponseDefinitionBuilder newResponseDefBuilder, ImmutableMap<String, Object> model, HandlebarsOptimizedTemplate bodyTemplate) {
         String newBody = uncheckedApplyTemplate(bodyTemplate, model);
         newResponseDefBuilder.withBody(newBody);
     }
 
-    private String uncheckedApplyTemplate(Template template, Object context) {
+    private String uncheckedApplyTemplate(HandlebarsOptimizedTemplate template, Object context) {
         try {
             return template.apply(context);
         } catch (IOException e) {
@@ -163,11 +162,11 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
         }
     }
 
-    private Template uncheckedCompileTemplate(String content) {
+    private HandlebarsOptimizedTemplate uncheckedCompileTemplate(String content) {
         try {
             return new HandlebarsOptimizedTemplate(handlebars, content);
         } catch (IOException e) {
-            return throwUnchecked(e, Template.class);
+            return throwUnchecked(e, HandlebarsOptimizedTemplate.class);
         }
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -165,7 +165,7 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
 
     private Template uncheckedCompileTemplate(String content) {
         try {
-            return handlebars.compileInline(content);
+            return new HandlebarsOptimizedTemplate(handlebars, content);
         } catch (IOException e) {
             return throwUnchecked(e, Template.class);
         }


### PR DESCRIPTION
See #1077 and #1082 
See also https://github.com/jknack/handlebars.java/issues/681

Response time with a text file without any {{ }}:

|  Size  | Without this PR | With this PR  |
| ------------- | ------------- | ------------- |
|  500kb  | 15 sec | 50 ms |
|  1Mb | 35 sec | 50 ms |