### PR TITLE
#1117 json body as string in response when adding a mapping with a js…

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.*;
@@ -31,249 +32,260 @@ import static java.util.Arrays.asList;
 
 public class ResponseDefinitionBuilder {
 
-	protected int status = HTTP_OK;
-	protected String statusMessage;
-	protected byte[] binaryBody;
-	protected String stringBody;
-	protected String base64Body;
-	protected String bodyFileName;
-	protected List<HttpHeader> headers = newArrayList();
-	protected Integer fixedDelayMilliseconds;
-	protected DelayDistribution delayDistribution;
-	protected ChunkedDribbleDelay chunkedDribbleDelay;
-	protected String proxyBaseUrl;
-	protected Fault fault;
-	protected List<String> responseTransformerNames;
-	protected Map<String, Object> transformerParameters = newHashMap();
-	protected Boolean wasConfigured = true;
+    protected int status = HTTP_OK;
+    protected String statusMessage;
+    protected byte[] binaryBody;
+    protected JsonNode jsonBody;
+    protected String stringBody;
+    protected String base64Body;
+    protected String bodyFileName;
+    protected List<HttpHeader> headers = newArrayList();
+    protected Integer fixedDelayMilliseconds;
+    protected DelayDistribution delayDistribution;
+    protected ChunkedDribbleDelay chunkedDribbleDelay;
+    protected String proxyBaseUrl;
+    protected Fault fault;
+    protected List<String> responseTransformerNames;
+    protected Map<String, Object> transformerParameters = newHashMap();
+    protected Boolean wasConfigured = true;
 
-	public static ResponseDefinitionBuilder like(ResponseDefinition responseDefinition) {
-		ResponseDefinitionBuilder builder = new ResponseDefinitionBuilder();
-		builder.status = responseDefinition.getStatus();
-		builder.statusMessage = responseDefinition.getStatusMessage();
-		builder.headers = responseDefinition.getHeaders() != null ?
-				newArrayList(responseDefinition.getHeaders().all()) :
-				Lists.<HttpHeader>newArrayList();
-		builder.binaryBody = responseDefinition.getByteBodyIfBinary();
-		builder.stringBody = responseDefinition.getBody();
-		builder.base64Body = responseDefinition.getBase64Body();
-		builder.bodyFileName = responseDefinition.getBodyFileName();
-		builder.fixedDelayMilliseconds = responseDefinition.getFixedDelayMilliseconds();
-		builder.delayDistribution = responseDefinition.getDelayDistribution();
-		builder.chunkedDribbleDelay = responseDefinition.getChunkedDribbleDelay();
-		builder.proxyBaseUrl = responseDefinition.getProxyBaseUrl();
-		builder.fault = responseDefinition.getFault();
-		builder.responseTransformerNames = responseDefinition.getTransformers();
-		builder.transformerParameters = responseDefinition.getTransformerParameters() != null ?
-			Parameters.from(responseDefinition.getTransformerParameters()) :
-			Parameters.empty();
-		builder.wasConfigured = responseDefinition.isFromConfiguredStub();
-		return builder;
-	}
+    public static ResponseDefinitionBuilder like(ResponseDefinition responseDefinition) {
+        ResponseDefinitionBuilder builder = new ResponseDefinitionBuilder();
+        builder.status = responseDefinition.getStatus();
+        builder.statusMessage = responseDefinition.getStatusMessage();
+        builder.headers = responseDefinition.getHeaders() != null ? newArrayList(responseDefinition.getHeaders().all()) : Lists.<HttpHeader>newArrayList();
+        builder.binaryBody = responseDefinition.getByteBodyIfBinary();
+        builder.stringBody = responseDefinition.getBody();
+        builder.base64Body = responseDefinition.getBase64Body();
+        builder.jsonBody = responseDefinition.getJsonBody();
+        builder.bodyFileName = responseDefinition.getBodyFileName();
+        builder.fixedDelayMilliseconds = responseDefinition.getFixedDelayMilliseconds();
+        builder.delayDistribution = responseDefinition.getDelayDistribution();
+        builder.chunkedDribbleDelay = responseDefinition.getChunkedDribbleDelay();
+        builder.proxyBaseUrl = responseDefinition.getProxyBaseUrl();
+        builder.fault = responseDefinition.getFault();
+        builder.responseTransformerNames = responseDefinition.getTransformers();
+        builder.transformerParameters = responseDefinition.getTransformerParameters() != null ? Parameters.from(responseDefinition.getTransformerParameters()) : Parameters.empty();
+        builder.wasConfigured = responseDefinition.isFromConfiguredStub();
+        return builder;
+    }
 
     public static ResponseDefinition jsonResponse(Object body) {
         return jsonResponse(body, HTTP_OK);
     }
 
-	public static ResponseDefinition jsonResponse(Object body, int status) {
-		return new ResponseDefinitionBuilder()
-				.withBody(Json.write(body))
-				.withStatus(status)
-				.withHeader("Content-Type", "application/json")
-				.build();
-	}
-
-	public ResponseDefinitionBuilder but() {
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withStatus(int status) {
-		this.status = status;
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withHeader(String key, String... values) {
-		headers.add(new HttpHeader(key, values));
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withBodyFile(String fileName) {
-		this.bodyFileName = fileName;
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withBody(String body) {
-		this.stringBody = body;
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withBody(byte[] body) {
-		this.binaryBody = body;
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withFixedDelay(Integer milliseconds) {
-		this.fixedDelayMilliseconds = milliseconds;
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withRandomDelay(DelayDistribution distribution) {
-		this.delayDistribution = distribution;
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withLogNormalRandomDelay(double medianMilliseconds, double sigma) {
-		return withRandomDelay(new LogNormal(medianMilliseconds, sigma));
-	}
-
-	public ResponseDefinitionBuilder withUniformRandomDelay(int lowerMilliseconds, int upperMilliseconds) {
-		return withRandomDelay(new UniformDistribution(lowerMilliseconds, upperMilliseconds));
-	}
-
-	public ResponseDefinitionBuilder withChunkedDribbleDelay(int numberOfChunks, int totalDuration) {
-		this.chunkedDribbleDelay = new ChunkedDribbleDelay(numberOfChunks, totalDuration);
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withTransformers(String... responseTransformerNames) {
-		this.responseTransformerNames = asList(responseTransformerNames);
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withTransformerParameter(String name, Object value) {
-		transformerParameters.put(name, value);
-		return this;
-	}
-
-	public ResponseDefinitionBuilder withTransformer(String transformerName, String parameterKey, Object parameterValue) {
-		withTransformers(transformerName);
-		withTransformerParameter(parameterKey, parameterValue);
-		return this;
-	}
-
-	public ProxyResponseDefinitionBuilder proxiedFrom(String proxyBaseUrl) {
-		this.proxyBaseUrl = proxyBaseUrl;
-		return new ProxyResponseDefinitionBuilder(this);
-	}
-
-	public static ResponseDefinitionBuilder responseDefinition() {
-		return new ResponseDefinitionBuilder();
-	}
-
-	public static <T> ResponseDefinitionBuilder okForJson(T body) {
-        return responseDefinition()
-            .withStatus(HTTP_OK)
-            .withBody(Json.write(body))
-            .withHeader("Content-Type", "application/json");
+    public static ResponseDefinition jsonResponse(Object body, int status) {
+            return new ResponseDefinitionBuilder().withBody(Json.write(body)).withStatus(status).withHeader("Content-Type", "application/json").build();
     }
 
-	public static <T> ResponseDefinitionBuilder okForEmptyJson() {
-		return responseDefinition()
-			.withStatus(HTTP_OK)
-			.withBody("{}")
-			.withHeader("Content-Type", "application/json");
-	}
+    public ResponseDefinitionBuilder but() {
+        return this;
+    }
 
-	public ResponseDefinitionBuilder withHeaders(HttpHeaders headers) {
-		this.headers = ImmutableList.copyOf(headers.all());
-		return this;
-	}
+    public ResponseDefinitionBuilder withStatus(int status) {
+        this.status = status;
+        return this;
+    }
 
-	public ResponseDefinitionBuilder withBase64Body(String base64Body) {
-		this.base64Body = base64Body;
-		return this;
-	}
+    public ResponseDefinitionBuilder withHeader(String key, String... values) {
+        headers.add(new HttpHeader(key, values));
+        return this;
+    }
 
-	public ResponseDefinitionBuilder withStatusMessage(String message) {
-		this.statusMessage = message;
-		return this;
-	}
+    public ResponseDefinitionBuilder withBodyFile(String fileName) {
+        this.bodyFileName = fileName;
+        return this;
+    }
 
-	public static class ProxyResponseDefinitionBuilder extends ResponseDefinitionBuilder {
+    public ResponseDefinitionBuilder withBody(String body) {
+        this.stringBody = body;
+        return this;
+    }
 
-		private List<HttpHeader> additionalRequestHeaders = newArrayList();
+    public ResponseDefinitionBuilder withBody(byte[] body) {
+        this.binaryBody = body;
+        return this;
+    }
 
-		public ProxyResponseDefinitionBuilder(ResponseDefinitionBuilder from) {
-			this.status = from.status;
-			this.statusMessage = from.statusMessage;
-			this.headers = from.headers;
-			this.binaryBody = from.binaryBody;
-			this.stringBody = from.stringBody;
-			this.base64Body = from.base64Body;
-			this.bodyFileName = from.bodyFileName;
-			this.fault = from.fault;
-			this.fixedDelayMilliseconds = from.fixedDelayMilliseconds;
-			this.delayDistribution = from.delayDistribution;
-			this.chunkedDribbleDelay = from.chunkedDribbleDelay;
-			this.proxyBaseUrl = from.proxyBaseUrl;
-			this.responseTransformerNames = from.responseTransformerNames;
-			this.transformerParameters = from.transformerParameters;
-		}
+    public ResponseDefinitionBuilder withFixedDelay(Integer milliseconds) {
+        this.fixedDelayMilliseconds = milliseconds;
+        return this;
+    }
 
-		public ProxyResponseDefinitionBuilder withAdditionalRequestHeader(String key, String value) {
-			additionalRequestHeaders.add(new HttpHeader(key, value));
-			return this;
-		}
+    public ResponseDefinitionBuilder withRandomDelay(DelayDistribution distribution) {
+        this.delayDistribution = distribution;
+        return this;
+    }
 
-		@Override
-		public ResponseDefinition build() {
-			return !additionalRequestHeaders.isEmpty() ?
-					super.build(new HttpHeaders(additionalRequestHeaders)) :
-					super.build();
-		}
-	}
+    public ResponseDefinitionBuilder withLogNormalRandomDelay(double medianMilliseconds, double sigma) {
+        return withRandomDelay(new LogNormal(medianMilliseconds, sigma));
+    }
 
-	public ResponseDefinitionBuilder withFault(Fault fault) {
-		this.fault = fault;
-		return this;
-	}
+    public ResponseDefinitionBuilder withUniformRandomDelay(int lowerMilliseconds, int upperMilliseconds) {
+        return withRandomDelay(new UniformDistribution(lowerMilliseconds, upperMilliseconds));
+    }
 
-	public ResponseDefinition build() {
-		return build(null);
-	}
+    public ResponseDefinitionBuilder withChunkedDribbleDelay(int numberOfChunks, int totalDuration) {
+        this.chunkedDribbleDelay = new ChunkedDribbleDelay(numberOfChunks, totalDuration);
+        return this;
+    }
 
-	private boolean isBinaryBody() {
-		return binaryBody != null;
-	}
+    public ResponseDefinitionBuilder withTransformers(String... responseTransformerNames) {
+        this.responseTransformerNames = asList(responseTransformerNames);
+        return this;
+    }
 
-	protected ResponseDefinition build(HttpHeaders additionalProxyRequestHeaders) {
-		HttpHeaders httpHeaders = headers == null || headers.isEmpty() ? null : new HttpHeaders(headers);
-		Parameters transformerParameters = this.transformerParameters == null || this.transformerParameters.isEmpty() ? null : Parameters.from(this.transformerParameters);
-		return isBinaryBody() ?
-				new ResponseDefinition(
-						status,
-						statusMessage,
-						binaryBody,
-						null,
-						base64Body,
-						bodyFileName,
-						httpHeaders,
-						additionalProxyRequestHeaders,
-						fixedDelayMilliseconds,
-						delayDistribution,
-						chunkedDribbleDelay,
-						proxyBaseUrl,
-						fault,
-						responseTransformerNames,
-						transformerParameters,
-                        wasConfigured) :
-				new ResponseDefinition(
-						status,
-						statusMessage,
-						stringBody,
-						null,
-						base64Body,
-						bodyFileName,
-						httpHeaders,
-						additionalProxyRequestHeaders,
-						fixedDelayMilliseconds,
-						delayDistribution,
-						chunkedDribbleDelay,
-						proxyBaseUrl,
-						fault,
-						responseTransformerNames,
-						transformerParameters,
-					    wasConfigured
-				);
-	}
+    public ResponseDefinitionBuilder withTransformerParameter(String name, Object value) {
+        transformerParameters.put(name, value);
+        return this;
+    }
+
+    public ResponseDefinitionBuilder withTransformer(String transformerName, String parameterKey, Object parameterValue) {
+        withTransformers(transformerName);
+        withTransformerParameter(parameterKey, parameterValue);
+        return this;
+    }
+
+    public ProxyResponseDefinitionBuilder proxiedFrom(String proxyBaseUrl) {
+        this.proxyBaseUrl = proxyBaseUrl;
+        return new ProxyResponseDefinitionBuilder(this);
+    }
+
+    public static ResponseDefinitionBuilder responseDefinition() {
+        return new ResponseDefinitionBuilder();
+    }
+
+    public static <T> ResponseDefinitionBuilder okForJson(T body) {
+        return responseDefinition().withStatus(HTTP_OK).withBody(Json.write(body)).withHeader("Content-Type", "application/json");
+    }
+
+    public static <T> ResponseDefinitionBuilder okForEmptyJson() {
+        return responseDefinition().withStatus(HTTP_OK).withBody("{}").withHeader("Content-Type", "application/json");
+    }
+
+    public ResponseDefinitionBuilder withHeaders(HttpHeaders headers) {
+        this.headers = ImmutableList.copyOf(headers.all());
+        return this;
+    }
+
+    public ResponseDefinitionBuilder withBase64Body(String base64Body) {
+        this.base64Body = base64Body;
+        return this;
+    }
+
+    public ResponseDefinitionBuilder withStatusMessage(String message) {
+        this.statusMessage = message;
+        return this;
+    }
+
+    public static class ProxyResponseDefinitionBuilder extends ResponseDefinitionBuilder {
+
+        private List<HttpHeader> additionalRequestHeaders = newArrayList();
+
+        public ProxyResponseDefinitionBuilder(ResponseDefinitionBuilder from) {
+            this.status = from.status;
+            this.statusMessage = from.statusMessage;
+            this.headers = from.headers;
+            this.binaryBody = from.binaryBody;
+            this.stringBody = from.stringBody;
+            this.jsonBody = from.jsonBody;
+            this.base64Body = from.base64Body;
+            this.bodyFileName = from.bodyFileName;
+            this.fault = from.fault;
+            this.fixedDelayMilliseconds = from.fixedDelayMilliseconds;
+            this.delayDistribution = from.delayDistribution;
+            this.chunkedDribbleDelay = from.chunkedDribbleDelay;
+            this.proxyBaseUrl = from.proxyBaseUrl;
+            this.responseTransformerNames = from.responseTransformerNames;
+            this.transformerParameters = from.transformerParameters;
+        }
+
+        public ProxyResponseDefinitionBuilder withAdditionalRequestHeader(String key, String value) {
+            additionalRequestHeaders.add(new HttpHeader(key, value));
+            return this;
+        }
+
+        @Override
+        public ResponseDefinition build() {
+            return !additionalRequestHeaders.isEmpty() ? super.build(new HttpHeaders(additionalRequestHeaders)) : super.build();
+        }
+    }
+
+    public ResponseDefinitionBuilder withFault(Fault fault) {
+        this.fault = fault;
+        return this;
+    }
+
+    public ResponseDefinition build() {
+        return build(null);
+    }
+
+    private boolean isBinaryBody() {
+        return binaryBody != null;
+    }
+
+    private boolean isJsonBody() {
+        return jsonBody != null;
+    }
+
+    protected ResponseDefinition build(HttpHeaders additionalProxyRequestHeaders) {
+        HttpHeaders httpHeaders = headers == null || headers.isEmpty() ? null : new HttpHeaders(headers);
+        Parameters transformerParameters = this.transformerParameters == null || this.transformerParameters.isEmpty() ? null : Parameters.from(this.transformerParameters);
+        if (isBinaryBody()) {
+            return new ResponseDefinition(
+                    status,
+                    statusMessage,
+                    binaryBody,
+                    null,
+                    base64Body,
+                    bodyFileName,
+                    httpHeaders,
+                    additionalProxyRequestHeaders,
+                    fixedDelayMilliseconds,
+                    delayDistribution,
+                    chunkedDribbleDelay,
+                    proxyBaseUrl,
+                    fault,
+                    responseTransformerNames,
+                    transformerParameters,
+                    wasConfigured);
+        }
+        else if (isJsonBody()) {
+            return new ResponseDefinition(
+                    status,
+                    statusMessage,
+                    binaryBody,
+                    jsonBody,
+                    null,
+                    bodyFileName,
+                    httpHeaders,
+                    additionalProxyRequestHeaders,
+                    fixedDelayMilliseconds,
+                    delayDistribution,
+                    chunkedDribbleDelay,
+                    proxyBaseUrl,
+                    fault,
+                    responseTransformerNames,
+                    transformerParameters,
+                    wasConfigured);
+        } else {
+            return new ResponseDefinition(
+                    status,
+                    statusMessage,
+                    stringBody,
+                    null,
+                    base64Body,
+                    bodyFileName,
+                    httpHeaders,
+                    additionalProxyRequestHeaders,
+                    fixedDelayMilliseconds,
+                    delayDistribution,
+                    chunkedDribbleDelay,
+                    proxyBaseUrl,
+                    fault,
+                    responseTransformerNames,
+                    transformerParameters,
+                    wasConfigured);
+        }
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
@@ -32,6 +32,7 @@ public class Body {
 
     private final byte[] content;
     private final boolean binary;
+    private boolean json;
 
     public Body(byte[] content) {
         this(content, true);
@@ -50,6 +51,7 @@ public class Body {
     public Body(JsonNode content) {
         this.content = Json.toByteArray(content);
         binary = false;
+        json = true;
     }
 
     static Body fromBytes(byte[] bytes) {
@@ -93,6 +95,12 @@ public class Body {
         return binary;
     }
 
+    public JsonNode asJson() {return Json.node(asString()); }
+
+    public boolean isJson() {
+        return json;
+    }
+
     public boolean isAbsent() {
         return content == null;
     }
@@ -120,6 +128,9 @@ public class Body {
         return "Body {" +
                 "content=" + asString() +
                 ", binary=" + binary +
+                ", json=" + json+
                 '}';
     }
+
+
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Body.java
@@ -32,7 +32,7 @@ public class Body {
 
     private final byte[] content;
     private final boolean binary;
-    private boolean json;
+    private final boolean json;
 
     public Body(byte[] content) {
         this(content, true);
@@ -41,11 +41,13 @@ public class Body {
     private Body(byte[] content, boolean binary) {
         this.content = content;
         this.binary = binary;
+        json = false;
     }
 
     public Body(String content) {
         this.content = Strings.bytesFromString(content);
         binary = false;
+        json = false;
     }
 
     public Body(JsonNode content) {
@@ -131,6 +133,4 @@ public class Body {
                 ", json=" + json+
                 '}';
     }
-
-
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -236,7 +236,7 @@ public class ResponseDefinition {
     }
 
     public String getBody() {
-        return !body.isBinary() ? body.asString() : null;
+        return (!body.isBinary() && !body.isJson()) ? body.asString() : null;
     }
 
     @JsonIgnore
@@ -251,6 +251,11 @@ public class ResponseDefinition {
 
     public String getBase64Body() {
         return body.isBinary() ? body.asBase64() : null;
+    }
+
+    public JsonNode getJsonBody() {
+
+        return body.isJson() ? body.asJson(): null;
     }
 
     public String getBodyFileName() {
@@ -373,4 +378,6 @@ public class ResponseDefinition {
     public String toString() {
         return this.wasConfigured ? Json.write(this) : "(no response definition configured)";
     }
+
+
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/diff/Diff.java
@@ -224,7 +224,7 @@ public class Diff {
 
         try {
             return pattern.getClass().equals(EqualToJsonPattern.class) ?
-                Json.prettyPrint(body.asString()) :
+                Json.prettyPrint(Json.write(body.asJson())) :
                 pattern.getClass().equals(EqualToXmlPattern.class) ?
                     Xml.prettyPrint(body.asString()) :
                     pattern.getClass().equals(BinaryEqualToPattern.class) ?

--- a/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/BodyTest.java
@@ -15,7 +15,10 @@
  */
 package com.github.tomakehurst.wiremock.http;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.IntNode;
+import com.github.tomakehurst.wiremock.common.Json;
+
 import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
@@ -32,6 +35,7 @@ public class BodyTest {
 
         assertThat(body.asString(), is("this content"));
         assertThat(body.isBinary(), is(true));
+        assertThat(body.isJson(), is(false));
     }
 
     @Test
@@ -40,6 +44,7 @@ public class BodyTest {
 
         assertThat(body.asString(), is("this content"));
         assertThat(body.isBinary(), is(false));
+        assertThat(body.isJson(), is(false));
     }
 
     @Test
@@ -48,6 +53,7 @@ public class BodyTest {
 
         assertThat(body.asString(), is("1"));
         assertThat(body.isBinary(), is(false));
+        assertThat(body.isJson(), is(true));
     }
 
     @Test
@@ -58,6 +64,15 @@ public class BodyTest {
 
         assertThat(body.asString(), is("this content"));
         assertThat(body.isBinary(), is(true));
+        assertThat(body.isJson(), is(false));
     }
 
+
+    @Test
+    public void bodyAsJson() {
+        final JsonNode jsonContent = Json.node("{\"name\":\"wiremock\",\"isCool\":true}");
+        Body body = Body.fromOneOf(null, null, jsonContent, "lskdjflsjdflks");
+
+        assertThat(body.asJson(), is(jsonContent));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.tomakehurst.wiremock.stubbing;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Fault;
@@ -77,7 +78,25 @@ public class ResponseDefinitionTest {
     public void correctlyUnmarshalsFromJsonWhenBodyIsAString() {
         ResponseDefinition responseDef = Json.read(STRING_BODY, ResponseDefinition.class);
         assertThat(responseDef.getBase64Body(), is(nullValue()));
+        assertThat(responseDef.getJsonBody(), is(nullValue()));
         assertThat(responseDef.getBody(), is("String content"));
+    }
+
+    private static final String JSON_BODY =
+            "{	        								\n" +
+                    "		\"status\": 200,    				\n" +
+                    "		\"jsonBody\": {\"name\":\"wirmock\",\"isCool\":true} \n" +
+                    "}											";
+
+    @Test
+    public void correctlyUnmarshalsFromJsonWhenBodyIsJson() {
+        ResponseDefinition responseDef = Json.read(JSON_BODY, ResponseDefinition.class);
+        assertThat(responseDef.getBase64Body(), is(nullValue()));
+        assertThat(responseDef.getBody(), is(nullValue()));
+
+        JsonNode jsonNode = Json.node("{\"name\":\"wirmock\",\"isCool\":true}");
+        assertThat(responseDef.getJsonBody(), is(jsonNode));
+
     }
 
     @Test


### PR DESCRIPTION
When adding a mapping by using the rest API and if the mapping contains a jsonBody, I expect that the response also contains a jsonBody in stead of a body as a string with escaped characters. Also when I try to get the mapping (by it's ID) it also gives the body as a string with escaped characters