### PR TITLE
Custom handlebar template standalone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,6 @@ subprojects {
         relocate "org.custommonkey", "wiremock.org.custommonkey"
         relocate "com.flipkart", "wiremock.com.flipkart"
         relocate "net.sf", "wiremock.net.sf"
-        relocate "com.github.jknack", "wiremock.com.github.jknack"
         relocate "org.antlr", "wiremock.org.antlr"
 
         dependencies {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -18,10 +18,12 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Template;
+import com.github.jknack.handlebars.cache.TemplateCache;
 import com.github.jknack.handlebars.helper.AssignHelper;
 import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.helper.NumberHelper;
 import com.github.jknack.handlebars.helper.StringHelpers;
+import com.github.jknack.handlebars.io.TemplateLoader;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.TextFile;
@@ -63,6 +65,10 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer {
 
     public ResponseTemplateTransformer(boolean global, Map<String, Helper> helpers) {
         this(global, new Handlebars(), helpers);
+    }
+
+    public ResponseTemplateTransformer(boolean global, TemplateCache templateCache, Map<String, Helper> helpers) {
+        this(global, templateCache == null ? new Handlebars() : new Handlebars().with(templateCache), helpers);
     }
 
     public ResponseTemplateTransformer(boolean global, Handlebars handlebars, Map<String, Helper> helpers) {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -35,12 +35,12 @@ import com.github.tomakehurst.wiremock.security.BasicAuthenticator;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
 import com.github.tomakehurst.wiremock.verification.notmatched.NotMatchedRenderer;
 import com.github.tomakehurst.wiremock.verification.notmatched.PlainTextStubNotMatchedRenderer;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.cache.TemplateCache;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.*;
 import com.google.common.io.Resources;
-import com.github.jknack.handlebars.Helper;
-import com.github.jknack.handlebars.cache.TemplateCache;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 
@@ -52,12 +52,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.common.ProxySettings.NO_PROXY;
 import static com.github.tomakehurst.wiremock.core.WireMockApp.MAPPINGS_ROOT;
 import static com.github.tomakehurst.wiremock.extension.ExtensionLoader.valueAssignableFrom;
 import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class CommandLineOptions implements Options {
 
@@ -90,6 +90,7 @@ public class CommandLineOptions implements Options {
     private static final String CONTAINER_THREADS = "container-threads";
     private static final String GLOBAL_RESPONSE_TEMPLATING = "global-response-templating";
     private static final String LOCAL_RESPONSE_TEMPLATING = "local-response-templating";
+    private static final String RESPONSE_TEMPLATING_CACHE = "response-templating-cache";
     private static final String ADMIN_API_BASIC_AUTH = "admin-api-basic-auth";
     private static final String ADMIN_API_REQUIRE_HTTPS = "admin-api-require-https";
     private static final String ASYNCHRONOUS_RESPONSE_ENABLED = "async-response-enabled";
@@ -130,6 +131,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(JETTY_HEADER_BUFFER_SIZE, "The size of Jetty's buffer for request headers").withRequiredArg();
         optionParser.accepts(JETTY_STOP_TIMEOUT, "Timeout in milliseconds for Jetty to stop").withRequiredArg();
         optionParser.accepts(PRINT_ALL_NETWORK_TRAFFIC, "Print all raw incoming and outgoing network traffic to console");
+        optionParser.accepts(RESPONSE_TEMPLATING_CACHE, "Set TemplateCache class for Handlebars templates").withRequiredArg();
         optionParser.accepts(GLOBAL_RESPONSE_TEMPLATING, "Preprocess all responses with Handlebars templates").withOptionalArg();
         optionParser.accepts(LOCAL_RESPONSE_TEMPLATING, "Preprocess selected responses with Handlebars templates").withOptionalArg();
         optionParser.accepts(ADMIN_API_BASIC_AUTH, "Require HTTP Basic authentication for admin API calls with the supplied credentials in username:password format").withRequiredArg();
@@ -314,13 +316,19 @@ public class CommandLineOptions implements Options {
             );
         }
 
+        TemplateCache templateCache = null;
+
+        if (optionSet.has(RESPONSE_TEMPLATING_CACHE)) {
+            templateCache = getTemplateCache((String) optionSet.valueOf(RESPONSE_TEMPLATING_CACHE));
+        }
+
         if (optionSet.has(GLOBAL_RESPONSE_TEMPLATING) && ResponseDefinitionTransformer.class.isAssignableFrom(extensionType)) {
             String classNames = (String) optionSet.valueOf(GLOBAL_RESPONSE_TEMPLATING);
-            ResponseTemplateTransformer transformer =  new ResponseTemplateTransformer(true, getHelpers(classNames));
+            ResponseTemplateTransformer transformer =  new ResponseTemplateTransformer(true, templateCache, getHelpers(classNames));
             builder.put(transformer.getName(), (T) transformer);
         } else if (optionSet.has(LOCAL_RESPONSE_TEMPLATING) && ResponseDefinitionTransformer.class.isAssignableFrom(extensionType)) {
             String classNames = (String) optionSet.valueOf(LOCAL_RESPONSE_TEMPLATING);
-            ResponseTemplateTransformer transformer =  new ResponseTemplateTransformer(false, getHelpers(classNames));
+            ResponseTemplateTransformer transformer =  new ResponseTemplateTransformer(false, templateCache, getHelpers(classNames));
             builder.put(transformer.getName(), (T) transformer);
         }
 
@@ -509,6 +517,20 @@ public class CommandLineOptions implements Options {
 
     private int getAsynchronousResponseThreads() {
         return Integer.valueOf((String) optionSet.valueOf(ASYNCHRONOUS_RESPONSE_THREADS));
+    }
+
+    private TemplateCache getTemplateCache(String className){
+        if (isNotEmpty(className)) {
+            try {
+                Class<?> cacheClass = Thread.currentThread().getContextClassLoader().loadClass(className.trim());
+                if (TemplateCache.class.isAssignableFrom(cacheClass)){
+                    return (TemplateCache)cacheClass.newInstance();
+                }
+            } catch (Exception e) {
+                throw new AssertionError("Cannot load TemplateCache", e);
+            }
+        }
+        return null;
     }
 
     private Map<String, Helper> getHelpers(String classNames){


### PR DESCRIPTION
Add feature to supply custom handlebars helpers to standalone by extending global-response-templating and local-response-templating command line parameters to also be supplied with a comma separated list of classes which implement an enum of helpers, where the name of the enum is also the name of the function. eg

```
      public enum Helpers implements Helper<String> {
        echo {
            private EchoHelper helper = new EchoHelper("echo");
            public Object apply(String value, Options options) throws IOException {
                return helper.apply(String.valueOf(value), options);
            }
        };
 
        @Override
        public Object apply(String value, Options options) throws IOException {
            return value.toString();
        }
    }

    public static class EchoHelper extends HandlebarsHelper<Object> {
        private final String name;
        public EchoHelper(String name){
            this.name = name;
        }

        @Override
        public Object apply(Object value, Options options) throws IOException {
            return value.toString().toUpperCase();
        }
    }
```
Also add a command line parameter to allow the setting of the handlebars TemplateCache.