### PR TITLE
Update docs with how to build standalone jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ To run all of WireMock's tests:
 
 To build both JARs (thin and standalone):
 ```bash
-./gradlew jar shadowJar
+./gradlew -c release-settings.gradle :java8:shadowJar
 ```
 
-The built JARs will be placed under ``build/libs``.
+The built JAR will be placed under ``java8/build/libs``.
+


### PR DESCRIPTION
I couldn't work out how to build since the `shadowJar` task advised in the README was missing. Actually, I discovered how in the './go' task, then later found this thread: https://groups.google.com/forum/#!topic/wiremock-user/Mt6R04oU0Nw

I don't know if there's other places in the docs to update, but this would help newcomers...

(force pushed to branch in my fork as accidentally included an unrelated commit)