### PR TITLE
Apply disableBodyFileTemplating only to body content

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformer.java
@@ -142,10 +142,12 @@ public class ResponseTemplateTransformer extends ResponseDefinitionTransformer i
         } else if (responseDefinition.specifiesBodyFile()) {
             HandlebarsOptimizedTemplate filePathTemplate = new HandlebarsOptimizedTemplate(handlebars, responseDefinition.getBodyFileName());
             String compiledFilePath = uncheckedApplyTemplate(filePathTemplate, model);
-            TextFile file = files.getTextFileNamed(compiledFilePath);
 
             boolean disableBodyFileTemplating = parameters.getBoolean("disableBodyFileTemplating", false);
-            if (!disableBodyFileTemplating) {
+            if (disableBodyFileTemplating) {
+                newResponseDefBuilder.withBodyFile(compiledFilePath);
+            } else {
+                TextFile file = files.getTextFileNamed(compiledFilePath);
                 HandlebarsOptimizedTemplate bodyTemplate = getTemplate(
                         TemplateCacheKey.forFileBody(responseDefinition, compiledFilePath), file.readContentsAsString());
                 applyTemplatedResponseBody(newResponseDefBuilder, model, bodyTemplate);

--- a/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ResponseTemplatingAcceptanceTest.java
@@ -170,6 +170,14 @@ public class ResponseTemplatingAcceptanceTest {
                             .withTransformerParameter("disableBodyFileTemplating", true)));
 
             assertThat(client.get("/templated").content(), is("{{request.path.[0]}}"));
+
+            wm.stubFor(get(urlPathMatching("/templated/.*"))
+                    .withId(id)
+                    .willReturn(aResponse()
+                            .withBodyFile("templated-example-{{request.path.1}}.txt")
+                            .withTransformerParameter("disableBodyFileTemplating", true)));
+
+            assertThat(client.get("/templated/1").content(), is("{{request.path.[0]}}"));
         }
 
     }


### PR DESCRIPTION
The `disableBodyFileTemplating` property provides a useful way to disable templating for body files on a per stub basis. However, it can cause problems with a stub such as this one:

```
{
    "request": {
        "method": "GET",
        "urlPattern": "/asset/.*"
    },
    "response": {
        "status": 200,
        "bodyFileName": "{{request.path.1}}",
        "headers": {
            "Content-Type": "image/jpeg"
        },
        "transformerParameters": {
            "disableBodyFileTemplating": true
        }
    }
}
```

In this case the body file is an image, but the file name is derived through templating. If I don't pass `"disableBodyFileTemplating": true`, WireMock crashes as it tries to apply the handlebar templating to a binary `.jpg` file. However, if I do pass `"disableBodyFileTemplating": true` it also breaks because the file name is not expanded (WireMock tries to find the file at `__files/{{request.path.1}}`).

This PR makes a small change to the templating logic so that even if body file templating is disabled, the file path is still expanded.
