### PR TITLE
Use modified requests

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -44,6 +44,7 @@ public class ResponseDefinitionBuilder {
     protected DelayDistribution delayDistribution;
     protected ChunkedDribbleDelay chunkedDribbleDelay;
     protected String proxyBaseUrl;
+    protected boolean useModifiedRequest;
     protected Fault fault;
     protected List<String> responseTransformerNames;
     protected Map<String, Object> transformerParameters = newHashMap();
@@ -63,6 +64,7 @@ public class ResponseDefinitionBuilder {
         builder.delayDistribution = responseDefinition.getDelayDistribution();
         builder.chunkedDribbleDelay = responseDefinition.getChunkedDribbleDelay();
         builder.proxyBaseUrl = responseDefinition.getProxyBaseUrl();
+        builder.useModifiedRequest = responseDefinition.isUseModifiedRequest();
         builder.fault = responseDefinition.getFault();
         builder.responseTransformerNames = responseDefinition.getTransformers();
         builder.transformerParameters = responseDefinition.getTransformerParameters() != null ? Parameters.from(responseDefinition.getTransformerParameters()) : Parameters.empty();
@@ -127,6 +129,11 @@ public class ResponseDefinitionBuilder {
 
     public ResponseDefinitionBuilder withChunkedDribbleDelay(int numberOfChunks, int totalDuration) {
         this.chunkedDribbleDelay = new ChunkedDribbleDelay(numberOfChunks, totalDuration);
+        return this;
+    }
+
+    public ResponseDefinitionBuilder withModifiedRequests() {
+        this.useModifiedRequest = true;
         return this;
     }
 
@@ -196,6 +203,7 @@ public class ResponseDefinitionBuilder {
             this.delayDistribution = from.delayDistribution;
             this.chunkedDribbleDelay = from.chunkedDribbleDelay;
             this.proxyBaseUrl = from.proxyBaseUrl;
+            this.useModifiedRequest = from.useModifiedRequest;
             this.responseTransformerNames = from.responseTransformerNames;
             this.transformerParameters = from.transformerParameters;
         }
@@ -245,6 +253,7 @@ public class ResponseDefinitionBuilder {
                     delayDistribution,
                     chunkedDribbleDelay,
                     proxyBaseUrl,
+                    useModifiedRequest,
                     fault,
                     responseTransformerNames,
                     transformerParameters,
@@ -264,6 +273,7 @@ public class ResponseDefinitionBuilder {
                     delayDistribution,
                     chunkedDribbleDelay,
                     proxyBaseUrl,
+                    useModifiedRequest,
                     fault,
                     responseTransformerNames,
                     transformerParameters,
@@ -282,6 +292,7 @@ public class ResponseDefinitionBuilder {
                     delayDistribution,
                     chunkedDribbleDelay,
                     proxyBaseUrl,
+                    useModifiedRequest,
                     fault,
                     responseTransformerNames,
                     transformerParameters,

--- a/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AbstractRequestHandler.java
@@ -66,7 +66,11 @@ public abstract class AbstractRequestHandler implements RequestHandler, RequestE
 		}
 
 		ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
-		responseDefinition.setOriginalRequest(request);
+		if (responseDefinition.isUseModifiedRequest() && serveEvent.getRequest() != null) {
+			responseDefinition.setOriginalRequest(serveEvent.getRequest());
+		} else {
+			responseDefinition.setOriginalRequest(request);
+		}
 		Response response = responseRenderer.render(serveEvent);
 		ServeEvent completedServeEvent = serveEvent.complete(response, (int) stopwatch.elapsed(MILLISECONDS));
 

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -25,7 +25,6 @@ import com.github.tomakehurst.wiremock.common.Errors;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.AbstractTransformer;
 import com.github.tomakehurst.wiremock.extension.Parameters;
-import com.google.common.net.MediaType;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +46,7 @@ public class ResponseDefinition {
     private final DelayDistribution delayDistribution;
     private final ChunkedDribbleDelay chunkedDribbleDelay;
     private final String proxyBaseUrl;
+    private final boolean useModifiedRequest;
     private final Fault fault;
     private final List<String> transformers;
     private final Parameters transformerParameters;
@@ -68,11 +68,12 @@ public class ResponseDefinition {
                               @JsonProperty("delayDistribution") DelayDistribution delayDistribution,
                               @JsonProperty("chunkedDribbleDelay") ChunkedDribbleDelay chunkedDribbleDelay,
                               @JsonProperty("proxyBaseUrl") String proxyBaseUrl,
+                              @JsonProperty("useModifiedRequest") boolean useModifiedRequest,
                               @JsonProperty("fault") Fault fault,
                               @JsonProperty("transformers") List<String> transformers,
                               @JsonProperty("transformerParameters") Parameters transformerParameters,
                               @JsonProperty("fromConfiguredStub") Boolean wasConfigured) {
-        this(status, statusMessage, Body.fromOneOf(null, body, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, chunkedDribbleDelay, proxyBaseUrl, fault, transformers, transformerParameters, wasConfigured);
+        this(status, statusMessage, Body.fromOneOf(null, body, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, chunkedDribbleDelay, proxyBaseUrl, useModifiedRequest, fault, transformers, transformerParameters, wasConfigured);
     }
 
     public ResponseDefinition(int status,
@@ -87,11 +88,12 @@ public class ResponseDefinition {
                               DelayDistribution delayDistribution,
                               ChunkedDribbleDelay chunkedDribbleDelay,
                               String proxyBaseUrl,
+                              boolean useModifiedRequest,
                               Fault fault,
                               List<String> transformers,
                               Parameters transformerParameters,
                               Boolean wasConfigured) {
-        this(status, statusMessage, Body.fromOneOf(body, null, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, chunkedDribbleDelay, proxyBaseUrl, fault, transformers, transformerParameters, wasConfigured);
+        this(status, statusMessage, Body.fromOneOf(body, null, jsonBody, base64Body), bodyFileName, headers, additionalProxyRequestHeaders, fixedDelayMilliseconds, delayDistribution, chunkedDribbleDelay, proxyBaseUrl, useModifiedRequest, fault, transformers, transformerParameters, wasConfigured);
     }
 
     private ResponseDefinition(int status,
@@ -104,6 +106,7 @@ public class ResponseDefinition {
                                DelayDistribution delayDistribution,
                                ChunkedDribbleDelay chunkedDribbleDelay,
                                String proxyBaseUrl,
+                               boolean useModifiedRequest,
                                Fault fault,
                                List<String> transformers,
                                Parameters transformerParameters,
@@ -120,6 +123,7 @@ public class ResponseDefinition {
         this.delayDistribution = delayDistribution;
         this.chunkedDribbleDelay = chunkedDribbleDelay;
         this.proxyBaseUrl = proxyBaseUrl;
+        this.useModifiedRequest = useModifiedRequest;
         this.fault = fault;
         this.transformers = transformers;
         this.transformerParameters = transformerParameters;
@@ -127,15 +131,15 @@ public class ResponseDefinition {
     }
 
     public ResponseDefinition(final int statusCode, final String bodyContent) {
-        this(statusCode, null, Body.fromString(bodyContent), null, null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
+        this(statusCode, null, Body.fromString(bodyContent), null, null, null, null, null, null, null, false, null, Collections.<String>emptyList(), Parameters.empty(), true);
     }
 
     public ResponseDefinition(final int statusCode, final byte[] bodyContent) {
-        this(statusCode, null, Body.fromBytes(bodyContent), null, null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
+        this(statusCode, null, Body.fromBytes(bodyContent), null, null, null, null, null, null, null, false, null, Collections.<String>emptyList(), Parameters.empty(), true);
     }
 
     public ResponseDefinition() {
-        this(HTTP_OK, null, Body.none(), null, null, null, null, null, null, null, null, Collections.<String>emptyList(), Parameters.empty(), true);
+        this(HTTP_OK, null, Body.none(), null, null, null, null, null, null, null, false, null, Collections.<String>emptyList(), Parameters.empty(), true);
     }
 
     public static ResponseDefinition notFound() {
@@ -214,6 +218,7 @@ public class ResponseDefinition {
             original.delayDistribution,
             original.chunkedDribbleDelay,
             original.proxyBaseUrl,
+            original.useModifiedRequest,
             original.fault,
             original.transformers,
             original.transformerParameters,
@@ -301,6 +306,11 @@ public class ResponseDefinition {
 
     public String getProxyBaseUrl() {
         return proxyBaseUrl;
+    }
+
+    @JsonIgnore
+    public boolean isUseModifiedRequest() {
+        return useModifiedRequest;
     }
 
     @JsonIgnore

--- a/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
@@ -128,6 +128,7 @@ public class StubResponseRendererTest {
                     null,
                     null,
                     null,
+                    false,
                     null,
                     null,
                     null,

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -50,6 +50,7 @@ public class ResponseDefinitionTest {
                 null,
                 null,
                 "http://base.com",
+                false,
                 Fault.EMPTY_RESPONSE,
                 ImmutableList.of("transformer-1"),
                 Parameters.one("name", "Jeff"),


### PR DESCRIPTION
I'm submitting this pull request because if you use the extension StubRequestFilter to wrap a request which modifies the URL that will be proxied, the original url gets used for the proxy request.

This change allows for a particular stub to retain the existing functionality of proxying the unmodified request url, or to set the useModifiedRequest flag to true, where the wrapped request will be sent to the ResponseDefinition when rendering the response.  

An example config might contain:

```
{
  "priority": 1,
  "request": {
    "headers" : {
      "X-Destination-Service" : {
        "equalTo" : "foo"
      }
    }
  },
  "response": {
    "proxyBaseUrl" : "https://foo.service/",
    "useModifiedRequest": "true"
  }
}
```

or in a test:

```
        stubFor(
                get(urlMatching('/.*'))
                        .withHeader('X-Destination-Service', containing('foo'))
                        .atPriority(1)
                        .willReturn(aResponse().withStatus(200)
                                .proxiedFrom('https://foo.service')
                                .withModifiedRequests()
                        )
        )
```
The filter I used with this feature is: 

```
public class ServiceNameFilter extends StubRequestFilter {
    @Override
    public RequestFilterAction filter(Request request) {
        String service = "foo";
        Request wrappedRequest = RequestWrapper.create()
                .transformAbsoluteUrl(url -> url.replaceFirst("/" + service, ""))
                .addHeader("X-Destination-Service", service)
                .wrap(request);
        return RequestFilterAction.continueWith(wrappedRequest);
    }

    @Override
    public String getName() {
        return "service-name-filter";
    }
}
```

Where my ServiceNameFilter stripped foo off the front of the url such as https://wiremock.server/foo/status, to make it so I wanted https://foo.service/status as the proxied request.  The filter was also responsible for adding the header.  In our case the reason for this was to disambiguate between two services that had the same url patterns for their requests that we wanted to mock out or proxy on.

Without my changes to ResponseDefinition, the proxied request was https://foo.service/foo/status, even though the filter wrapped the request and made it return /status as the url.

I wanted to make tests that asserted this behavior, but it turns out it wasn't clear where those tests should reside.  I can come back and add tests if someone provides a little guidance on what would fit well with the project.  

The default behavior is intended to be unchanged with this feature.  If there are unintended consequences for this change, then there may need to be adjustments.

I wasn't able to find the code from https://github.com/tomakehurst/wiremock/issues/1147 or seem to make it work with 2.24.1

This feature request seems relevant:
https://github.com/tomakehurst/wiremock/issues/1154

I think this may be a solution to this Feature Request:
https://github.com/tomakehurst/wiremock/issues/745

It might be possible to make the filter configurable, but since the filters seem to only be global, that seems difficult.  I dug into the code a little looking for something like this, but I am not extremely familiar with the code base, so I couldn't find a clear strategy.