### PR TITLE
Add support for unix timestamp in seconds

### DIFF
--- a/docs-v2/_docs/response-templating.md
+++ b/docs-v2/_docs/response-templating.md
@@ -283,11 +283,13 @@ Dates can be rendered in a specific timezone (the default is UTC):
 ```
 {% endraw %}
 
-Pass `epoch` as the format to render the date as unix epoch time.
+Pass `epoch` as the format to render the date as UNIX epoch time (in milliseconds), or `unix` as the format to render
+the UNIX timestamp in seconds.
 
 {% raw %}
 ```
 {{now offset='2 years' format='epoch'}}
+{{now offset='2 years' format='unix'}}
 ```
 {% endraw %}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 public class RenderableDate {
+    private static final long DIVIDE_MILLISECONDS_TO_SECONDS = 1000L;
 
     private final Date date;
     private final String format;
@@ -41,7 +42,7 @@ public class RenderableDate {
             }
 
             if (format.equals("unix")) {
-                return String.valueOf(date.getTime() / 1000L);
+                return String.valueOf(date.getTime() / DIVIDE_MILLISECONDS_TO_SECONDS);
             }
 
             return formatCustom();

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/RenderableDate.java
@@ -36,9 +36,15 @@ public class RenderableDate {
     @Override
     public String toString() {
         if (format != null) {
-            return format.equals("epoch") ?
-                String.valueOf(date.getTime()) :
-                formatCustom();
+            if (format.equals("epoch")) {
+                return String.valueOf(date.getTime());
+            }
+
+            if (format.equals("unix")) {
+                return String.valueOf(date.getTime() / 1000L);
+            }
+
+            return formatCustom();
         }
 
         return timezoneName != null ?

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsCurrentDateHelperTest.java
@@ -101,7 +101,7 @@ public class HandlebarsCurrentDateHelperTest {
     }
 
     @Test
-    public void rendersNowAsUnixEpoch() throws Exception {
+    public void rendersNowAsUnixEpochInMilliseconds() throws Exception {
         ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of(
             "format", "epoch"
         );
@@ -110,6 +110,18 @@ public class HandlebarsCurrentDateHelperTest {
         Object output = render(date, optionsHash);
 
         assertThat(output.toString(), is(String.valueOf(date.getTime())));
+    }
+
+    @Test
+    public void rendersNowAsUnixEpochInSeconds() throws Exception {
+        ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of(
+                "format", "unix"
+        );
+
+        Date date = new Date();
+        Object output = render(date, optionsHash);
+
+        assertThat(output.toString(), is(String.valueOf(date.getTime() / 1000L)));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1110 by adding support for `{{now format='unix'}}`