### PR TITLE
WIP: Record stub information from JEE annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ allprojects {
     group = 'com.github.tomakehurst'
     version = '2.22.0'
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     repositories {
         mavenCentral()
@@ -87,6 +87,7 @@ allprojects {
         compile("com.github.jknack:handlebars-helpers:$versions.handlebars") {
             exclude group: 'org.mozilla', module: 'rhino'
         }
+        compile 'javax:javaee-api:8.0'
 
         testCompile "org.hamcrest:hamcrest-all:1.3"
         testCompile("org.jmock:jmock:2.5.1") {

--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -45,6 +45,10 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
     private Map<String, Parameters> postServeActions = newLinkedHashMap();
     private Metadata metadata;
 
+    BasicMappingBuilder(RequestPatternBuilder requestPatternBuilder) {
+        this.requestPatternBuilder = requestPatternBuilder;
+	}
+
     BasicMappingBuilder(RequestMethod method, UrlPattern urlPattern) {
         requestPatternBuilder = new RequestPatternBuilder(method, urlPattern);
 	}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/InvocationMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/InvocationMappingBuilder.java
@@ -1,0 +1,30 @@
+package com.github.tomakehurst.wiremock.client;
+
+import java.lang.reflect.Proxy;
+
+import javax.ws.rs.core.HttpHeaders;
+
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+
+class InvocationMappingBuilder<T> extends BasicMappingBuilder {
+
+	public InvocationMappingBuilder(final Class<T> resource, final ResourceInvocation<T> invocation) {
+		super(InvocationMappingBuilder.requestMatcher(resource, invocation));
+	}
+
+	private static <T> RequestPatternBuilder requestMatcher(final Class<T> resource,
+			final ResourceInvocation<T> invocation) {
+		final RecordingInvocationHandler handler = new RecordingInvocationHandler();
+
+		@SuppressWarnings("unchecked")
+		final T recordingProxy = (T) Proxy.newProxyInstance(resource.getClassLoader(), new Class[] { resource },
+				handler);
+
+		invocation.invoke(recordingProxy);
+
+		final RequestPatternBuilder pb = new RequestPatternBuilder(handler.getRequestMethod(), handler.getUrlPattern()) //
+				.withHeader(HttpHeaders.CONTENT_TYPE, handler.getRequestContentType());
+
+		return pb;
+	}
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/RecordingInvocationHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/RecordingInvocationHandler.java
@@ -1,0 +1,59 @@
+package com.github.tomakehurst.wiremock.client;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
+
+class RecordingInvocationHandler implements InvocationHandler {
+
+	private RequestMethod requestMethod;
+
+	@Override
+	public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
+		if (findAnnotation(method, GET.class).isPresent()) {
+			this.requestMethod = RequestMethod.GET;
+		} else if (findAnnotation(method, POST.class).isPresent()) {
+			this.requestMethod = RequestMethod.POST;
+		} else if (findAnnotation(method, PUT.class).isPresent()) {
+			this.requestMethod = RequestMethod.PUT;
+		} else if (findAnnotation(method, DELETE.class).isPresent()) {
+			this.requestMethod = RequestMethod.DELETE;
+		}
+		return null;
+	}
+
+	private Optional<Annotation> findAnnotation(final Method method, final Class<?> findAnnotation) {
+		final Annotation[] methodAnnotations = method.getAnnotations();
+		for (final Annotation annotation : methodAnnotations) {
+			if (annotation.annotationType() == findAnnotation) {
+				return Optional.of(annotation);
+			}
+		}
+		return Optional.empty();
+	}
+
+	public RequestMethod getRequestMethod() {
+		return requestMethod;
+	}
+
+	public UrlPattern getUrlPattern() {
+		// TODO
+		return null;
+	}
+
+	public StringValuePattern getRequestContentType() {
+		// TODO
+		return null;
+	}
+
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResourceInvocation.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResourceInvocation.java
@@ -1,0 +1,5 @@
+package com.github.tomakehurst.wiremock.client;
+
+public interface ResourceInvocation<T> {
+	public void invoke(T r);
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -794,4 +794,8 @@ public class WireMock {
     public static void importStubs(StubImport stubImport) {
         defaultInstance.get().importStubMappings(stubImport);
     }
+
+	public static <T> MappingBuilder invocation(final Class<T> resource, final ResourceInvocation<T> invocation) {
+		return new InvocationMappingBuilder<>(resource, invocation);
+	}
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/InvocationMappingBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/InvocationMappingBuilderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.client;
+
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+
+public class InvocationMappingBuilderTest {
+
+	@Test
+	public void canRecordGet() {
+		final StubMapping actual = new InvocationMappingBuilder<>(TestResouce.class, (r) -> r.getStuff()).build();
+
+		assertThat(actual.getRequest().getMethod(), equalTo(GET));
+	}
+
+	@Test
+	public void canRecordPost() {
+		final TestResourceDTO data = new TestResourceDTO("some value");
+		final StubMapping actual = new InvocationMappingBuilder<>(TestResouce.class, (r) -> r.postStuff(data)).build();
+
+		assertThat(actual.getRequest().getMethod(), equalTo(POST));
+	}
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/client/TestResouce.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/TestResouce.java
@@ -1,0 +1,22 @@
+package com.github.tomakehurst.wiremock.client;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+public interface TestResouce {
+
+	@Path("/stuff")
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public TestResourceDTO getStuff();
+
+	@Path("/stuff")
+	@POST
+	@Consumes(MediaType.APPLICATION_JSON)
+	public void postStuff(TestResourceDTO data);
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/client/TestResourceDTO.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/TestResourceDTO.java
@@ -1,0 +1,14 @@
+package com.github.tomakehurst.wiremock.client;
+
+public class TestResourceDTO {
+
+  private final String attrString;
+
+  public TestResourceDTO(final String attrString) {
+    this.attrString = attrString;
+  }
+
+  public String getAttrString() {
+    return attrString;
+  }
+}

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -16,6 +16,7 @@
 package ignored;
 
 import com.github.tomakehurst.wiremock.AcceptanceTestBase;
+import com.github.tomakehurst.wiremock.client.TestResouce;
 import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.Json;
@@ -539,4 +540,9 @@ public class Examples extends AcceptanceTestBase {
                 .willReturn(ok())
                 .build()));
     }
+
+	@Test
+	public void fromInvocation() {
+		stubFor(invocation(TestResouce.class, (r) -> r.getStuff()).willReturn(aResponse().withStatus(202)));
+	}
 }


### PR DESCRIPTION
This is a work in progress. Would be nice to have some opinions on this idea before I spend too much time on it.

The idea is to use the JEE annotations on resources. Have some of the stubbing options configured by giving the `stubFor` an actual method call.

Something like this:

```java
stubFor(invocation(TestResouce.class, (r) -> r.getStuff())
 .willReturn(aResponse().withStatus(202)));
```

I'd like to use lambda here... so **ok to drop Java 7 support now?** =)

**If Java 7 is still needed** then perhaps a pattern like this can be used:
```java
import static se.bjurr.wiremock.builder.*;

...

final MyDTO dto1 = new MyDTO("some value 1");
final MyDTO dto2 = new MyDTO("some value 2");
final List<MyDTO> listOfDtos = Arrays.asList(dto1, dto2);

doReturn(Status.ACCEPTED,listOfDtos) //
  .afterADelayOf(10, TimeUnit.SECONDS) //
  .afterInvocationOf(TestResouce.class) //
  .getListOfStuff();
```

But I cannot really fit that into the current `stubFor` pattern used here.

# TODO
 - headers
 - query parameters
 - path
 - match post content, json equal serialized input in POST/PUT methods.
 - ...