### PR TITLE
Add scenario index on record: differentiates per RequestPattern group

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessor.java
@@ -45,14 +45,16 @@ public class ScenarioProcessor {
             }
         });
 
+        int scenarioIndex = 0;
         for (Map.Entry<RequestPattern, Collection<StubMapping>> entry: groupsWithMoreThanOneStub.entrySet()) {
-            putStubsInScenario(ImmutableList.copyOf(entry.getValue()));
+            scenarioIndex++;
+            putStubsInScenario(scenarioIndex, ImmutableList.copyOf(entry.getValue()));
         }
     }
 
-    private void putStubsInScenario(List<StubMapping> stubMappings) {
+    private void putStubsInScenario(int scenarioIndex, List<StubMapping> stubMappings) {
         StubMapping firstScenario = stubMappings.get(0);
-        String scenarioName = "scenario-" + Urls.urlToPathParts(URI.create(firstScenario.getRequest().getUrl()));
+        String scenarioName = "scenario-" + Integer.toString(scenarioIndex) + "-" + Urls.urlToPathParts(URI.create(firstScenario.getRequest().getUrl()));
 
         int count = 1;
         for (StubMapping stub: stubMappings) {

--- a/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/RecordApiAcceptanceTest.java
@@ -324,33 +324,33 @@ public class RecordApiAcceptanceTest extends AcceptanceTestBase {
             "}                                                   ";
 
     private static final String REPEATS_AS_SCENARIOS_SNAPSHOT_RESPONSE =
-            "{                                                               \n" +
-            "    \"mappings\": [                                             \n" +
-            "        {                                                       \n" +
-            "            \"scenarioName\" : \"scenario-bar-baz\",            \n" +
-            "            \"requiredScenarioState\" : \"Started\",            \n" +
-            "            \"newScenarioState\" : \"scenario-bar-baz-2\",      \n" +
-            "            \"request\" : {                                     \n" +
-            "                \"url\" : \"/bar/baz\",                         \n" +
-            "                \"method\" : \"GET\"                            \n" +
-            "            }                                                   \n" +
-            "        },                                                      \n" +
-            "        {                                                       \n" +
-            "            \"request\" : {                                     \n" +
-            "                \"url\" : \"/foo\",                             \n" +
-            "                \"method\" : \"GET\"                            \n" +
-            "            }                                                   \n" +
-            "        },                                                      \n" +
-            "        {                                                       \n" +
-            "            \"scenarioName\" : \"scenario-bar-baz\",            \n" +
-            "            \"requiredScenarioState\" : \"scenario-bar-baz-2\", \n" +
-            "            \"request\" : {                                     \n" +
-            "                \"url\" : \"/bar/baz\",                         \n" +
-            "                \"method\" : \"GET\"                            \n" +
-            "            }                                                   \n" +
-            "        }                                                       \n" +
-            "    ]                                                           \n" +
-            "}                                                                 ";
+            "{                                                                 \n" +
+            "    \"mappings\": [                                               \n" +
+            "        {                                                         \n" +
+            "            \"scenarioName\" : \"scenario-1-bar-baz\",            \n" +
+            "            \"requiredScenarioState\" : \"Started\",              \n" +
+            "            \"newScenarioState\" : \"scenario-1-bar-baz-2\",      \n" +
+            "            \"request\" : {                                       \n" +
+            "                \"url\" : \"/bar/baz\",                           \n" +
+            "                \"method\" : \"GET\"                              \n" +
+            "            }                                                     \n" +
+            "        },                                                        \n" +
+            "        {                                                         \n" +
+            "            \"request\" : {                                       \n" +
+            "                \"url\" : \"/foo\",                               \n" +
+            "                \"method\" : \"GET\"                              \n" +
+            "            }                                                     \n" +
+            "        },                                                        \n" +
+            "        {                                                         \n" +
+            "            \"scenarioName\" : \"scenario-1-bar-baz\",            \n" +
+            "            \"requiredScenarioState\" : \"scenario-1-bar-baz-2\", \n" +
+            "            \"request\" : {                                       \n" +
+            "                \"url\" : \"/bar/baz\",                           \n" +
+            "                \"method\" : \"GET\"                              \n" +
+            "            }                                                     \n" +
+            "        }                                                         \n" +
+            "    ]                                                             \n" +
+            "}                                                                   ";
 
     @Test
     public void returnsStubMappingsWithScenariosForRepeatedRequests() {

--- a/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/SnapshotDslAcceptanceTest.java
@@ -246,8 +246,8 @@ public class SnapshotDslAcceptanceTest extends AcceptanceTestBase {
 
         assertThat(mappings, everyItem(WireMatchers.isInAScenario()));
         assertThat(mappings.get(0).getRequiredScenarioState(), is(Scenario.STARTED));
-        assertThat(mappings.get(1).getRequiredScenarioState(), is("scenario-stateful-2"));
-        assertThat(mappings.get(2).getRequiredScenarioState(), is("scenario-stateful-3"));
+        assertThat(mappings.get(1).getRequiredScenarioState(), is("scenario-1-stateful-2"));
+        assertThat(mappings.get(2).getRequiredScenarioState(), is("scenario-1-stateful-3"));
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/ScenarioProcessorTest.java
@@ -39,21 +39,21 @@ public class ScenarioProcessorTest {
 
         processor.putRepeatedRequestsInScenarios(asList(foobar1, other1, foobar2, foobar3, other2));
 
-        assertThat(foobar1.getScenarioName(), is("scenario-foo-bar"));
+        assertThat(foobar1.getScenarioName(), is("scenario-1-foo-bar"));
         assertThat(foobar1.getRequiredScenarioState(), is(Scenario.STARTED));
-        assertThat("scenario-foo-bar-2", is(foobar1.getNewScenarioState()));
+        assertThat("scenario-1-foo-bar-2", is(foobar1.getNewScenarioState()));
 
         assertThat(foobar2.getScenarioName(), is(foobar1.getScenarioName()));
-        assertThat(foobar2.getRequiredScenarioState(), is("scenario-foo-bar-2"));
-        assertThat(foobar2.getNewScenarioState(), is("scenario-foo-bar-3"));
+        assertThat(foobar2.getRequiredScenarioState(), is("scenario-1-foo-bar-2"));
+        assertThat(foobar2.getNewScenarioState(), is("scenario-1-foo-bar-3"));
 
         assertThat(foobar1.getScenarioName(), is(foobar3.getScenarioName()));
-        assertThat(foobar3.getRequiredScenarioState(), is("scenario-foo-bar-3"));
+        assertThat(foobar3.getRequiredScenarioState(), is("scenario-1-foo-bar-3"));
         assertThat("Last mapping should not have a state transition", foobar3.getNewScenarioState(), nullValue());
 
-        assertThat(other1.getScenarioName(), is("scenario-other"));
-        assertThat(other1.getNewScenarioState(), is("scenario-other-2"));
-        assertThat(other2.getRequiredScenarioState(), is("scenario-other-2"));
+        assertThat(other1.getScenarioName(), is("scenario-2-other"));
+        assertThat(other1.getNewScenarioState(), is("scenario-2-other-2"));
+        assertThat(other2.getRequiredScenarioState(), is("scenario-2-other-2"));
     }
 
     @Test


### PR DESCRIPTION
Without this playback gets confused when the same url is
hit (such as is typical with a SOAP API) but groups differently
based on payload or headers.