### PR TITLE
Upgrade jackson to avoid CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ allprojects {
             handlebars     : '4.0.7',
             jetty          : '9.2.26.v20180806', // Please don't raise PRs upgrading this to the latest version as it drops Java 7 support. See https://github.com/tomakehurst/wiremock/issues/407 and https://github.com/tomakehurst/wiremock/pull/887 for details
             guava          : '20.0',
-            jackson        : '2.9.8',
-            jacksonDatabind: '2.9.8',
+            jackson        : '2.9.9',
+            jacksonDatabind: '2.9.9',
             xmlUnit        : '2.6.2'
 
         ],
@@ -49,8 +49,8 @@ allprojects {
             handlebars     : '4.1.2',
             jetty          : '9.4.15.v20190215',
             guava          : '27.0.1-jre',
-            jackson        : '2.9.8',
-            jacksonDatabind: '2.9.8',
+            jackson        : '2.9.9',
+            jacksonDatabind: '2.9.9',
             xmlUnit        : '2.6.2'
         ]
     ]


### PR DESCRIPTION
jackson-databind 2.9.8 by CVE-2019-12086, which is fixed in jackson-databind 2.9.9.

See: https://github.com/FasterXML/jackson-databind/issues/2326