### PR TITLE
Fix: tabs to spaces

### DIFF
--- a/java8/src/test/java/com/github/tomakehurst/wiremock/WireMockClientWithProxyAcceptanceTest.java
+++ b/java8/src/test/java/com/github/tomakehurst/wiremock/WireMockClientWithProxyAcceptanceTest.java
@@ -30,40 +30,40 @@ import static org.junit.Assert.assertThat;
 
 
 public class WireMockClientWithProxyAcceptanceTest {
-	
-	private static WireMockServer wireMockServer;
-	private static WireMockTestClient testClient;
-	private static HttpProxyServer proxyServer;
+    
+    private static WireMockServer wireMockServer;
+    private static WireMockTestClient testClient;
+    private static HttpProxyServer proxyServer;
 
-	@BeforeClass
-	public static void init() {
-		wireMockServer = new WireMockServer(DYNAMIC_PORT);
-		wireMockServer.start();
-		proxyServer = DefaultHttpProxyServer.bootstrap().withPort(0).start();
+    @BeforeClass
+    public static void init() {
+    	wireMockServer = new WireMockServer(DYNAMIC_PORT);
+    	wireMockServer.start();
+    	proxyServer = DefaultHttpProxyServer.bootstrap().withPort(0).start();
 
-		testClient = new WireMockTestClient(wireMockServer.port());
-	}
-	
-	@AfterClass
-	public static void stopServer() {
-		wireMockServer.stop();
-		proxyServer.stop();
-	}
+    	testClient = new WireMockTestClient(wireMockServer.port());
+    }
+    
+    @AfterClass
+    public static void stopServer() {
+    	wireMockServer.stop();
+    	proxyServer.stop();
+    }
 
-	@Test
-	public void supportsProxyingWithTheStaticClient() {
+    @Test
+    public void supportsProxyingWithTheStaticClient() {
         WireMock.configureFor("http", "localhost", wireMockServer.port(), proxyServer.getListenAddress().getHostString(), proxyServer.getListenAddress().getPort());
 
-		givenThat(get(urlEqualTo("/my/new/resource"))
-					.willReturn(aResponse()
-						.withStatus(304)));
+    	givenThat(get(urlEqualTo("/my/new/resource"))
+    				.willReturn(aResponse()
+    					.withStatus(304)));
 
-		assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
-	}
+    	assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
+    }
 
-	@Test
-	public void supportsProxyingWithTheInstanceClient() {
-		WireMock wireMock = WireMock.create()
+    @Test
+    public void supportsProxyingWithTheInstanceClient() {
+    	WireMock wireMock = WireMock.create()
                 .scheme("http")
                 .host("localhost")
                 .port(wireMockServer.port())
@@ -73,13 +73,13 @@ public class WireMockClientWithProxyAcceptanceTest {
                 .proxyPort(proxyServer.getListenAddress().getPort())
                 .build();
 
-		wireMock.register(
-				get(urlEqualTo("/my/new/resource"))
-				.willReturn(
-						aResponse()
-						.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
-						.withStatus(200)));
+    	wireMock.register(
+    			get(urlEqualTo("/my/new/resource"))
+    			.willReturn(
+    					aResponse()
+    					.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
+    					.withStatus(200)));
 
-		assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
-	}
+    	assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -58,8 +58,8 @@ public class WireMockServer implements Container, Stubbing, Admin {
     private final WireMockApp wireMockApp;
     private final StubRequestHandler stubRequestHandler;
 
-	private final HttpServer httpServer;
-	private final Notifier notifier;
+    private final HttpServer httpServer;
+    private final Notifier notifier;
 
     private final Options options;
 
@@ -92,13 +92,13 @@ public class WireMockServer implements Container, Stubbing, Admin {
                 .notifier(notifier));
     }
 
-	public WireMockServer(int port, FileSource fileSource, boolean enableBrowserProxying, ProxySettings proxySettings) {
+    public WireMockServer(int port, FileSource fileSource, boolean enableBrowserProxying, ProxySettings proxySettings) {
         this(wireMockConfig()
                 .port(port)
                 .fileSource(fileSource)
                 .enableBrowserProxying(enableBrowserProxying)
                 .proxyVia(proxySettings));
-	}
+    }
 
     public WireMockServer(int port, FileSource fileSource, boolean enableBrowserProxying) {
         this(wireMockConfig()
@@ -108,46 +108,46 @@ public class WireMockServer implements Container, Stubbing, Admin {
     }
 
     public WireMockServer(int port) {
-		this(wireMockConfig().port(port));
-	}
+    	this(wireMockConfig().port(port));
+    }
 
     public WireMockServer(int port, Integer httpsPort) {
         this(wireMockConfig().port(port).httpsPort(httpsPort));
     }
 
     public WireMockServer() {
-		this(wireMockConfig());
-	}
+    	this(wireMockConfig());
+    }
 
-	public void loadMappingsUsing(final MappingsLoader mappingsLoader) {
+    public void loadMappingsUsing(final MappingsLoader mappingsLoader) {
         wireMockApp.loadMappingsUsing(mappingsLoader);
-	}
+    }
 
     public GlobalSettingsHolder getGlobalSettingsHolder() {
         return wireMockApp.getGlobalSettingsHolder();
     }
 
     public void addMockServiceRequestListener(RequestListener listener) {
-		stubRequestHandler.addRequestListener(listener);
-	}
+    	stubRequestHandler.addRequestListener(listener);
+    }
 
-	public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource) {
-	    addMockServiceRequestListener(
+    public void enableRecordMappings(FileSource mappingsFileSource, FileSource filesFileSource) {
+        addMockServiceRequestListener(
                 new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, wireMockApp, options.matchingHeaders()));
         notifier.info("Recording mappings to " + mappingsFileSource.getPath());
-	}
+    }
 
     public void stop() {
         httpServer.stop();
-	}
+    }
 
-	public void start() {
+    public void start() {
         try {
-		    httpServer.start();
+    	    httpServer.start();
         } catch (Exception e) {
             throw new FatalStartupException(e);
         }
-	}
+    }
 
     /**
      * Gracefully shutdown the server.

--- a/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/OldEditStubMappingTask.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/admin/tasks/OldEditStubMappingTask.java
@@ -24,10 +24,10 @@ import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 
 public class OldEditStubMappingTask implements AdminTask {
 
-	@Override
-	public ResponseDefinition execute(Admin admin, Request request, PathParams pathParams) {
-		StubMapping stubMapping = StubMapping.buildFrom(request.getBodyAsString());
-		admin.editStubMapping(stubMapping);
-		return ResponseDefinition.noContent();
-	}
+    @Override
+    public ResponseDefinition execute(Admin admin, Request request, PathParams pathParams) {
+    	StubMapping stubMapping = StubMapping.buildFrom(request.getBodyAsString());
+    	admin.editStubMapping(stubMapping);
+    	return ResponseDefinition.noContent();
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/BasicMappingBuilder.java
@@ -34,50 +34,50 @@ import static com.google.common.collect.Maps.newLinkedHashMap;
 class BasicMappingBuilder implements ScenarioMappingBuilder {
 
     private RequestPatternBuilder requestPatternBuilder;
-	private ResponseDefinitionBuilder responseDefBuilder;
-	private Integer priority;
-	private String scenarioName;
-	private String requiredScenarioState;
-	private String newScenarioState;
-	private UUID id = UUID.randomUUID();
-	private String name;
+    private ResponseDefinitionBuilder responseDefBuilder;
+    private Integer priority;
+    private String scenarioName;
+    private String requiredScenarioState;
+    private String newScenarioState;
+    private UUID id = UUID.randomUUID();
+    private String name;
     private boolean isPersistent = false;
     private Map<String, Parameters> postServeActions = newLinkedHashMap();
     private Metadata metadata;
 
     BasicMappingBuilder(RequestMethod method, UrlPattern urlPattern) {
         requestPatternBuilder = new RequestPatternBuilder(method, urlPattern);
-	}
+    }
 
-	BasicMappingBuilder(ValueMatcher<Request> requestMatcher) {
+    BasicMappingBuilder(ValueMatcher<Request> requestMatcher) {
         requestPatternBuilder = new RequestPatternBuilder(requestMatcher);
-	}
+    }
 
-	BasicMappingBuilder(String customRequestMatcherName, Parameters parameters) {
-		requestPatternBuilder = new RequestPatternBuilder(customRequestMatcherName, parameters);
-	}
+    BasicMappingBuilder(String customRequestMatcherName, Parameters parameters) {
+    	requestPatternBuilder = new RequestPatternBuilder(customRequestMatcherName, parameters);
+    }
 
-	@Override
-	public BasicMappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder) {
-		this.responseDefBuilder = responseDefBuilder;
-		return this;
-	}
+    @Override
+    public BasicMappingBuilder willReturn(ResponseDefinitionBuilder responseDefBuilder) {
+    	this.responseDefBuilder = responseDefBuilder;
+    	return this;
+    }
 
-	@Override
-	public BasicMappingBuilder atPriority(Integer priority) {
-		this.priority = priority;
-		return this;
-	}
+    @Override
+    public BasicMappingBuilder atPriority(Integer priority) {
+    	this.priority = priority;
+    	return this;
+    }
 
-	@Override
-	public BasicMappingBuilder withHeader(String key, StringValuePattern headerPattern) {
+    @Override
+    public BasicMappingBuilder withHeader(String key, StringValuePattern headerPattern) {
         requestPatternBuilder.withHeader(key, headerPattern);
-		return this;
-	}
+    	return this;
+    }
 
     @Override
     public BasicMappingBuilder withCookie(String name, StringValuePattern cookieValuePattern) {
-		requestPatternBuilder.withCookie(name, cookieValuePattern);
+    	requestPatternBuilder.withCookie(name, cookieValuePattern);
         return this;
     }
 
@@ -94,11 +94,11 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
         return this;
     }
 
-	@Override
-	public BasicMappingBuilder withRequestBody(ContentPattern<?> bodyPattern) {
+    @Override
+    public BasicMappingBuilder withRequestBody(ContentPattern<?> bodyPattern) {
         requestPatternBuilder.withRequestBody(bodyPattern);
-		return this;
-	}
+    	return this;
+    }
 
     @Override
     public BasicMappingBuilder withMultipartRequestBody(MultipartValuePatternBuilder multipartPatternBuilder) {
@@ -110,33 +110,33 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
     public BasicMappingBuilder inScenario(String scenarioName) {
         checkArgument(scenarioName != null, "Scenario name must not be null");
 
-		this.scenarioName = scenarioName;
-		return this;
-	}
+    	this.scenarioName = scenarioName;
+    	return this;
+    }
 
     @Override
-	public BasicMappingBuilder whenScenarioStateIs(String stateName) {
-		this.requiredScenarioState = stateName;
-		return this;
-	}
+    public BasicMappingBuilder whenScenarioStateIs(String stateName) {
+    	this.requiredScenarioState = stateName;
+    	return this;
+    }
 
     @Override
-	public BasicMappingBuilder willSetStateTo(String stateName) {
-		this.newScenarioState = stateName;
-		return this;
-	}
+    public BasicMappingBuilder willSetStateTo(String stateName) {
+    	this.newScenarioState = stateName;
+    	return this;
+    }
 
-	@Override
-	public BasicMappingBuilder withId(UUID id) {
-		this.id = id;
-		return this;
-	}
+    @Override
+    public BasicMappingBuilder withId(UUID id) {
+    	this.id = id;
+    	return this;
+    }
 
-	@Override
-	public BasicMappingBuilder withName(String name) {
-		this.name = name;
-		return this;
-	}
+    @Override
+    public BasicMappingBuilder withName(String name) {
+    	this.name = name;
+    	return this;
+    }
 
     @Override
     public ScenarioMappingBuilder persistent() {
@@ -145,10 +145,10 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
     }
 
     @Override
-	public BasicMappingBuilder withBasicAuth(String username, String password) {
-		requestPatternBuilder.withBasicAuth(new BasicCredentials(username, password));
-		return this;
-	}
+    public BasicMappingBuilder withBasicAuth(String username, String password) {
+    	requestPatternBuilder.withBasicAuth(new BasicCredentials(username, password));
+    	return this;
+    }
 
     @Override
     public <P> BasicMappingBuilder withPostServeAction(String extensionName, P parameters) {
@@ -159,11 +159,11 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
         return this;
     }
 
-	@Override
-	public BasicMappingBuilder withMetadata(Map<String, ?> metadataMap) {
-    	this.metadata = new Metadata(metadataMap);
-		return this;
-	}
+    @Override
+    public BasicMappingBuilder withMetadata(Map<String, ?> metadataMap) {
+        this.metadata = new Metadata(metadataMap);
+    	return this;
+    }
 
     @Override
     public BasicMappingBuilder withMetadata(Metadata metadata) {
@@ -177,11 +177,11 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
         return this;
     }
 
-	@Override
-	public BasicMappingBuilder andMatching(ValueMatcher<Request> customMatcher) {
-    	requestPatternBuilder.andMatching(customMatcher);
-		return this;
-	}
+    @Override
+    public BasicMappingBuilder andMatching(ValueMatcher<Request> customMatcher) {
+        requestPatternBuilder.andMatching(customMatcher);
+    	return this;
+    }
 
     @Override
     public BasicMappingBuilder andMatching(String customRequestMatcherName) {
@@ -196,26 +196,26 @@ class BasicMappingBuilder implements ScenarioMappingBuilder {
     }
 
     @Override
-	public StubMapping build() {
-		if (scenarioName == null && (requiredScenarioState != null || newScenarioState != null)) {
-			throw new IllegalStateException("Scenario name must be specified to require or set a new scenario state");
-		}
-		RequestPattern requestPattern = requestPatternBuilder.build();
-		ResponseDefinition response = firstNonNull(responseDefBuilder, aResponse()).build();
-		StubMapping mapping = new StubMapping(requestPattern, response);
-		mapping.setPriority(priority);
-		mapping.setScenarioName(scenarioName);
-		mapping.setRequiredScenarioState(requiredScenarioState);
-		mapping.setNewScenarioState(newScenarioState);
-		mapping.setUuid(id);
-		mapping.setName(name);
+    public StubMapping build() {
+    	if (scenarioName == null && (requiredScenarioState != null || newScenarioState != null)) {
+    		throw new IllegalStateException("Scenario name must be specified to require or set a new scenario state");
+    	}
+    	RequestPattern requestPattern = requestPatternBuilder.build();
+    	ResponseDefinition response = firstNonNull(responseDefBuilder, aResponse()).build();
+    	StubMapping mapping = new StubMapping(requestPattern, response);
+    	mapping.setPriority(priority);
+    	mapping.setScenarioName(scenarioName);
+    	mapping.setRequiredScenarioState(requiredScenarioState);
+    	mapping.setNewScenarioState(newScenarioState);
+    	mapping.setUuid(id);
+    	mapping.setName(name);
         mapping.setPersistent(isPersistent);
 
         mapping.setPostServeActions(postServeActions.isEmpty() ? null : postServeActions);
 
         mapping.setMetadata(metadata);
 
-		return mapping;
-	}
+    	return mapping;
+    }
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
@@ -29,11 +29,11 @@ import static com.google.common.collect.FluentIterable.from;
 
 public class VerificationException extends AssertionError {
 
-	private static final long serialVersionUID = 5116216532516117538L;
+    private static final long serialVersionUID = 5116216532516117538L;
 
-	public VerificationException(String message) {
-		super(message);
-	}
+    public VerificationException(String message) {
+    	super(message);
+    }
 
     public static VerificationException forUnmatchedRequestPattern(Diff diff) {
         return new VerificationException("No requests exactly matched. Most similar request was:", diff);

--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -51,21 +51,21 @@ import static com.google.common.net.HttpHeaders.LOCATION;
 
 public class WireMock {
 
-	private static final int DEFAULT_PORT = 8080;
-	private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 8080;
+    private static final String DEFAULT_HOST = "localhost";
 
-	private final Admin admin;
-	private final GlobalSettingsHolder globalSettingsHolder = new GlobalSettingsHolder();
+    private final Admin admin;
+    private final GlobalSettingsHolder globalSettingsHolder = new GlobalSettingsHolder();
 
-	private static InheritableThreadLocal<WireMock> defaultInstance = new InheritableThreadLocal<WireMock>(){
+    private static InheritableThreadLocal<WireMock> defaultInstance = new InheritableThreadLocal<WireMock>(){
             @Override
             protected WireMock initialValue() {
-            	return WireMock.create().build();
+                return WireMock.create().build();
             }
-	};
+    };
 
-	public static WireMockBuilder create() {
-	    return new WireMockBuilder();
+    public static WireMockBuilder create() {
+        return new WireMockBuilder();
     }
 
     public WireMock(Admin admin) {
@@ -77,44 +77,44 @@ public class WireMock {
     }
 
     public WireMock(String host, int port) {
-		admin = new HttpAdminClient(host, port);
-	}
+    	admin = new HttpAdminClient(host, port);
+    }
 
-	public WireMock(String host, int port, String urlPathPrefix) {
-		admin = new HttpAdminClient(host, port, urlPathPrefix);
-	}
+    public WireMock(String host, int port, String urlPathPrefix) {
+    	admin = new HttpAdminClient(host, port, urlPathPrefix);
+    }
 
-	public WireMock(String scheme, String host, int port) {
-		admin = new HttpAdminClient(scheme, host, port);
-	}
+    public WireMock(String scheme, String host, int port) {
+    	admin = new HttpAdminClient(scheme, host, port);
+    }
 
-	public WireMock(String scheme, String host, int port, String urlPathPrefix) {
-		admin = new HttpAdminClient(scheme, host, port, urlPathPrefix);
-	}
+    public WireMock(String scheme, String host, int port, String urlPathPrefix) {
+    	admin = new HttpAdminClient(scheme, host, port, urlPathPrefix);
+    }
 
     public WireMock(String scheme, String host, int port, String urlPathPrefix, String hostHeader, String proxyHost, int proxyPort, ClientAuthenticator authenticator) {
         admin = new HttpAdminClient(scheme, host, port, urlPathPrefix, hostHeader, proxyHost, proxyPort, authenticator);
     }
 
-	public WireMock() {
-		admin = new HttpAdminClient(DEFAULT_HOST, DEFAULT_PORT);
-	}
+    public WireMock() {
+    	admin = new HttpAdminClient(DEFAULT_HOST, DEFAULT_PORT);
+    }
 
-	public static StubMapping givenThat(MappingBuilder mappingBuilder) {
-		return defaultInstance.get().register(mappingBuilder);
-	}
+    public static StubMapping givenThat(MappingBuilder mappingBuilder) {
+    	return defaultInstance.get().register(mappingBuilder);
+    }
 
-	public static StubMapping stubFor(MappingBuilder mappingBuilder) {
-		return givenThat(mappingBuilder);
-	}
+    public static StubMapping stubFor(MappingBuilder mappingBuilder) {
+    	return givenThat(mappingBuilder);
+    }
 
-	public static void editStub(MappingBuilder mappingBuilder) {
-		defaultInstance.get().editStubMapping(mappingBuilder);
-	}
+    public static void editStub(MappingBuilder mappingBuilder) {
+    	defaultInstance.get().editStubMapping(mappingBuilder);
+    }
 
-	public static void removeStub(MappingBuilder mappingBuilder) {
-		defaultInstance.get().removeStubMapping(mappingBuilder);
-	}
+    public static void removeStub(MappingBuilder mappingBuilder) {
+    	defaultInstance.get().removeStubMapping(mappingBuilder);
+    }
 
     public static void removeStub(StubMapping stubMapping) {
         defaultInstance.get().removeStubMapping(stubMapping);
@@ -132,33 +132,33 @@ public class WireMock {
         defaultInstance.set(WireMock.create().port(port).build());
     }
 
-	public static void configureFor(String host, int port) {
-		defaultInstance.set(WireMock.create().host(host).port(port).build());
-	}
+    public static void configureFor(String host, int port) {
+    	defaultInstance.set(WireMock.create().host(host).port(port).build());
+    }
 
-	public static void configureFor(String host, int port, String urlPathPrefix) {
-		defaultInstance.set(WireMock.create().host(host).port(port).urlPathPrefix(urlPathPrefix).build());
-	}
+    public static void configureFor(String host, int port, String urlPathPrefix) {
+    	defaultInstance.set(WireMock.create().host(host).port(port).urlPathPrefix(urlPathPrefix).build());
+    }
 
-	public static void configureFor(String scheme, String host, int port, String urlPathPrefix) {
-		defaultInstance.set(WireMock.create().scheme(scheme).host(host).port(port).urlPathPrefix(urlPathPrefix).build());
-	}
+    public static void configureFor(String scheme, String host, int port, String urlPathPrefix) {
+    	defaultInstance.set(WireMock.create().scheme(scheme).host(host).port(port).urlPathPrefix(urlPathPrefix).build());
+    }
 
-	public static void configureFor(String scheme, String host, int port) {
-		defaultInstance.set(WireMock.create().scheme(scheme).host(host).port(port).build());
-	}
+    public static void configureFor(String scheme, String host, int port) {
+    	defaultInstance.set(WireMock.create().scheme(scheme).host(host).port(port).build());
+    }
 
     public static void configureFor(String scheme, String host, int port, String proxyHost, int proxyPort) {
         defaultInstance.set(WireMock.create().scheme(scheme).host(host).port(port).urlPathPrefix("").hostHeader(null).proxyHost(proxyHost).proxyPort(proxyPort).build());
     }
 
     public static void configureFor(WireMock client) {
-	    defaultInstance.set(client);
+        defaultInstance.set(client);
     }
 
-	public static void configure() {
-		defaultInstance.set(WireMock.create().build());
-	}
+    public static void configure() {
+    	defaultInstance.set(WireMock.create().build());
+    }
 
     public static StringValuePattern equalTo(String value) {
         return new EqualToPattern(value);
@@ -172,9 +172,9 @@ public class WireMock {
         return new BinaryEqualToPattern(content);
     }
 
-	public static StringValuePattern equalToIgnoreCase(String value) {
-		return new EqualToPattern(value, true);
-	}
+    public static StringValuePattern equalToIgnoreCase(String value) {
+    	return new EqualToPattern(value, true);
+    }
 
     public static StringValuePattern equalToJson(String value) {
         return new EqualToJsonPattern(value, null, null);
@@ -201,7 +201,7 @@ public class WireMock {
     }
 
     public static EqualToXmlPattern equalToXml(String value, boolean enablePlaceholders, String placeholderOpeningDelimiterRegex, String placeholderClosingDelimiterRegex) {
-	    return new EqualToXmlPattern(value, enablePlaceholders, placeholderOpeningDelimiterRegex, placeholderClosingDelimiterRegex);
+        return new EqualToXmlPattern(value, enablePlaceholders, placeholderOpeningDelimiterRegex, placeholderClosingDelimiterRegex);
     }
 
     public static MatchesXPathPattern matchingXPath(String value) {
@@ -248,25 +248,25 @@ public class WireMock {
         defaultInstance.get().removeMappings();
     }
 
-	public void resetMappings() {
-		admin.resetAll();
-	}
+    public void resetMappings() {
+    	admin.resetAll();
+    }
 
-	public static void reset() {
-		defaultInstance.get().resetMappings();
-	}
+    public static void reset() {
+    	defaultInstance.get().resetMappings();
+    }
 
-	public static void resetAllRequests() {
-		defaultInstance.get().resetRequests();
-	}
+    public static void resetAllRequests() {
+    	defaultInstance.get().resetRequests();
+    }
 
-	public void resetRequests() {
-		admin.resetRequests();
-	}
+    public void resetRequests() {
+    	admin.resetRequests();
+    }
 
-	public void resetScenarios() {
-		admin.resetScenarios();
-	}
+    public void resetScenarios() {
+    	admin.resetScenarios();
+    }
 
     public static List<Scenario> getAllScenarios() {
         return defaultInstance.get().getScenarios();
@@ -277,8 +277,8 @@ public class WireMock {
     }
 
     public static void resetAllScenarios() {
-		defaultInstance.get().resetScenarios();
-	}
+    	defaultInstance.get().resetScenarios();
+    }
 
     public void resetToDefaultMappings() {
         admin.resetToDefaultMappings();
@@ -288,27 +288,27 @@ public class WireMock {
         defaultInstance.get().resetToDefaultMappings();
     }
 
-	public StubMapping register(MappingBuilder mappingBuilder) {
-		StubMapping mapping = mappingBuilder.build();
-		register(mapping);
-		return mapping;
-	}
+    public StubMapping register(MappingBuilder mappingBuilder) {
+    	StubMapping mapping = mappingBuilder.build();
+    	register(mapping);
+    	return mapping;
+    }
 
     public void register(StubMapping mapping) {
         admin.addStubMapping(mapping);
     }
 
-	public void editStubMapping(MappingBuilder mappingBuilder) {
-		admin.editStubMapping(mappingBuilder.build());
-	}
+    public void editStubMapping(MappingBuilder mappingBuilder) {
+    	admin.editStubMapping(mappingBuilder.build());
+    }
 
-	public void removeStubMapping(MappingBuilder mappingBuilder) {
-		admin.removeStubMapping(mappingBuilder.build());
-	}
+    public void removeStubMapping(MappingBuilder mappingBuilder) {
+    	admin.removeStubMapping(mappingBuilder.build());
+    }
 
-	public void removeStubMapping(StubMapping stubMapping) {
-		admin.removeStubMapping(stubMapping);
-	}
+    public void removeStubMapping(StubMapping stubMapping) {
+    	admin.removeStubMapping(stubMapping);
+    }
 
     public ListStubMappingsResult allStubMappings() {
         return admin.listAllStubMappings();
@@ -338,81 +338,81 @@ public class WireMock {
         return UrlPattern.ANY;
     }
 
-	public static CountMatchingStrategy lessThan(int expected) {
-		return new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN, expected);
-	}
+    public static CountMatchingStrategy lessThan(int expected) {
+    	return new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN, expected);
+    }
 
-	public static CountMatchingStrategy lessThanOrExactly(int expected) {
-		return new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN_OR_EQUAL, expected);
-	}
+    public static CountMatchingStrategy lessThanOrExactly(int expected) {
+    	return new CountMatchingStrategy(CountMatchingStrategy.LESS_THAN_OR_EQUAL, expected);
+    }
 
-	public static CountMatchingStrategy exactly(int expected) {
-		return new CountMatchingStrategy(CountMatchingStrategy.EQUAL_TO, expected);
-	}
+    public static CountMatchingStrategy exactly(int expected) {
+    	return new CountMatchingStrategy(CountMatchingStrategy.EQUAL_TO, expected);
+    }
 
-	public static CountMatchingStrategy moreThanOrExactly(int expected) {
-		return new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN_OR_EQUAL, expected);
-	}
+    public static CountMatchingStrategy moreThanOrExactly(int expected) {
+    	return new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN_OR_EQUAL, expected);
+    }
 
-	public static CountMatchingStrategy moreThan(int expected) {
-		return new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN, expected);
-	}
+    public static CountMatchingStrategy moreThan(int expected) {
+    	return new CountMatchingStrategy(CountMatchingStrategy.GREATER_THAN, expected);
+    }
 
-	public static MappingBuilder get(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.GET, urlPattern);
-	}
+    public static MappingBuilder get(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.GET, urlPattern);
+    }
 
-	public static MappingBuilder post(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.POST, urlPattern);
-	}
+    public static MappingBuilder post(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.POST, urlPattern);
+    }
 
-	public static MappingBuilder put(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.PUT, urlPattern);
-	}
+    public static MappingBuilder put(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.PUT, urlPattern);
+    }
 
-	public static MappingBuilder delete(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.DELETE, urlPattern);
-	}
+    public static MappingBuilder delete(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.DELETE, urlPattern);
+    }
 
-	public static MappingBuilder patch(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.PATCH, urlPattern);
-	}
+    public static MappingBuilder patch(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.PATCH, urlPattern);
+    }
 
-	public static MappingBuilder head(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.HEAD, urlPattern);
-	}
+    public static MappingBuilder head(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.HEAD, urlPattern);
+    }
 
-	public static MappingBuilder options(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.OPTIONS, urlPattern);
-	}
+    public static MappingBuilder options(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.OPTIONS, urlPattern);
+    }
 
-	public static MappingBuilder trace(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.TRACE, urlPattern);
-	}
+    public static MappingBuilder trace(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.TRACE, urlPattern);
+    }
 
-	public static MappingBuilder any(UrlPattern urlPattern) {
-		return new BasicMappingBuilder(RequestMethod.ANY, urlPattern);
-	}
+    public static MappingBuilder any(UrlPattern urlPattern) {
+    	return new BasicMappingBuilder(RequestMethod.ANY, urlPattern);
+    }
 
     public static MappingBuilder request(String method, UrlPattern urlPattern) {
         return new BasicMappingBuilder(RequestMethod.fromString(method), urlPattern);
     }
 
-	public static MappingBuilder requestMatching(String customRequestMatcherName) {
-		return new BasicMappingBuilder(customRequestMatcherName, Parameters.empty());
-	}
+    public static MappingBuilder requestMatching(String customRequestMatcherName) {
+    	return new BasicMappingBuilder(customRequestMatcherName, Parameters.empty());
+    }
 
-	public static MappingBuilder requestMatching(String customRequestMatcherName, Parameters parameters) {
-		return new BasicMappingBuilder(customRequestMatcherName, parameters);
-	}
+    public static MappingBuilder requestMatching(String customRequestMatcherName, Parameters parameters) {
+    	return new BasicMappingBuilder(customRequestMatcherName, parameters);
+    }
 
-	public static MappingBuilder requestMatching(ValueMatcher<Request> requestMatcher) {
-		return new BasicMappingBuilder(requestMatcher);
-	}
+    public static MappingBuilder requestMatching(ValueMatcher<Request> requestMatcher) {
+    	return new BasicMappingBuilder(requestMatcher);
+    }
 
-	public static ResponseDefinitionBuilder aResponse() {
-		return new ResponseDefinitionBuilder();
-	}
+    public static ResponseDefinitionBuilder aResponse() {
+    	return new ResponseDefinitionBuilder();
+    }
 
     public static ResponseDefinitionBuilder ok() {
         return aResponse().withStatus(200);
@@ -513,19 +513,19 @@ public class WireMock {
         return aResponse().withStatus(status);
     }
 
-	public void verifyThat(RequestPatternBuilder requestPatternBuilder) {
-		verifyThat(moreThanOrExactly(1), requestPatternBuilder);
-	}
+    public void verifyThat(RequestPatternBuilder requestPatternBuilder) {
+    	verifyThat(moreThanOrExactly(1), requestPatternBuilder);
+    }
 
-	public void verifyThat(int expectedCount, RequestPatternBuilder requestPatternBuilder) {
-		verifyThat(exactly(expectedCount), requestPatternBuilder);
-	}
+    public void verifyThat(int expectedCount, RequestPatternBuilder requestPatternBuilder) {
+    	verifyThat(exactly(expectedCount), requestPatternBuilder);
+    }
 
-	public void verifyThat(CountMatchingStrategy expectedCount, RequestPatternBuilder requestPatternBuilder) {
-		final RequestPattern requestPattern = requestPatternBuilder.build();
+    public void verifyThat(CountMatchingStrategy expectedCount, RequestPatternBuilder requestPatternBuilder) {
+    	final RequestPattern requestPattern = requestPatternBuilder.build();
 
-		int actualCount;
-		if (requestPattern.hasInlineCustomMatcher()) {
+    	int actualCount;
+    	if (requestPattern.hasInlineCustomMatcher()) {
             List<LoggedRequest> requests = admin.findRequestsMatching(RequestPattern.everything()).getRequests();
             actualCount = from(requests).filter(thatMatch(requestPattern)).size();
         } else {
@@ -537,9 +537,9 @@ public class WireMock {
         if (!expectedCount.match(actualCount)) {
             throw actualCount == 0 ?
                 verificationExceptionForNearMisses(requestPatternBuilder, requestPattern) :
-			    new VerificationException(requestPattern, expectedCount, actualCount);
-		}
-	}
+    		    new VerificationException(requestPattern, expectedCount, actualCount);
+    	}
+    }
 
     private VerificationException verificationExceptionForNearMisses(RequestPatternBuilder requestPatternBuilder, RequestPattern requestPattern) {
         List<NearMiss> nearMisses = findAllNearMissesFor(requestPatternBuilder);
@@ -551,17 +551,17 @@ public class WireMock {
         return new VerificationException(requestPattern, find(allRequests()));
     }
 
-	public static void verify(RequestPatternBuilder requestPatternBuilder) {
-		defaultInstance.get().verifyThat(requestPatternBuilder);
-	}
+    public static void verify(RequestPatternBuilder requestPatternBuilder) {
+    	defaultInstance.get().verifyThat(requestPatternBuilder);
+    }
 
-	public static void verify(int count, RequestPatternBuilder requestPatternBuilder) {
-		defaultInstance.get().verifyThat(count, requestPatternBuilder);
-	}
+    public static void verify(int count, RequestPatternBuilder requestPatternBuilder) {
+    	defaultInstance.get().verifyThat(count, requestPatternBuilder);
+    }
 
-	public static void verify(CountMatchingStrategy countMatchingStrategy, RequestPatternBuilder requestPatternBuilder) {
-		defaultInstance.get().verifyThat(countMatchingStrategy, requestPatternBuilder);
-	}
+    public static void verify(CountMatchingStrategy countMatchingStrategy, RequestPatternBuilder requestPatternBuilder) {
+    	defaultInstance.get().verifyThat(countMatchingStrategy, requestPatternBuilder);
+    }
 
     public List<LoggedRequest> find(RequestPatternBuilder requestPatternBuilder) {
         FindRequestsResult result = admin.findRequestsMatching(requestPatternBuilder.build());
@@ -573,7 +573,7 @@ public class WireMock {
         return defaultInstance.get().find(requestPatternBuilder);
     }
 
-	public static List<ServeEvent> getAllServeEvents() {
+    public static List<ServeEvent> getAllServeEvents() {
         return defaultInstance.get().getServeEvents();
     }
 
@@ -582,11 +582,11 @@ public class WireMock {
     }
 
     public static void removeServeEvent(UUID eventId) {
-	    defaultInstance.get().removeEvent(eventId);
+        defaultInstance.get().removeEvent(eventId);
     }
 
     public void removeEvent(UUID eventId) {
-	    admin.removeServeEvent(eventId);
+        admin.removeServeEvent(eventId);
     }
 
     public List<ServeEvent> removeEvents(RequestPatternBuilder requestPatternBuilder) {
@@ -594,93 +594,93 @@ public class WireMock {
     }
 
     public static List<ServeEvent> removeServeEvents(RequestPatternBuilder requestPatternBuilder) {
-	    return defaultInstance.get().removeEvents(requestPatternBuilder);
+        return defaultInstance.get().removeEvents(requestPatternBuilder);
     }
 
     public static List<ServeEvent> removeEventsByStubMetadata(StringValuePattern pattern) {
-	    return defaultInstance.get().removeEventsByMetadata(pattern);
+        return defaultInstance.get().removeEventsByMetadata(pattern);
     }
 
     public List<ServeEvent> removeEventsByMetadata(StringValuePattern pattern) {
-	    return admin.removeServeEventsForStubsMatchingMetadata(pattern).getServeEvents();
+        return admin.removeServeEventsForStubsMatchingMetadata(pattern).getServeEvents();
     }
 
     public static RequestPatternBuilder getRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.GET, urlPattern);
-	}
+    	return new RequestPatternBuilder(RequestMethod.GET, urlPattern);
+    }
 
-	public static RequestPatternBuilder postRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.POST, urlPattern);
-	}
+    public static RequestPatternBuilder postRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.POST, urlPattern);
+    }
 
-	public static RequestPatternBuilder putRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.PUT, urlPattern);
-	}
+    public static RequestPatternBuilder putRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.PUT, urlPattern);
+    }
 
-	public static RequestPatternBuilder deleteRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.DELETE, urlPattern);
-	}
+    public static RequestPatternBuilder deleteRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.DELETE, urlPattern);
+    }
 
-	public static RequestPatternBuilder patchRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.PATCH, urlPattern);
-	}
+    public static RequestPatternBuilder patchRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.PATCH, urlPattern);
+    }
 
-	public static RequestPatternBuilder headRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.HEAD, urlPattern);
-	}
+    public static RequestPatternBuilder headRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.HEAD, urlPattern);
+    }
 
-	public static RequestPatternBuilder optionsRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.OPTIONS, urlPattern);
-	}
+    public static RequestPatternBuilder optionsRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.OPTIONS, urlPattern);
+    }
 
-	public static RequestPatternBuilder traceRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.TRACE, urlPattern);
-	}
+    public static RequestPatternBuilder traceRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.TRACE, urlPattern);
+    }
 
-	public static RequestPatternBuilder anyRequestedFor(UrlPattern urlPattern) {
-		return new RequestPatternBuilder(RequestMethod.ANY, urlPattern);
-	}
+    public static RequestPatternBuilder anyRequestedFor(UrlPattern urlPattern) {
+    	return new RequestPatternBuilder(RequestMethod.ANY, urlPattern);
+    }
 
     public static RequestPatternBuilder requestMadeFor(String customMatcherName, Parameters parameters) {
         return RequestPatternBuilder.forCustomMatcher(customMatcherName, parameters);
     }
 
-	public static RequestPatternBuilder requestMadeFor(ValueMatcher<Request> requestMatcher) {
-		return RequestPatternBuilder.forCustomMatcher(requestMatcher);
-	}
+    public static RequestPatternBuilder requestMadeFor(ValueMatcher<Request> requestMatcher) {
+    	return RequestPatternBuilder.forCustomMatcher(requestMatcher);
+    }
 
-	public static void setGlobalFixedDelay(int milliseconds) {
-		defaultInstance.get().setGlobalFixedDelayVariable(milliseconds);
-	}
+    public static void setGlobalFixedDelay(int milliseconds) {
+    	defaultInstance.get().setGlobalFixedDelayVariable(milliseconds);
+    }
 
-	public void setGlobalFixedDelayVariable(int milliseconds) {
-		GlobalSettings settings = globalSettingsHolder.get()
+    public void setGlobalFixedDelayVariable(int milliseconds) {
+    	GlobalSettings settings = globalSettingsHolder.get()
                 .copy()
                 .fixedDelay(milliseconds)
                 .build();
-		updateGlobalSettings(settings);
-	}
+    	updateGlobalSettings(settings);
+    }
 
-	public static void setGlobalRandomDelay(DelayDistribution distribution) {
-		defaultInstance.get().setGlobalRandomDelayVariable(distribution);
-	}
+    public static void setGlobalRandomDelay(DelayDistribution distribution) {
+    	defaultInstance.get().setGlobalRandomDelayVariable(distribution);
+    }
 
-	public void setGlobalRandomDelayVariable(DelayDistribution distribution) {
-		GlobalSettings settings = globalSettingsHolder.get()
+    public void setGlobalRandomDelayVariable(DelayDistribution distribution) {
+    	GlobalSettings settings = globalSettingsHolder.get()
                 .copy()
                 .delayDistribution(distribution)
                 .build();
-		updateGlobalSettings(settings);
-	}
-
-	public static void updateSettings(GlobalSettings settings) {
-	    defaultInstance.get().updateGlobalSettings(settings);
+    	updateGlobalSettings(settings);
     }
 
-	public void updateGlobalSettings(GlobalSettings settings) {
-		globalSettingsHolder.replaceWith(settings);
-		admin.updateGlobalSettings(settings);
-	}
+    public static void updateSettings(GlobalSettings settings) {
+        defaultInstance.get().updateGlobalSettings(settings);
+    }
+
+    public void updateGlobalSettings(GlobalSettings settings) {
+    	globalSettingsHolder.replaceWith(settings);
+    	admin.updateGlobalSettings(settings);
+    }
 
     public void shutdown() {
         admin.shutdownServer();
@@ -730,10 +730,10 @@ public class WireMock {
         loadMappingsFrom(new File(rootDir));
     }
 
-	public void loadMappingsFrom(File rootDir) {
-		FileSource mappingsSource = new SingleRootFileSource(rootDir);
-		new RemoteMappingsLoader(mappingsSource, this).load();
-	}
+    public void loadMappingsFrom(File rootDir) {
+    	FileSource mappingsSource = new SingleRootFileSource(rootDir);
+    	new RemoteMappingsLoader(mappingsSource, this).load();
+    }
 
     public static List<StubMapping> snapshotRecord() {
         return defaultInstance.get().takeSnapshotRecording();
@@ -796,19 +796,19 @@ public class WireMock {
     }
 
     public List<StubMapping> findAllStubsByMetadata(StringValuePattern pattern) {
-	    return admin.findAllStubsByMetadata(pattern).getMappings();
+        return admin.findAllStubsByMetadata(pattern).getMappings();
     }
 
     public static List<StubMapping> findStubsByMetadata(StringValuePattern pattern) {
-	    return defaultInstance.get().findAllStubsByMetadata(pattern);
+        return defaultInstance.get().findAllStubsByMetadata(pattern);
     }
 
     public void removeStubsByMetadataPattern(StringValuePattern pattern) {
-	    admin.removeStubsByMetadata(pattern);
+        admin.removeStubsByMetadata(pattern);
     }
 
     public static void removeStubsByMetadata(StringValuePattern pattern) {
-	    defaultInstance.get().removeStubsByMetadataPattern(pattern);
+        defaultInstance.get().removeStubsByMetadataPattern(pattern);
     }
 
     public void importStubMappings(StubImport stubImport) {
@@ -816,11 +816,11 @@ public class WireMock {
     }
 
     public void importStubMappings(StubImportBuilder stubImport) {
-	    importStubMappings(stubImport.build());
+        importStubMappings(stubImport.build());
     }
 
     public static void importStubs(StubImportBuilder stubImport) {
-	    importStubs(stubImport.build());
+        importStubs(stubImport.build());
     }
 
     public static void importStubs(StubImport stubImport) {
@@ -828,7 +828,7 @@ public class WireMock {
     }
 
     public GlobalSettings getGlobalSettings() {
-	    return admin.getGlobalSettings().getSettings();
+        return admin.getGlobalSettings().getSettings();
     }
 
     public static GlobalSettings getSettings() {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/AbstractFileSource.java
@@ -64,7 +64,7 @@ public abstract class AbstractFileSource implements FileSource {
 
     @Override
     public String getPath() {
-    	return rootDirectory.getPath();
+        return rootDirectory.getPath();
     }
 
     @Override
@@ -74,34 +74,34 @@ public abstract class AbstractFileSource implements FileSource {
 
     @Override
     public List<TextFile> listFilesRecursively() {
-    	assertExistsAndIsDirectory();
-    	List<File> fileList = newArrayList();
-    	recursivelyAddFilesToList(rootDirectory, fileList);
-    	return toTextFileList(fileList);
+        assertExistsAndIsDirectory();
+        List<File> fileList = newArrayList();
+        recursivelyAddFilesToList(rootDirectory, fileList);
+        return toTextFileList(fileList);
     }
 
     private void recursivelyAddFilesToList(File root, List<File> fileList) {
-    	File[] files = root.listFiles();
-    	for (File file: files) {
-    		if (file.isDirectory()) {
-    			recursivelyAddFilesToList(file, fileList);
-    		} else {
-    			fileList.add(file);
-    		}
-    	}
+        File[] files = root.listFiles();
+        for (File file: files) {
+        	if (file.isDirectory()) {
+        		recursivelyAddFilesToList(file, fileList);
+        	} else {
+        		fileList.add(file);
+        	}
+        }
     }
 
     private List<TextFile> toTextFileList(List<File> fileList) {
-    	return newArrayList(transform(fileList, new Function<File, TextFile>() {
-    		public TextFile apply(File input) {
-    			return new TextFile(input.toURI());
-    		}
-    	}));
+        return newArrayList(transform(fileList, new Function<File, TextFile>() {
+        	public TextFile apply(File input) {
+        		return new TextFile(input.toURI());
+        	}
+        }));
     }
 
     @Override
     public void writeTextFile(String name, String contents) {
-    	writeTextFileAndTranslateExceptions(contents, writableFileFor(name));
+        writeTextFileAndTranslateExceptions(contents, writableFileFor(name));
     }
 
     @Override
@@ -182,11 +182,11 @@ public abstract class AbstractFileSource implements FileSource {
     }
 
     private FileFilter filesOnly() {
-    	return new FileFilter() {
-    		public boolean accept(File file) {
-    			return file.isFile();
-    		}
-    	};
+        return new FileFilter() {
+        	public boolean accept(File file) {
+        		return file.isFile();
+        	}
+        };
     }
 
     public static Predicate<BinaryFile> byFileExtension(final String extension) {

--- a/src/main/java/com/github/tomakehurst/wiremock/common/BinaryFile.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/BinaryFile.java
@@ -25,39 +25,39 @@ import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 
 public class BinaryFile implements InputStreamSource {
 
-	private URI uri;
+    private URI uri;
 
-	public BinaryFile(URI uri) {
-		this.uri = uri;
-	}
+    public BinaryFile(URI uri) {
+    	this.uri = uri;
+    }
 
-	public byte[] readContents() {
-		try(InputStream stream = getStream()) {
-			return ByteStreams.toByteArray(stream);
-		} catch (final IOException ioe) {
-			return throwUnchecked(ioe, byte[].class);
-		}
-	}
+    public byte[] readContents() {
+    	try(InputStream stream = getStream()) {
+    		return ByteStreams.toByteArray(stream);
+    	} catch (final IOException ioe) {
+    		return throwUnchecked(ioe, byte[].class);
+    	}
+    }
 
-	protected URI getUri() {
-		return uri;
-	}
+    protected URI getUri() {
+    	return uri;
+    }
 
-	public String name() {
-		return uri.toString();
-	}
+    public String name() {
+    	return uri.toString();
+    }
 
-	@Override
-	public String toString() {
-		return name();
-	}
+    @Override
+    public String toString() {
+    	return name();
+    }
 
-	@Override
-	public InputStream getStream() {
-		try {
-			return uri.toURL().openStream();
-		} catch (IOException e) {
-			return throwUnchecked(e, InputStream.class);
-		}
-	}
+    @Override
+    public InputStream getStream() {
+    	try {
+    		return uri.toURL().openStream();
+    	} catch (IOException e) {
+    		return throwUnchecked(e, InputStream.class);
+    	}
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/FileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/FileSource.java
@@ -23,14 +23,14 @@ public interface FileSource {
 
     BinaryFile getBinaryFileNamed(String name);
     TextFile getTextFileNamed(String name);
-	void createIfNecessary();
-	FileSource child(String subDirectoryName);
-	String getPath();
-	URI getUri();
-	List<TextFile> listFilesRecursively();
-	void writeTextFile(String name, String contents);
+    void createIfNecessary();
+    FileSource child(String subDirectoryName);
+    String getPath();
+    URI getUri();
+    List<TextFile> listFilesRecursively();
+    void writeTextFile(String name, String contents);
     void writeBinaryFile(String name, byte[] contents);
     boolean exists();
 
-	void deleteFile(String name);
+    void deleteFile(String name);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/HttpClientUtils.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/HttpClientUtils.java
@@ -25,33 +25,33 @@ import static com.google.common.base.Charsets.UTF_8;
 
 public class HttpClientUtils {
 
-	public static String getEntityAsStringAndCloseStream(HttpResponse httpResponse) {
-		HttpEntity entity = httpResponse.getEntity();
-		if (entity != null) {
-			try {
-				String content = EntityUtils.toString(entity, UTF_8.name());
-				entity.getContent().close();
-				return content;
-			} catch (IOException ioe) {
-				throw new RuntimeException(ioe);
-			}
-		}
-		
-		return null;
-	}
-	
-	public static byte[] getEntityAsByteArrayAndCloseStream(HttpResponse httpResponse) {
-		HttpEntity entity = httpResponse.getEntity();
-		if (entity != null) {
-			try {
-				byte[] content = EntityUtils.toByteArray(entity);
-				entity.getContent().close();
-				return content;
-			} catch (IOException ioe) {
-				throw new RuntimeException(ioe);
-			}
-		}
-		
-		return null;
-	}
+    public static String getEntityAsStringAndCloseStream(HttpResponse httpResponse) {
+    	HttpEntity entity = httpResponse.getEntity();
+    	if (entity != null) {
+    		try {
+    			String content = EntityUtils.toString(entity, UTF_8.name());
+    			entity.getContent().close();
+    			return content;
+    		} catch (IOException ioe) {
+    			throw new RuntimeException(ioe);
+    		}
+    	}
+    	
+    	return null;
+    }
+    
+    public static byte[] getEntityAsByteArrayAndCloseStream(HttpResponse httpResponse) {
+    	HttpEntity entity = httpResponse.getEntity();
+    	if (entity != null) {
+    		try {
+    			byte[] content = EntityUtils.toByteArray(entity);
+    			entity.getContent().close();
+    			return content;
+    		} catch (IOException ioe) {
+    			throw new RuntimeException(ioe);
+    		}
+    	}
+    	
+    	return null;
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -44,21 +44,21 @@ public final class Json {
             return objectMapper;
         }
     };
-	
-	private Json() {}
+    
+    private Json() {}
 
     public static <T> T read(String json, Class<T> clazz) {
-		try {
-			ObjectMapper mapper = getObjectMapper();
-			return mapper.readValue(json, clazz);
-		} catch (JsonProcessingException processingException) {
+    	try {
+    		ObjectMapper mapper = getObjectMapper();
+    		return mapper.readValue(json, clazz);
+    	} catch (JsonProcessingException processingException) {
             throw JsonException.fromJackson(processingException);
         } catch (IOException ioe) {
-			return throwUnchecked(ioe, clazz);
-		}
-	}
+    		return throwUnchecked(ioe, clazz);
+    	}
+    }
 
-	public static <T> T read(String json, TypeReference<T> typeRef) {
+    public static <T> T read(String json, TypeReference<T> typeRef) {
         try {
             ObjectMapper mapper = getObjectMapper();
             return mapper.readValue(json, typeRef);
@@ -70,7 +70,7 @@ public final class Json {
     }
 
     public static <T> String write(T object) {
-	    return write(object, PublicView.class);
+        return write(object, PublicView.class);
     }
 
     public static <T> String writePrivate(T object) {
@@ -78,17 +78,17 @@ public final class Json {
     }
 
     public static <T> String write(T object, Class<?> view) {
-		try {
-			ObjectMapper mapper = getObjectMapper();
+    	try {
+    		ObjectMapper mapper = getObjectMapper();
             ObjectWriter objectWriter = mapper.writerWithDefaultPrettyPrinter();
             if (view != null) {
                 objectWriter = objectWriter.withView(view);
             }
             return objectWriter.writeValueAsString(object);
-		} catch (IOException ioe) {
+    	} catch (IOException ioe) {
             return throwUnchecked(ioe, String.class);
-		}
-	}
+    	}
+    }
 
 
     public static ObjectMapper getObjectMapper() {
@@ -96,15 +96,15 @@ public final class Json {
     }
 
     public static byte[] toByteArray(Object object) {
-		try {
-			ObjectMapper mapper = getObjectMapper();
-			return mapper.writeValueAsBytes(object);
-		} catch (IOException ioe) {
+    	try {
+    		ObjectMapper mapper = getObjectMapper();
+    		return mapper.writeValueAsBytes(object);
+    	} catch (IOException ioe) {
             return throwUnchecked(ioe, byte[].class);
-		}
-	}
+    	}
+    }
 
-	public static JsonNode node(String json) {
+    public static JsonNode node(String json) {
         return read(json, JsonNode.class);
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/common/LocalNotifier.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/LocalNotifier.java
@@ -17,34 +17,34 @@ package com.github.tomakehurst.wiremock.common;
 
 public class LocalNotifier {
 
-	private static ThreadLocal<Notifier> notifierHolder = new ThreadLocal<Notifier>();
-	
-	public static Notifier notifier() {
-		Notifier notifier = notifierHolder.get();
-		if (notifier == null) {
-			notifier = new NullNotifier();
-		}
-		
-		return notifier;
-	}
-	
-	public static void set(Notifier notifier) {
-		notifierHolder.set(notifier);
-	}
-	
-	private static class NullNotifier implements Notifier {
+    private static ThreadLocal<Notifier> notifierHolder = new ThreadLocal<Notifier>();
+    
+    public static Notifier notifier() {
+    	Notifier notifier = notifierHolder.get();
+    	if (notifier == null) {
+    		notifier = new NullNotifier();
+    	}
+    	
+    	return notifier;
+    }
+    
+    public static void set(Notifier notifier) {
+    	notifierHolder.set(notifier);
+    }
+    
+    private static class NullNotifier implements Notifier {
 
-		@Override
-		public void info(String message) {
-		}
+    	@Override
+    	public void info(String message) {
+    	}
 
-		@Override
-		public void error(String message) {
-		}
+    	@Override
+    	public void error(String message) {
+    	}
 
-		@Override
-		public void error(String message, Throwable t) {
-		}
-		
-	}
+    	@Override
+    	public void error(String message, Throwable t) {
+    	}
+    	
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Notifier.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Notifier.java
@@ -16,10 +16,10 @@
 package com.github.tomakehurst.wiremock.common;
 
 public interface Notifier {
-	
-	public static final String KEY = "Notifier";
+    
+    public static final String KEY = "Notifier";
 
-	void info(String message);
-	void error(String message);
-	void error(String message, Throwable t);
+    void info(String message);
+    void error(String message);
+    void error(String message, Throwable t);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/SingleRootFileSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/SingleRootFileSource.java
@@ -19,15 +19,15 @@ import java.io.File;
 
 public class SingleRootFileSource extends AbstractFileSource {
 
-	public SingleRootFileSource(File rootDirectory) {
-		super(rootDirectory);
-	}
-	
-	public SingleRootFileSource(String rootPath) {
-	    super(new File(rootPath));
-	}
-	
-	@Override
+    public SingleRootFileSource(File rootDirectory) {
+    	super(rootDirectory);
+    }
+    
+    public SingleRootFileSource(String rootPath) {
+        super(new File(rootPath));
+    }
+    
+    @Override
     public FileSource child(String subDirectoryName) {
         return new SingleRootFileSource(new File(rootDirectory, subDirectoryName));
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/common/TextFile.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/TextFile.java
@@ -22,13 +22,13 @@ import static com.google.common.base.Charsets.UTF_8;
 
 public class TextFile extends BinaryFile {
 
-	public TextFile(URI uri) {
+    public TextFile(URI uri) {
         super(uri);
-	}
-	
-	public String readContentsAsString() {
+    }
+    
+    public String readContentsAsString() {
         return new String(super.readContents(), UTF_8);
-	}
+    }
 
     public String getPath() {
         return new File(getUri().getSchemeSpecificPart()).getPath();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Admin.java
@@ -33,14 +33,14 @@ import java.util.UUID;
 
 public interface Admin {
 
-	void addStubMapping(StubMapping stubMapping);
-	void editStubMapping(StubMapping stubMapping);
-	void removeStubMapping(StubMapping stubbMapping);
+    void addStubMapping(StubMapping stubMapping);
+    void editStubMapping(StubMapping stubMapping);
+    void removeStubMapping(StubMapping stubbMapping);
     ListStubMappingsResult listAllStubMappings();
     SingleStubMappingResult getStubMapping(UUID id);
     void saveMappings();
 
-	void resetRequests();
+    void resetRequests();
     void resetScenarios();
     void resetMappings();
     void resetAll();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -260,8 +260,8 @@ public class WireMockConfiguration implements Options {
     }
 
     public WireMockConfiguration recordRequestHeadersForMatching(List<String> headers) {
-    	this.matchingHeaders = transform(headers, CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS);
-    	return this;
+        this.matchingHeaders = transform(headers, CaseInsensitiveKey.TO_CASE_INSENSITIVE_KEYS);
+        return this;
     }
 
     public WireMockConfiguration preserveHostHeader(boolean preserveHostHeader) {
@@ -424,7 +424,7 @@ public class WireMockConfiguration implements Options {
 
     @Override
     public List<CaseInsensitiveKey> matchingHeaders() {
-    	return matchingHeaders;
+        return matchingHeaders;
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/HandlebarsOptimizedTemplate.java
@@ -23,41 +23,41 @@ import com.github.tomakehurst.wiremock.common.Exceptions;
 
 public class HandlebarsOptimizedTemplate {
 
-	private final Template template;
+    private final Template template;
 
-	private String startContent;
-	private String templateContent;
-	private String endContent;
+    private String startContent;
+    private String templateContent;
+    private String endContent;
 
-	public HandlebarsOptimizedTemplate(final Handlebars handlebars, final String content) {
-		startContent = content;
-		templateContent = "";
-		endContent = "";
+    public HandlebarsOptimizedTemplate(final Handlebars handlebars, final String content) {
+    	startContent = content;
+    	templateContent = "";
+    	endContent = "";
 
-		int firstDelimStartPosition = content.indexOf(Handlebars.DELIM_START);
-		if (firstDelimStartPosition != -1) {
-			int lastDelimEndPosition = content.lastIndexOf(Handlebars.DELIM_END);
-			if (lastDelimEndPosition != -1) {
-				startContent = content.substring(0, firstDelimStartPosition);
-				templateContent = content.substring(firstDelimStartPosition,
-						lastDelimEndPosition + Handlebars.DELIM_END.length());
-				endContent = content.substring(lastDelimEndPosition + Handlebars.DELIM_END.length(), content.length());
-			}
-		}
+    	int firstDelimStartPosition = content.indexOf(Handlebars.DELIM_START);
+    	if (firstDelimStartPosition != -1) {
+    		int lastDelimEndPosition = content.lastIndexOf(Handlebars.DELIM_END);
+    		if (lastDelimEndPosition != -1) {
+    			startContent = content.substring(0, firstDelimStartPosition);
+    			templateContent = content.substring(firstDelimStartPosition,
+    					lastDelimEndPosition + Handlebars.DELIM_END.length());
+    			endContent = content.substring(lastDelimEndPosition + Handlebars.DELIM_END.length(), content.length());
+    		}
+    	}
 
-		this.template = uncheckedCompileTemplate(handlebars, templateContent);
-	}
+    	this.template = uncheckedCompileTemplate(handlebars, templateContent);
+    }
 
-	private static Template uncheckedCompileTemplate(Handlebars handlebars, String templateContent) {
-		try {
-			return handlebars.compileInline(templateContent);
-		} catch (IOException e) {
-			return Exceptions.throwUnchecked(e, Template.class);
-		}
-	}
+    private static Template uncheckedCompileTemplate(Handlebars handlebars, String templateContent) {
+    	try {
+    		return handlebars.compileInline(templateContent);
+    	} catch (IOException e) {
+    		return Exceptions.throwUnchecked(e, Template.class);
+    	}
+    }
 
-	public String apply(Object context) throws IOException {
-		StringBuilder sb = new StringBuilder();
-		return sb.append(startContent).append(template.apply(context)).append(endContent).toString();
-	}
+    public String apply(Object context) throws IOException {
+    	StringBuilder sb = new StringBuilder();
+    	return sb.append(startContent).append(template.apply(context)).append(endContent).toString();
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/global/GlobalSettingsHolder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/global/GlobalSettingsHolder.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class GlobalSettingsHolder {
 
-	private AtomicReference<GlobalSettings> globalSettingsRef = new AtomicReference<>(GlobalSettings.defaults());
-	
-	public void replaceWith(GlobalSettings globalSettings) {
-		globalSettingsRef.set(globalSettings);
-	}
-	
-	public GlobalSettings get() {
-		return globalSettingsRef.get();
-	}
+    private AtomicReference<GlobalSettings> globalSettingsRef = new AtomicReference<>(GlobalSettings.defaults());
+    
+    public void replaceWith(GlobalSettings globalSettings) {
+    	globalSettingsRef.set(globalSettings);
+    }
+    
+    public GlobalSettings get() {
+    	return globalSettingsRef.get();
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandler.java
@@ -42,23 +42,23 @@ public class AdminRequestHandler extends AbstractRequestHandler {
     private final Authenticator authenticator;
     private final boolean requireHttps;
 
-	public AdminRequestHandler(AdminRoutes adminRoutes,
+    public AdminRequestHandler(AdminRoutes adminRoutes,
                                Admin admin,
                                ResponseRenderer responseRenderer,
                                Authenticator authenticator,
                                boolean requireHttps,
                                List<RequestFilter> requestFilters
     ) {
-		super(responseRenderer, requestFilters);
+    	super(responseRenderer, requestFilters);
         this.adminRoutes = adminRoutes;
         this.admin = admin;
         this.authenticator = authenticator;
         this.requireHttps = requireHttps;
     }
 
-	@Override
-	public ServeEvent handleRequest(Request request) {
-	    if (requireHttps && !URI.create(request.getAbsoluteUrl()).getScheme().equals("https")) {
+    @Override
+    public ServeEvent handleRequest(Request request) {
+        if (requireHttps && !URI.create(request.getAbsoluteUrl()).getScheme().equals("https")) {
             notifier().info("HTTPS is required for admin requests, sending upgrade redirect");
             return ServeEvent.of(
                 LoggedRequest.createFrom(request),
@@ -66,7 +66,7 @@ public class AdminRequestHandler extends AbstractRequestHandler {
             );
         }
 
-	    if (!authenticator.authenticate(request)) {
+        if (!authenticator.authenticate(request)) {
             notifier().info("Authentication failed for " + request.getMethod() + " " + request.getUrl());
             return ServeEvent.of(
                 LoggedRequest.createFrom(request),
@@ -99,8 +99,8 @@ public class AdminRequestHandler extends AbstractRequestHandler {
         }
     }
 
-	private static String withoutAdminRoot(String url) {
-	    return url.replace(ADMIN_CONTEXT_ROOT, "");
-	}
-	
+    private static String withoutAdminRoot(String url) {
+        return url.replace(ADMIN_CONTEXT_ROOT, "");
+    }
+    
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ContentTypeHeader.java
@@ -24,14 +24,14 @@ import java.nio.charset.Charset;
 
 public class ContentTypeHeader extends HttpHeader {
 
-	public static final String KEY = "Content-Type";
-	
-	private String[] parts;
+    public static final String KEY = "Content-Type";
+    
+    private String[] parts;
 
-	public ContentTypeHeader(String stringValue) {
+    public ContentTypeHeader(String stringValue) {
         super(KEY, stringValue);
-		parts = stringValue != null ? stringValue.split(";") : new String[0];
-	}
+    	parts = stringValue != null ? stringValue.split(";") : new String[0];
+    }
 
     private ContentTypeHeader() {
         super(KEY);
@@ -45,25 +45,25 @@ public class ContentTypeHeader extends HttpHeader {
         return isPresent() ? this : new ContentTypeHeader(stringValue);
     }
 
-	public String mimeTypePart() {
-		return parts != null ? parts[0] : null;
-	}
-	
-	public Optional<String> encodingPart() {
-		for (int i = 1; i < parts.length; i++) {
-			if (parts[i].matches("\\s*charset\\s*=.*") ) {
-				return Optional.of(parts[i].split("=")[1].replace("\"", ""));
-			}
-		}
+    public String mimeTypePart() {
+    	return parts != null ? parts[0] : null;
+    }
+    
+    public Optional<String> encodingPart() {
+    	for (int i = 1; i < parts.length; i++) {
+    		if (parts[i].matches("\\s*charset\\s*=.*") ) {
+    			return Optional.of(parts[i].split("=")[1].replace("\"", ""));
+    		}
+    	}
 
-		return Optional.absent();
-	}
+    	return Optional.absent();
+    }
 
-	public Charset charset() {
-		if (isPresent() && encodingPart().isPresent()) {
-			return Charset.forName(encodingPart().get());
-		}
+    public Charset charset() {
+    	if (isPresent() && encodingPart().isPresent()) {
+    		return Charset.forName(encodingPart().get());
+    	}
 
-		return Strings.DEFAULT_CHARSET;
-	}
+    	return Strings.DEFAULT_CHARSET;
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Fault.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Fault.java
@@ -19,33 +19,33 @@ import com.github.tomakehurst.wiremock.core.FaultInjector;
 
 public enum Fault {
 
-	CONNECTION_RESET_BY_PEER {
-		@Override
-		public void apply(FaultInjector faultInjector) {
-			faultInjector.connectionResetByPeer();
-		}
-	},
+    CONNECTION_RESET_BY_PEER {
+    	@Override
+    	public void apply(FaultInjector faultInjector) {
+    		faultInjector.connectionResetByPeer();
+    	}
+    },
 
-	EMPTY_RESPONSE {
-		@Override
-		public void apply(FaultInjector faultInjector) {
-			faultInjector.emptyResponseAndCloseConnection();
-		}
-	},
-	
-	MALFORMED_RESPONSE_CHUNK {
-		@Override
-		public void apply(FaultInjector faultInjector) {
-			faultInjector.malformedResponseChunk();
-		}
-	},
-	
-	RANDOM_DATA_THEN_CLOSE {
-		@Override
-		public void apply(FaultInjector faultInjector) {
-			faultInjector.randomDataAndCloseConnection();
-		}
-	};
-	
-	public abstract void apply(FaultInjector faultInjector);
+    EMPTY_RESPONSE {
+    	@Override
+    	public void apply(FaultInjector faultInjector) {
+    		faultInjector.emptyResponseAndCloseConnection();
+    	}
+    },
+    
+    MALFORMED_RESPONSE_CHUNK {
+    	@Override
+    	public void apply(FaultInjector faultInjector) {
+    		faultInjector.malformedResponseChunk();
+    	}
+    },
+    
+    RANDOM_DATA_THEN_CLOSE {
+    	@Override
+    	public void apply(FaultInjector faultInjector) {
+    		faultInjector.randomDataAndCloseConnection();
+    	}
+    };
+    
+    public abstract void apply(FaultInjector faultInjector);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpClientFactory.java
@@ -89,7 +89,7 @@ public class HttpClientFactory {
         }
 
         return builder.build();
-	}
+    }
 
     private static SSLContext buildSSLContextWithTrustStore(KeyStoreSettings trustStoreSettings) {
         try {
@@ -121,9 +121,9 @@ public class HttpClientFactory {
         return createClient(maxConnections, timeoutMilliseconds, NO_PROXY, NO_STORE);
     }
 
-	public static CloseableHttpClient createClient(int timeoutMilliseconds) {
-		return createClient(DEFAULT_MAX_CONNECTIONS, timeoutMilliseconds);
-	}
+    public static CloseableHttpClient createClient(int timeoutMilliseconds) {
+    	return createClient(DEFAULT_MAX_CONNECTIONS, timeoutMilliseconds);
+    }
 
     public static CloseableHttpClient createClient(ProxySettings proxySettings) {
         return createClient(DEFAULT_MAX_CONNECTIONS, DEFAULT_TIMEOUT, proxySettings, NO_STORE);

--- a/src/main/java/com/github/tomakehurst/wiremock/http/MimeType.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/MimeType.java
@@ -16,18 +16,18 @@
 package com.github.tomakehurst.wiremock.http;
 
 public enum MimeType {
-	
-	JSON("application/json"),
-	XML("text/xml"),
-	PLAIN("text/plain");
+    
+    JSON("application/json"),
+    XML("text/xml"),
+    PLAIN("text/plain");
 
-	private String mimeString;
-	
-	private MimeType(String mimeString) {
-		this.mimeString = mimeString;
-	}
-	
-	public String toString() {
-		return mimeString;
-	}
+    private String mimeString;
+    
+    private MimeType(String mimeString) {
+    	this.mimeString = mimeString;
+    }
+    
+    public String toString() {
+    	return mimeString;
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestHandler.java
@@ -16,8 +16,8 @@
 package com.github.tomakehurst.wiremock.http;
 
 public interface RequestHandler {
-	
-	String HANDLER_CLASS_KEY = "RequestHandlerClass";
+    
+    String HANDLER_CLASS_KEY = "RequestHandlerClass";
 
-	void handle(Request request, HttpResponder httpResponder);
+    void handle(Request request, HttpResponder httpResponder);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/RequestListener.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/RequestListener.java
@@ -17,5 +17,5 @@ package com.github.tomakehurst.wiremock.http;
 
 public interface RequestListener {
 
-	void requestReceived(Request request, Response response);
+    void requestReceived(Request request, Response response);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/Response.java
@@ -31,17 +31,17 @@ import static java.net.HttpURLConnection.HTTP_OK;
 
 public class Response {
 
-	private final int status;
+    private final int status;
     private final String statusMessage;
     private final InputStreamSource bodyStreamSource;
-	private final HttpHeaders headers;
-	private final boolean configured;
-	private final Fault fault;
-	private final boolean fromProxy;
-	private final long initialDelay;
+    private final HttpHeaders headers;
+    private final boolean configured;
+    private final Fault fault;
+    private final boolean fromProxy;
+    private final long initialDelay;
     private final ChunkedDribbleDelay chunkedDribbleDelay;
 
-	public static Response notConfigured() {
+    public static Response notConfigured() {
         return new Response(
                 HTTP_NOT_FOUND,
                 null,
@@ -97,9 +97,9 @@ public class Response {
         this.fromProxy = fromProxy;
     }
 
-	public int getStatus() {
-		return status;
-	}
+    public int getStatus() {
+    	return status;
+    }
 
     public String getStatusMessage() {
         return statusMessage;
@@ -113,29 +113,29 @@ public class Response {
         }
     }
 
-	public String getBodyAsString() {
+    public String getBodyAsString() {
         return Strings.stringFromBytes(getBody(), headers.getContentTypeHeader().charset());
-	}
+    }
 
     public InputStream getBodyStream() {
         return bodyStreamSource == null ? null : bodyStreamSource.getStream();
     }
 
     public boolean hasInlineBody() {
-	    return !BinaryFile.class.isAssignableFrom(bodyStreamSource.getClass());
+        return !BinaryFile.class.isAssignableFrom(bodyStreamSource.getClass());
     }
 
-	public HttpHeaders getHeaders() {
-		return headers;
-	}
+    public HttpHeaders getHeaders() {
+    	return headers;
+    }
 
     public Fault getFault() {
         return fault;
     }
 
     public long getInitialDelay() {
-	    return initialDelay;
-	}
+        return initialDelay;
+    }
 
     public ChunkedDribbleDelay getChunkedDribbleDelay() {
         return chunkedDribbleDelay;
@@ -145,9 +145,9 @@ public class Response {
         return chunkedDribbleDelay != null;
     }
 
-	public boolean wasConfigured() {
-		return configured;
-	}
+    public boolean wasConfigured() {
+    	return configured;
+    }
 
     public boolean isFromProxy() {
         return fromProxy;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseRenderer.java
@@ -18,7 +18,7 @@ package com.github.tomakehurst.wiremock.http;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 
 public interface ResponseRenderer {
-	
-	Response render(ServeEvent serveEvent);
-	
+    
+    Response render(ServeEvent serveEvent);
+    
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandler.java
@@ -29,34 +29,34 @@ import java.util.Map;
 import static com.github.tomakehurst.wiremock.common.LocalNotifier.notifier;
 
 public class StubRequestHandler extends AbstractRequestHandler {
-	
-	private final StubServer stubServer;
+    
+    private final StubServer stubServer;
     private final Admin admin;
     private final Map<String, PostServeAction> postServeActions;
     private final RequestJournal requestJournal;
 
-	public StubRequestHandler(StubServer stubServer,
+    public StubRequestHandler(StubServer stubServer,
                               ResponseRenderer responseRenderer,
                               Admin admin,
                               Map<String, PostServeAction> postServeActions,
                               RequestJournal requestJournal,
                               List<RequestFilter> requestFilters) {
-		super(responseRenderer, requestFilters);
-		this.stubServer = stubServer;
+    	super(responseRenderer, requestFilters);
+    	this.stubServer = stubServer;
         this.admin = admin;
         this.postServeActions = postServeActions;
         this.requestJournal = requestJournal;
     }
 
-	@Override
-	public ServeEvent handleRequest(Request request) {
-		return stubServer.serveStubFor(request);
-	}
+    @Override
+    public ServeEvent handleRequest(Request request) {
+    	return stubServer.serveStubFor(request);
+    }
 
-	@Override
-	protected boolean logRequests() {
-		return true;
-	}
+    @Override
+    protected boolean logRequests() {
+    	return true;
+    }
 
     @Override
     protected void beforeResponseSent(ServeEvent serveEvent, Response response) {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubResponseRenderer.java
@@ -31,59 +31,59 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 public class StubResponseRenderer implements ResponseRenderer {
 
-	private final FileSource fileSource;
-	private final GlobalSettingsHolder globalSettingsHolder;
-	private final ProxyResponseRenderer proxyResponseRenderer;
-	private final List<ResponseTransformer> responseTransformers;
+    private final FileSource fileSource;
+    private final GlobalSettingsHolder globalSettingsHolder;
+    private final ProxyResponseRenderer proxyResponseRenderer;
+    private final List<ResponseTransformer> responseTransformers;
 
     public StubResponseRenderer(FileSource fileSource,
-								GlobalSettingsHolder globalSettingsHolder,
-								ProxyResponseRenderer proxyResponseRenderer,
-								List<ResponseTransformer> responseTransformers) {
+    							GlobalSettingsHolder globalSettingsHolder,
+    							ProxyResponseRenderer proxyResponseRenderer,
+    							List<ResponseTransformer> responseTransformers) {
         this.fileSource = fileSource;
         this.globalSettingsHolder = globalSettingsHolder;
         this.proxyResponseRenderer = proxyResponseRenderer;
-		this.responseTransformers = responseTransformers;
-	}
+    	this.responseTransformers = responseTransformers;
+    }
 
-	@Override
-	public Response render(ServeEvent serveEvent) {
+    @Override
+    public Response render(ServeEvent serveEvent) {
         ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
         if (!responseDefinition.wasConfigured()) {
-			return Response.notConfigured();
-		}
+    		return Response.notConfigured();
+    	}
 
-		Response response = buildResponse(serveEvent);
-		return applyTransformations(responseDefinition.getOriginalRequest(), responseDefinition, response, responseTransformers);
-	}
+    	Response response = buildResponse(serveEvent);
+    	return applyTransformations(responseDefinition.getOriginalRequest(), responseDefinition, response, responseTransformers);
+    }
 
-	private Response buildResponse(ServeEvent serveEvent) {
-		if (serveEvent.getResponseDefinition().isProxyResponse()) {
-			return proxyResponseRenderer.render(serveEvent);
-		} else {
-			Response.Builder responseBuilder = renderDirectly(serveEvent);
-			return responseBuilder.build();
-		}
-	}
+    private Response buildResponse(ServeEvent serveEvent) {
+    	if (serveEvent.getResponseDefinition().isProxyResponse()) {
+    		return proxyResponseRenderer.render(serveEvent);
+    	} else {
+    		Response.Builder responseBuilder = renderDirectly(serveEvent);
+    		return responseBuilder.build();
+    	}
+    }
 
-	private Response applyTransformations(Request request,
-										  ResponseDefinition responseDefinition,
-										  Response response,
-										  List<ResponseTransformer> transformers) {
-		if (transformers.isEmpty()) {
-			return response;
-		}
+    private Response applyTransformations(Request request,
+    									  ResponseDefinition responseDefinition,
+    									  Response response,
+    									  List<ResponseTransformer> transformers) {
+    	if (transformers.isEmpty()) {
+    		return response;
+    	}
 
-		ResponseTransformer transformer = transformers.get(0);
-		Response newResponse =
-				transformer.applyGlobally() || responseDefinition.hasTransformer(transformer) ?
-						transformer.transform(request, response, fileSource, responseDefinition.getTransformerParameters()) :
-						response;
+    	ResponseTransformer transformer = transformers.get(0);
+    	Response newResponse =
+    			transformer.applyGlobally() || responseDefinition.hasTransformer(transformer) ?
+    					transformer.transform(request, response, fileSource, responseDefinition.getTransformerParameters()) :
+    					response;
 
-		return applyTransformations(request, responseDefinition, newResponse, transformers.subList(1, transformers.size()));
-	}
+    	return applyTransformations(request, responseDefinition, newResponse, transformers.subList(1, transformers.size()));
+    }
 
-	private Response.Builder renderDirectly(ServeEvent serveEvent) {
+    private Response.Builder renderDirectly(ServeEvent serveEvent) {
         ResponseDefinition responseDefinition = serveEvent.getResponseDefinition();
 
         HttpHeaders headers = responseDefinition.getHeaders();
@@ -100,28 +100,28 @@ public class StubResponseRenderer implements ResponseRenderer {
 
         Response.Builder responseBuilder = response()
                 .status(responseDefinition.getStatus())
-				.statusMessage(responseDefinition.getStatusMessage())
+    			.statusMessage(responseDefinition.getStatusMessage())
                 .headers(headers)
                 .fault(responseDefinition.getFault())
-				.configureDelay(
-					globalSettingsHolder.get().getFixedDelay(),
-					globalSettingsHolder.get().getDelayDistribution(),
-					responseDefinition.getFixedDelayMilliseconds(),
-					responseDefinition.getDelayDistribution()
-				)
-				.chunkedDribbleDelay(responseDefinition.getChunkedDribbleDelay());
+    			.configureDelay(
+    				globalSettingsHolder.get().getFixedDelay(),
+    				globalSettingsHolder.get().getDelayDistribution(),
+    				responseDefinition.getFixedDelayMilliseconds(),
+    				responseDefinition.getDelayDistribution()
+    			)
+    			.chunkedDribbleDelay(responseDefinition.getChunkedDribbleDelay());
 
-		if (responseDefinition.specifiesBodyFile()) {
-			BinaryFile bodyFile = fileSource.getBinaryFileNamed(responseDefinition.getBodyFileName());
+    	if (responseDefinition.specifiesBodyFile()) {
+    		BinaryFile bodyFile = fileSource.getBinaryFileNamed(responseDefinition.getBodyFileName());
             responseBuilder.body(bodyFile);
-		} else if (responseDefinition.specifiesBodyContent()) {
+    	} else if (responseDefinition.specifiesBodyContent()) {
             if(responseDefinition.specifiesBinaryBodyContent()) {
                 responseBuilder.body(responseDefinition.getByteBody());
             } else {
                 responseBuilder.body(responseDefinition.getByteBody());
             }
-		}
+    	}
 
         return responseBuilder;
-	}
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockRule.java
@@ -45,30 +45,30 @@ public class WireMockRule extends WireMockServer implements MethodRule, TestRule
     }
 
     public WireMockRule(int port) {
-		this(wireMockConfig().port(port));
-	}
+    	this(wireMockConfig().port(port));
+    }
 
     public WireMockRule(int port, Integer httpsPort) {
         this(wireMockConfig().port(port).httpsPort(httpsPort));
     }
-	
-	public WireMockRule() {
-		this(wireMockConfig());
-	}
+    
+    public WireMockRule() {
+    	this(wireMockConfig());
+    }
 
     @Override
     public Statement apply(final Statement base, Description description) {
         return apply(base, null, null);
     }
 
-	@Override
-	public Statement apply(final Statement base, FrameworkMethod method, Object target) {
-		return new Statement() {
-			@Override
-			public void evaluate() throws Throwable {
-				start();
-				WireMock.configureFor("localhost", port());
-				try {
+    @Override
+    public Statement apply(final Statement base, FrameworkMethod method, Object target) {
+    	return new Statement() {
+    		@Override
+    		public void evaluate() throws Throwable {
+    			start();
+    			WireMock.configureFor("localhost", port());
+    			try {
                     before();
                     base.evaluate();
                     checkForUnmatchedRequests();
@@ -76,10 +76,10 @@ public class WireMockRule extends WireMockServer implements MethodRule, TestRule
                     after();
                     stop();
                 }
-			}
+    		}
 
-		};
-	}
+    	};
+    }
 
     private void checkForUnmatchedRequests() {
         if (failOnUnmatchedRequests) {

--- a/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockStaticRule.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/junit/WireMockStaticRule.java
@@ -28,39 +28,39 @@ import org.junit.runners.model.Statement;
 @Deprecated
 public class WireMockStaticRule implements MethodRule {
 
-	private final WireMockServer wireMockServer;
-	
-	public WireMockStaticRule(int port) {
-		wireMockServer = new WireMockServer(port);
-		wireMockServer.start();
-		WireMock.configureFor("localhost", port);
-	}
-	
-	public WireMockStaticRule() {
-		this(Options.DEFAULT_PORT);
-	}
-	
-	public void stopServer() {
-		wireMockServer.stop();
-	}
+    private final WireMockServer wireMockServer;
+    
+    public WireMockStaticRule(int port) {
+    	wireMockServer = new WireMockServer(port);
+    	wireMockServer.start();
+    	WireMock.configureFor("localhost", port);
+    }
+    
+    public WireMockStaticRule() {
+    	this(Options.DEFAULT_PORT);
+    }
+    
+    public void stopServer() {
+    	wireMockServer.stop();
+    }
 
-	@Override
-	public Statement apply(final Statement base, final FrameworkMethod method, Object target) {
-		return new Statement() {
+    @Override
+    public Statement apply(final Statement base, final FrameworkMethod method, Object target) {
+    	return new Statement() {
 
-			@Override
-			public void evaluate() throws Throwable {
-				try {
+    		@Override
+    		public void evaluate() throws Throwable {
+    			try {
                     before();
                     base.evaluate();
                 } finally {
                     after();
                     WireMock.reset();
                 }
-			}
-			
-		};
-	}
+    		}
+    		
+    	};
+    }
 
     protected void before() {
         // NOOP

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -57,12 +57,12 @@ import static com.github.tomakehurst.wiremock.http.CaseInsensitiveKey.TO_CASE_IN
 public class CommandLineOptions implements Options {
 
     private static final String HELP = "help";
-	private static final String RECORD_MAPPINGS = "record-mappings";
-	private static final String MATCH_HEADERS = "match-headers";
-	private static final String PROXY_ALL = "proxy-all";
+    private static final String RECORD_MAPPINGS = "record-mappings";
+    private static final String MATCH_HEADERS = "match-headers";
+    private static final String PROXY_ALL = "proxy-all";
     private static final String PRESERVE_HOST_HEADER = "preserve-host-header";
     private static final String PROXY_VIA = "proxy-via";
-	private static final String PORT = "port";
+    private static final String PORT = "port";
     private static final String BIND_ADDRESS = "bind-address";
     private static final String HTTPS_PORT = "https-port";
     private static final String HTTPS_KEYSTORE = "https-keystore";
@@ -104,8 +104,8 @@ public class CommandLineOptions implements Options {
     private Optional<Integer> resultingPort;
 
     public CommandLineOptions(String... args) {
-		OptionParser optionParser = new OptionParser();
-		optionParser.accepts(PORT, "The port number for the server to listen on (default: 8080). 0 for dynamic port selection.").withRequiredArg();
+    	OptionParser optionParser = new OptionParser();
+    	optionParser.accepts(PORT, "The port number for the server to listen on (default: 8080). 0 for dynamic port selection.").withRequiredArg();
         optionParser.accepts(HTTPS_PORT, "If this option is present WireMock will enable HTTPS on the specified port").withRequiredArg();
         optionParser.accepts(BIND_ADDRESS, "The IP to listen connections").withRequiredArg();
         optionParser.accepts(CONTAINER_THREADS, "The number of container threads").withRequiredArg();
@@ -117,11 +117,11 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(PROXY_ALL, "Will create a proxy mapping for /* to the specified URL").withRequiredArg();
         optionParser.accepts(PRESERVE_HOST_HEADER, "Will transfer the original host header from the client to the proxied service");
         optionParser.accepts(PROXY_VIA, "Specifies a proxy server to use when routing proxy mapped requests").withRequiredArg();
-		optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
-		optionParser.accepts(MATCH_HEADERS, "Enable request header matching when recording through a proxy").withRequiredArg();
-		optionParser.accepts(ROOT_DIR, "Specifies path for storing recordings (parent for " + MAPPINGS_ROOT + " and " + WireMockApp.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
-		optionParser.accepts(VERBOSE, "Enable verbose logging to stdout");
-		optionParser.accepts(ENABLE_BROWSER_PROXYING, "Allow wiremock to be set as a browser's proxy server");
+    	optionParser.accepts(RECORD_MAPPINGS, "Enable recording of all (non-admin) requests as mapping files");
+    	optionParser.accepts(MATCH_HEADERS, "Enable request header matching when recording through a proxy").withRequiredArg();
+    	optionParser.accepts(ROOT_DIR, "Specifies path for storing recordings (parent for " + MAPPINGS_ROOT + " and " + WireMockApp.FILES_ROOT + " folders)").withRequiredArg().defaultsTo(".");
+    	optionParser.accepts(VERBOSE, "Enable verbose logging to stdout");
+    	optionParser.accepts(ENABLE_BROWSER_PROXYING, "Allow wiremock to be set as a browser's proxy server");
         optionParser.accepts(DISABLE_REQUEST_JOURNAL, "Disable the request journal (to avoid heap growth when running wiremock for long periods without reset)");
         optionParser.accepts(DISABLE_BANNER, "Disable print banner logo");
         optionParser.accepts(EXTENSIONS, "Matching and/or response transformer extension class names, comma separated.").withRequiredArg();
@@ -145,15 +145,15 @@ public class CommandLineOptions implements Options {
 
         optionParser.accepts(HELP, "Print this message");
 
-		optionSet = optionParser.parse(args);
+    	optionSet = optionParser.parse(args);
         validate();
-		captureHelpTextIfRequested(optionParser);
+    	captureHelpTextIfRequested(optionParser);
 
         fileSource = new SingleRootFileSource((String) optionSet.valueOf(ROOT_DIR));
         mappingsSource = new JsonFileMappingsSource(fileSource.child(MAPPINGS_ROOT));
 
         resultingPort = Optional.absent();
-	}
+    }
 
     private void validate() {
         if (optionSet.has(HTTPS_KEYSTORE) && !optionSet.has(HTTPS_PORT)) {
@@ -166,36 +166,36 @@ public class CommandLineOptions implements Options {
     }
 
     private void captureHelpTextIfRequested(OptionParser optionParser) {
-		if (optionSet.has(HELP)) {
-			StringWriter out = new StringWriter();
-			try {
-				optionParser.printHelpOn(out);
-			} catch (IOException e) {
-				throw new RuntimeException(e);
-			}
+    	if (optionSet.has(HELP)) {
+    		StringWriter out = new StringWriter();
+    		try {
+    			optionParser.printHelpOn(out);
+    		} catch (IOException e) {
+    			throw new RuntimeException(e);
+    		}
 
-			helpText = out.toString();
-		}
-	}
+    		helpText = out.toString();
+    	}
+    }
 
-	public boolean verboseLoggingEnabled() {
-		return optionSet.has(VERBOSE);
-	}
+    public boolean verboseLoggingEnabled() {
+    	return optionSet.has(VERBOSE);
+    }
 
-	public boolean recordMappingsEnabled() {
-		return optionSet.has(RECORD_MAPPINGS);
-	}
+    public boolean recordMappingsEnabled() {
+    	return optionSet.has(RECORD_MAPPINGS);
+    }
 
-	@Override
-	public List<CaseInsensitiveKey> matchingHeaders() {
-		if (optionSet.hasArgument(MATCH_HEADERS)) {
-			String headerSpec = (String) optionSet.valueOf(MATCH_HEADERS);
+    @Override
+    public List<CaseInsensitiveKey> matchingHeaders() {
+    	if (optionSet.hasArgument(MATCH_HEADERS)) {
+    		String headerSpec = (String) optionSet.valueOf(MATCH_HEADERS);
             UnmodifiableIterator<String> headerKeys = Iterators.forArray(headerSpec.split(","));
             return ImmutableList.copyOf(Iterators.transform(headerKeys, TO_CASE_INSENSITIVE_KEYS));
-		}
+    	}
 
-		return Collections.emptyList();
-	}
+    	return Collections.emptyList();
+    }
 
     @Override
     public HttpServerFactory httpServerFactory() {
@@ -216,25 +216,25 @@ public class CommandLineOptions implements Options {
     }
 
     private boolean specifiesPortNumber() {
-		return optionSet.has(PORT);
-	}
+    	return optionSet.has(PORT);
+    }
 
-	@Override
+    @Override
     public int portNumber() {
         if (specifiesPortNumber()) {
             return Integer.parseInt((String) optionSet.valueOf(PORT));
         }
 
         return DEFAULT_PORT;
-	}
+    }
 
-	public void setResultingPort(int port) {
-		resultingPort = Optional.of(port);
-	}
+    public void setResultingPort(int port) {
+    	resultingPort = Optional.of(port);
+    }
 
     @Override
     public String bindAddress(){
-	if (optionSet.has(BIND_ADDRESS)) {
+    if (optionSet.has(BIND_ADDRESS)) {
             return (String) optionSet.valueOf(BIND_ADDRESS);
         }
 
@@ -283,20 +283,20 @@ public class CommandLineOptions implements Options {
     }
 
     public boolean help() {
-		return optionSet.has(HELP);
-	}
+    	return optionSet.has(HELP);
+    }
 
-	public String helpText() {
-		return helpText;
-	}
+    public String helpText() {
+    	return helpText;
+    }
 
-	public boolean specifiesProxyUrl() {
-		return optionSet.has(PROXY_ALL);
-	}
+    public boolean specifiesProxyUrl() {
+    	return optionSet.has(PROXY_ALL);
+    }
 
-	public String proxyUrl() {
-		return (String) optionSet.valueOf(PROXY_ALL);
-	}
+    public String proxyUrl() {
+    	return (String) optionSet.valueOf(PROXY_ALL);
+    }
 
     @Override
     public boolean shouldPreserveHostHeader() {
@@ -374,8 +374,8 @@ public class CommandLineOptions implements Options {
 
     @Override
     public boolean browserProxyingEnabled() {
-		return optionSet.has(ENABLE_BROWSER_PROXYING);
-	}
+    	return optionSet.has(ENABLE_BROWSER_PROXYING);
+    }
 
     @Override
     public ProxySettings proxyVia() {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSource.java
@@ -35,102 +35,102 @@ import static com.google.common.collect.Iterables.filter;
 
 public class JsonFileMappingsSource implements MappingsSource {
 
-	private final FileSource mappingsFileSource;
-	private final Map<UUID, StubMappingFileMetadata> fileNameMap;
+    private final FileSource mappingsFileSource;
+    private final Map<UUID, StubMappingFileMetadata> fileNameMap;
 
-	public JsonFileMappingsSource(FileSource mappingsFileSource) {
-		this.mappingsFileSource = mappingsFileSource;
-		fileNameMap = new HashMap<>();
-	}
+    public JsonFileMappingsSource(FileSource mappingsFileSource) {
+    	this.mappingsFileSource = mappingsFileSource;
+    	fileNameMap = new HashMap<>();
+    }
 
-	@Override
-	public void save(List<StubMapping> stubMappings) {
-		for (StubMapping mapping: stubMappings) {
-			if (mapping != null && mapping.isDirty()) {
-				save(mapping);
-			}
-		}
-	}
+    @Override
+    public void save(List<StubMapping> stubMappings) {
+    	for (StubMapping mapping: stubMappings) {
+    		if (mapping != null && mapping.isDirty()) {
+    			save(mapping);
+    		}
+    	}
+    }
 
-	@Override
-	public void save(StubMapping stubMapping) {
-		StubMappingFileMetadata fileMetadata = fileNameMap.get(stubMapping.getId());
-		if (fileMetadata == null) {
-			fileMetadata = new StubMappingFileMetadata(SafeNames.makeSafeFileName(stubMapping), false);
-		}
+    @Override
+    public void save(StubMapping stubMapping) {
+    	StubMappingFileMetadata fileMetadata = fileNameMap.get(stubMapping.getId());
+    	if (fileMetadata == null) {
+    		fileMetadata = new StubMappingFileMetadata(SafeNames.makeSafeFileName(stubMapping), false);
+    	}
 
-		if (fileMetadata.multi) {
-			throw new NotWritableException("Stubs loaded from multi-mapping files are read-only, and therefore cannot be saved");
-		}
+    	if (fileMetadata.multi) {
+    		throw new NotWritableException("Stubs loaded from multi-mapping files are read-only, and therefore cannot be saved");
+    	}
 
-		mappingsFileSource.writeTextFile(fileMetadata.path, writePrivate(stubMapping));
+    	mappingsFileSource.writeTextFile(fileMetadata.path, writePrivate(stubMapping));
 
         fileNameMap.put(stubMapping.getId(), fileMetadata);
-		stubMapping.setDirty(false);
-	}
+    	stubMapping.setDirty(false);
+    }
 
     @Override
     public void remove(StubMapping stubMapping) {
-		StubMappingFileMetadata fileMetadata = fileNameMap.get(stubMapping.getId());
-		if (fileMetadata.multi) {
-			throw new NotWritableException("Stubs loaded from multi-mapping files are read-only, and therefore cannot be removed");
-		}
+    	StubMappingFileMetadata fileMetadata = fileNameMap.get(stubMapping.getId());
+    	if (fileMetadata.multi) {
+    		throw new NotWritableException("Stubs loaded from multi-mapping files are read-only, and therefore cannot be removed");
+    	}
 
-		mappingsFileSource.deleteFile(fileMetadata.path);
+    	mappingsFileSource.deleteFile(fileMetadata.path);
         fileNameMap.remove(stubMapping.getId());
     }
 
-	@Override
-	public void removeAll() {
-		if (anyFilesAreMultiMapping()) {
-			throw new NotWritableException("Some stubs were loaded from multi-mapping files which are read-only, so remove all cannot be performed");
-		}
+    @Override
+    public void removeAll() {
+    	if (anyFilesAreMultiMapping()) {
+    		throw new NotWritableException("Some stubs were loaded from multi-mapping files which are read-only, so remove all cannot be performed");
+    	}
 
-		for (StubMappingFileMetadata fileMetadata: fileNameMap.values()) {
-			mappingsFileSource.deleteFile(fileMetadata.path);
-		}
-		fileNameMap.clear();
-	}
+    	for (StubMappingFileMetadata fileMetadata: fileNameMap.values()) {
+    		mappingsFileSource.deleteFile(fileMetadata.path);
+    	}
+    	fileNameMap.clear();
+    }
 
-	private boolean anyFilesAreMultiMapping() {
-		return any(fileNameMap.values(), new Predicate<StubMappingFileMetadata>() {
-			@Override
-			public boolean apply(StubMappingFileMetadata input) {
-				return input.multi;
-			}
-		});
-	}
+    private boolean anyFilesAreMultiMapping() {
+    	return any(fileNameMap.values(), new Predicate<StubMappingFileMetadata>() {
+    		@Override
+    		public boolean apply(StubMappingFileMetadata input) {
+    			return input.multi;
+    		}
+    	});
+    }
 
-	@Override
-	public void loadMappingsInto(StubMappings stubMappings) {
-		if (!mappingsFileSource.exists()) {
-			return;
-		}
+    @Override
+    public void loadMappingsInto(StubMappings stubMappings) {
+    	if (!mappingsFileSource.exists()) {
+    		return;
+    	}
 
-		Iterable<TextFile> mappingFiles = filter(mappingsFileSource.listFilesRecursively(), byFileExtension("json"));
-		for (TextFile mappingFile: mappingFiles) {
-			try {
-				StubMappingCollection stubCollection = Json.read(mappingFile.readContentsAsString(), StubMappingCollection.class);
-				for (StubMapping mapping: stubCollection.getMappingOrMappings()) {
-					mapping.setDirty(false);
-					stubMappings.addMapping(mapping);
-					StubMappingFileMetadata fileMetadata = new StubMappingFileMetadata(mappingFile.getPath(), stubCollection.isMulti());
-					fileNameMap.put(mapping.getId(), fileMetadata);
-				}
-			} catch (JsonException e) {
-				throw new MappingFileException(mappingFile.getPath(), e.getErrors().first().getDetail());
-			}
-		}
-	}
+    	Iterable<TextFile> mappingFiles = filter(mappingsFileSource.listFilesRecursively(), byFileExtension("json"));
+    	for (TextFile mappingFile: mappingFiles) {
+    		try {
+    			StubMappingCollection stubCollection = Json.read(mappingFile.readContentsAsString(), StubMappingCollection.class);
+    			for (StubMapping mapping: stubCollection.getMappingOrMappings()) {
+    				mapping.setDirty(false);
+    				stubMappings.addMapping(mapping);
+    				StubMappingFileMetadata fileMetadata = new StubMappingFileMetadata(mappingFile.getPath(), stubCollection.isMulti());
+    				fileNameMap.put(mapping.getId(), fileMetadata);
+    			}
+    		} catch (JsonException e) {
+    			throw new MappingFileException(mappingFile.getPath(), e.getErrors().first().getDetail());
+    		}
+    	}
+    }
 
-	private static class StubMappingFileMetadata {
-		final String path;
-		final boolean multi;
+    private static class StubMappingFileMetadata {
+    	final String path;
+    	final boolean multi;
 
-		public StubMappingFileMetadata(String path, boolean multi) {
-			this.path = path;
-			this.multi = multi;
-		}
-	}
+    	public StubMappingFileMetadata(String path, boolean multi) {
+    		this.path = path;
+    		this.multi = multi;
+    	}
+    }
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/MappingsLoader.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/MappingsLoader.java
@@ -19,6 +19,6 @@ import com.github.tomakehurst.wiremock.stubbing.StubMappings;
 
 public interface MappingsLoader {
 
-	void loadMappingsInto(StubMappings stubMappings);
+    void loadMappingsInto(StubMappings stubMappings);
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -46,21 +46,21 @@ public class WireMockServerRunner {
         System.setProperty("org.mortbay.log.class", "com.github.tomakehurst.wiremock.jetty.LoggerAdapter");
     }
 
-	private WireMockServer wireMockServer;
-	
-	public void run(String... args) {
-		CommandLineOptions options = new CommandLineOptions(args);
-		if (options.help()) {
-			out.println(options.helpText());
-			return;
-		}
+    private WireMockServer wireMockServer;
+    
+    public void run(String... args) {
+    	CommandLineOptions options = new CommandLineOptions(args);
+    	if (options.help()) {
+    		out.println(options.helpText());
+    		return;
+    	}
 
-		FileSource fileSource = options.filesRoot();
-		fileSource.createIfNecessary();
-		FileSource filesFileSource = fileSource.child(FILES_ROOT);
-		filesFileSource.createIfNecessary();
-		FileSource mappingsFileSource = fileSource.child(MAPPINGS_ROOT);
-		mappingsFileSource.createIfNecessary();
+    	FileSource fileSource = options.filesRoot();
+    	fileSource.createIfNecessary();
+    	FileSource filesFileSource = fileSource.child(FILES_ROOT);
+    	filesFileSource.createIfNecessary();
+    	FileSource mappingsFileSource = fileSource.child(MAPPINGS_ROOT);
+    	mappingsFileSource.createIfNecessary();
 
         wireMockServer = new WireMockServer(options);
 
@@ -68,9 +68,9 @@ public class WireMockServerRunner {
             wireMockServer.enableRecordMappings(mappingsFileSource, filesFileSource);
         }
 
-		if (options.specifiesProxyUrl()) {
-			addProxyMapping(options.proxyUrl());
-		}
+    	if (options.specifiesProxyUrl()) {
+    		addProxyMapping(options.proxyUrl());
+    	}
 
         try {
             wireMockServer.start();
@@ -88,40 +88,40 @@ public class WireMockServerRunner {
             System.exit(1);
         }
     }
-	
-	private void addProxyMapping(final String baseUrl) {
-		wireMockServer.loadMappingsUsing(new MappingsLoader() {
-			@Override
-			public void loadMappingsInto(StubMappings stubMappings) {
+    
+    private void addProxyMapping(final String baseUrl) {
+    	wireMockServer.loadMappingsUsing(new MappingsLoader() {
+    		@Override
+    		public void loadMappingsInto(StubMappings stubMappings) {
                 RequestPattern requestPattern = newRequestPattern(ANY, anyUrl()).build();
-				ResponseDefinition responseDef = responseDefinition()
-						.proxiedFrom(baseUrl)
-						.build();
+    			ResponseDefinition responseDef = responseDefinition()
+    					.proxiedFrom(baseUrl)
+    					.build();
 
-				StubMapping proxyBasedMapping = new StubMapping(requestPattern, responseDef);
-				proxyBasedMapping.setPriority(10); // Make it low priority so that existing stubs will take precedence
-				stubMappings.addMapping(proxyBasedMapping);
-			}
-		});
-	}
-	
-	public void stop() {
-		if (wireMockServer != null) {
-			wireMockServer.stop();
-		}
-	}
+    			StubMapping proxyBasedMapping = new StubMapping(requestPattern, responseDef);
+    			proxyBasedMapping.setPriority(10); // Make it low priority so that existing stubs will take precedence
+    			stubMappings.addMapping(proxyBasedMapping);
+    		}
+    	});
+    }
+    
+    public void stop() {
+    	if (wireMockServer != null) {
+    		wireMockServer.stop();
+    	}
+    }
 
     public boolean isRunning() {
-		if (wireMockServer == null) {
-			return false;
-		} else {
-			return wireMockServer.isRunning();
-		}
+    	if (wireMockServer == null) {
+    		return false;
+    	} else {
+    		return wireMockServer.isRunning();
+    	}
     }
 
     public int port() { return wireMockServer.port(); }
 
-	public static void main(String... args) {
-		new WireMockServerRunner().run(args);
-	}
+    public static void main(String... args) {
+    	new WireMockServerRunner().run(args);
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/Scenario.java
@@ -31,15 +31,15 @@ import static com.google.common.collect.FluentIterable.from;
 
 public class Scenario {
 
-	public static final String STARTED = "Started";
+    public static final String STARTED = "Started";
 
-	private final UUID id;
-	private final String name;
-	private final String state;
-	private final Set<StubMapping> stubMappings;
+    private final UUID id;
+    private final String name;
+    private final String state;
+    private final Set<StubMapping> stubMappings;
 
-	@JsonCreator
-	public Scenario(@JsonProperty("id") UUID id,
+    @JsonCreator
+    public Scenario(@JsonProperty("id") UUID id,
                     @JsonProperty("name") String name,
                     @JsonProperty("state") String currentState,
                     @JsonProperty("possibleStates") Set<String> ignored,
@@ -49,10 +49,10 @@ public class Scenario {
         this.state = currentState;
         this.stubMappings = stubMappings;
     }
-	
-	public static Scenario inStartedState(String name) {
-		return new Scenario(UUID.randomUUID(), name, STARTED, ImmutableSet.of(STARTED), Collections.<StubMapping>emptySet());
-	}
+    
+    public static Scenario inStartedState(String name) {
+    	return new Scenario(UUID.randomUUID(), name, STARTED, ImmutableSet.of(STARTED), Collections.<StubMapping>emptySet());
+    }
 
     public UUID getId() {
         return id;
@@ -63,8 +63,8 @@ public class Scenario {
     }
 
     public String getState() {
-		return state;
-	}
+    	return state;
+    }
 
     public Set<String> getPossibleStates() {
         FluentIterable<String> requiredStates = from(stubMappings)
@@ -92,12 +92,12 @@ public class Scenario {
     }
 
     Scenario setState(String newState) {
-		return new Scenario(id, name, newState, null, stubMappings);
-	}
+    	return new Scenario(id, name, newState, null, stubMappings);
+    }
 
-	Scenario reset() {
+    Scenario reset() {
         return new Scenario(id, name, STARTED, null, stubMappings);
-	}
+    }
 
     Scenario withStubMapping(StubMapping stubMapping) {
         Set<StubMapping> newMappings = ImmutableSet.<StubMapping>builder()
@@ -113,10 +113,10 @@ public class Scenario {
         return new Scenario(id, name, state, null, newMappings);
     }
 
-	@Override
-	public String toString() {
-		return Json.write(this);
-	}
+    @Override
+    public String toString() {
+    	return Json.write(this);
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -135,7 +135,7 @@ public class Scenario {
     }
 
     public static final Predicate<Scenario> withName(final String name) {
-	    return new Predicate<Scenario>() {
+        return new Predicate<Scenario>() {
             @Override
             public boolean apply(Scenario input) {
                 return input.getName().equals(name);

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSet.java
@@ -26,39 +26,39 @@ import static com.google.common.collect.Iterables.removeIf;
 
 public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
 
-	private AtomicLong insertionCount;
-	private ConcurrentSkipListSet<StubMapping> mappingSet;
-	
-	public SortedConcurrentMappingSet() {
-		insertionCount = new AtomicLong();
-		mappingSet = new ConcurrentSkipListSet<StubMapping>(sortedByPriorityThenReverseInsertionOrder());
-	}
-	
-	private Comparator<StubMapping> sortedByPriorityThenReverseInsertionOrder() {
-		return new Comparator<StubMapping>() {
-			public int compare(StubMapping one, StubMapping two) {
-				int priorityComparison = one.comparePriorityWith(two);
-				if (priorityComparison != 0) {
-					return priorityComparison;
-				}
+    private AtomicLong insertionCount;
+    private ConcurrentSkipListSet<StubMapping> mappingSet;
+    
+    public SortedConcurrentMappingSet() {
+    	insertionCount = new AtomicLong();
+    	mappingSet = new ConcurrentSkipListSet<StubMapping>(sortedByPriorityThenReverseInsertionOrder());
+    }
+    
+    private Comparator<StubMapping> sortedByPriorityThenReverseInsertionOrder() {
+    	return new Comparator<StubMapping>() {
+    		public int compare(StubMapping one, StubMapping two) {
+    			int priorityComparison = one.comparePriorityWith(two);
+    			if (priorityComparison != 0) {
+    				return priorityComparison;
+    			}
 
-				return Long.compare(two.getInsertionIndex(), one.getInsertionIndex());
-			}
-		};
-	}
+    			return Long.compare(two.getInsertionIndex(), one.getInsertionIndex());
+    		}
+    	};
+    }
 
-	@Override
-	public Iterator<StubMapping> iterator() {
-		return mappingSet.iterator();
-	}
-	
-	public void add(StubMapping mapping) {
-		mapping.setInsertionIndex(insertionCount.getAndIncrement());
-		mappingSet.add(mapping);
-	}
+    @Override
+    public Iterator<StubMapping> iterator() {
+    	return mappingSet.iterator();
+    }
+    
+    public void add(StubMapping mapping) {
+    	mapping.setInsertionIndex(insertionCount.getAndIncrement());
+    	mappingSet.add(mapping);
+    }
 
-	public boolean remove(final StubMapping mappingToRemove) {
-		boolean removedByUuid = removeIf(mappingSet, new Predicate<StubMapping>() {
+    public boolean remove(final StubMapping mappingToRemove) {
+    	boolean removedByUuid = removeIf(mappingSet, new Predicate<StubMapping>() {
             @Override
             public boolean apply(StubMapping mapping) {
                 return mappingToRemove.getUuid() != null &&
@@ -75,23 +75,23 @@ public class SortedConcurrentMappingSet implements Iterable<StubMapping> {
         });
 
         return removedByUuid || removedByRequestPattern;
-	}
+    }
 
-	public boolean replace(StubMapping existingStubMapping, StubMapping newStubMapping) {
+    public boolean replace(StubMapping existingStubMapping, StubMapping newStubMapping) {
 
-		if ( mappingSet.remove(existingStubMapping) ) {
-			mappingSet.add(newStubMapping);
-			return true;
-		}
-		return false;
-	}
+    	if ( mappingSet.remove(existingStubMapping) ) {
+    		mappingSet.add(newStubMapping);
+    		return true;
+    	}
+    	return false;
+    }
 
-	public void clear() {
-		mappingSet.clear();
-	}
-	
-	@Override
-	public String toString() {
-		return mappingSet.toString();
-	}
+    public void clear() {
+    	mappingSet.clear();
+    }
+    
+    @Override
+    public String toString() {
+    	return mappingSet.toString();
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMapping.java
@@ -34,71 +34,71 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @JsonPropertyOrder({ "id", "name", "request", "newRequest", "response", "uuid" })
 @JsonIgnoreProperties({ "$schema" }) // Allows this to be added as a hint to IDEs like VS Code
 public class StubMapping {
-	
-	public static final int DEFAULT_PRIORITY = 5; 
+    
+    public static final int DEFAULT_PRIORITY = 5; 
 
-	private UUID uuid = UUID.randomUUID();
-	private String name;
+    private UUID uuid = UUID.randomUUID();
+    private String name;
 
-	private boolean persistent;
+    private boolean persistent;
 
-	private RequestPattern request;
-	private ResponseDefinition response;
-	private Integer priority;
-	private String scenarioName;
-	private String requiredScenarioState;
-	private String newScenarioState;
+    private RequestPattern request;
+    private ResponseDefinition response;
+    private Integer priority;
+    private String scenarioName;
+    private String requiredScenarioState;
+    private String newScenarioState;
 
     private Map<String, Parameters> postServeActions;
 
     private Metadata metadata;
 
-	private long insertionIndex;
-	private boolean isDirty = true;
+    private long insertionIndex;
+    private boolean isDirty = true;
 
-	public StubMapping(RequestPattern requestPattern, ResponseDefinition response) {
-		setRequest(requestPattern);
-		this.response = response;
-	}
+    public StubMapping(RequestPattern requestPattern, ResponseDefinition response) {
+    	setRequest(requestPattern);
+    	this.response = response;
+    }
 
-	public StubMapping() {
-		//Concession to Jackson
-	}
+    public StubMapping() {
+    	//Concession to Jackson
+    }
 
-	public static final StubMapping NOT_CONFIGURED =
-	    new StubMapping(null, ResponseDefinition.notConfigured());
+    public static final StubMapping NOT_CONFIGURED =
+        new StubMapping(null, ResponseDefinition.notConfigured());
 
     public static StubMapping buildFrom(String mappingSpecJson) {
         return Json.read(mappingSpecJson, StubMapping.class);
     }
 
     public static String buildJsonStringFor(StubMapping mapping) {
-		return Json.write(mapping);
-	}
+    	return Json.write(mapping);
+    }
 
-	public UUID getUuid() {
-		return uuid;
-	}
+    public UUID getUuid() {
+    	return uuid;
+    }
 
-	public void setId(UUID uuid) {
-		this.uuid = uuid;
-	}
+    public void setId(UUID uuid) {
+    	this.uuid = uuid;
+    }
 
-	public UUID getId() {
-		return uuid;
-	}
+    public UUID getId() {
+    	return uuid;
+    }
 
-	public String getName() {
-    	return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setName(String name) {
-    	this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public void setUuid(UUID uuid) {
-		this.uuid = uuid;
-	}
+    public void setUuid(UUID uuid) {
+    	this.uuid = uuid;
+    }
 
     public boolean shouldBePersisted() {
         return persistent;
@@ -113,34 +113,34 @@ public class StubMapping {
     }
 
     public RequestPattern getRequest() {
-		return firstNonNull(request, RequestPattern.ANYTHING);
-	}
+    	return firstNonNull(request, RequestPattern.ANYTHING);
+    }
 
-	public ResponseDefinition getResponse() {
-		return firstNonNull(response, ResponseDefinition.ok());
-	}
+    public ResponseDefinition getResponse() {
+    	return firstNonNull(response, ResponseDefinition.ok());
+    }
 
-	public void setRequest(RequestPattern request) {
-		this.request = request;
-	}
+    public void setRequest(RequestPattern request) {
+    	this.request = request;
+    }
 
-	public void setResponse(ResponseDefinition response) {
-		this.response = response;
-	}
+    public void setResponse(ResponseDefinition response) {
+    	this.response = response;
+    }
 
     @Override
-	public String toString() {
-		return Json.write(this);
-	}
+    public String toString() {
+    	return Json.write(this);
+    }
 
-	@JsonView(Json.PrivateView.class)
-	public long getInsertionIndex() {
-		return insertionIndex;
-	}
+    @JsonView(Json.PrivateView.class)
+    public long getInsertionIndex() {
+    	return insertionIndex;
+    }
 
-	public void setInsertionIndex(long insertionIndex) {
-		this.insertionIndex = insertionIndex;
-	}
+    public void setInsertionIndex(long insertionIndex) {
+    	this.insertionIndex = insertionIndex;
+    }
 
     @JsonIgnore
     public boolean isDirty() {
@@ -152,58 +152,58 @@ public class StubMapping {
         this.isDirty = isDirty;
     }
 
-	public Integer getPriority() {
-		return priority;
-	}
+    public Integer getPriority() {
+    	return priority;
+    }
 
-	public void setPriority(Integer priority) {
-		this.priority = priority;
-	}
+    public void setPriority(Integer priority) {
+    	this.priority = priority;
+    }
 
-	public String getScenarioName() {
-		return scenarioName;
-	}
+    public String getScenarioName() {
+    	return scenarioName;
+    }
 
-	public void setScenarioName(String scenarioName) {
-		this.scenarioName = scenarioName;
-	}
+    public void setScenarioName(String scenarioName) {
+    	this.scenarioName = scenarioName;
+    }
 
-	public String getRequiredScenarioState() {
-		return requiredScenarioState;
-	}
+    public String getRequiredScenarioState() {
+    	return requiredScenarioState;
+    }
 
-	public void setRequiredScenarioState(String requiredScenarioState) {
-		this.requiredScenarioState = requiredScenarioState;
-	}
+    public void setRequiredScenarioState(String requiredScenarioState) {
+    	this.requiredScenarioState = requiredScenarioState;
+    }
 
-	public String getNewScenarioState() {
-		return newScenarioState;
-	}
+    public String getNewScenarioState() {
+    	return newScenarioState;
+    }
 
-	public void setNewScenarioState(String newScenarioState) {
-		this.newScenarioState = newScenarioState;
-	}
+    public void setNewScenarioState(String newScenarioState) {
+    	this.newScenarioState = newScenarioState;
+    }
 
-	@JsonIgnore
-	public boolean isInScenario() {
-		return scenarioName != null;
-	}
+    @JsonIgnore
+    public boolean isInScenario() {
+    	return scenarioName != null;
+    }
 
-	@JsonIgnore
-	public boolean modifiesScenarioState() {
-		return newScenarioState != null;
-	}
+    @JsonIgnore
+    public boolean modifiesScenarioState() {
+    	return newScenarioState != null;
+    }
 
-	@JsonIgnore
-	public boolean isIndependentOfScenarioState() {
-		return !isInScenario() || requiredScenarioState == null;
-	}
+    @JsonIgnore
+    public boolean isIndependentOfScenarioState() {
+    	return !isInScenario() || requiredScenarioState == null;
+    }
 
-	public int comparePriorityWith(StubMapping otherMapping) {
-		int thisPriority = priority != null ? priority : DEFAULT_PRIORITY;
-		int otherPriority = otherMapping.priority != null ? otherMapping.priority : DEFAULT_PRIORITY;
-		return thisPriority - otherPriority;
-	}
+    public int comparePriorityWith(StubMapping otherMapping) {
+    	int thisPriority = priority != null ? priority : DEFAULT_PRIORITY;
+    	int otherPriority = otherMapping.priority != null ? otherMapping.priority : DEFAULT_PRIORITY;
+    	return thisPriority - otherPriority;
+    }
 
     public Map<String, Parameters> getPostServeActions() {
         return postServeActions;
@@ -222,24 +222,24 @@ public class StubMapping {
     }
 
     @Override
-	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
-		StubMapping that = (StubMapping) o;
-		return isDirty == that.isDirty &&
-			Objects.equals(uuid, that.uuid) &&
-			Objects.equals(request, that.request) &&
-			Objects.equals(response, that.response) &&
-			Objects.equals(priority, that.priority) &&
-			Objects.equals(scenarioName, that.scenarioName) &&
-			Objects.equals(requiredScenarioState, that.requiredScenarioState) &&
-			Objects.equals(newScenarioState, that.newScenarioState) &&
-			Objects.equals(postServeActions, that.postServeActions) &&
-			Objects.equals(metadata, that.metadata);
-	}
+    public boolean equals(Object o) {
+    	if (this == o) return true;
+    	if (o == null || getClass() != o.getClass()) return false;
+    	StubMapping that = (StubMapping) o;
+    	return isDirty == that.isDirty &&
+    		Objects.equals(uuid, that.uuid) &&
+    		Objects.equals(request, that.request) &&
+    		Objects.equals(response, that.response) &&
+    		Objects.equals(priority, that.priority) &&
+    		Objects.equals(scenarioName, that.scenarioName) &&
+    		Objects.equals(requiredScenarioState, that.requiredScenarioState) &&
+    		Objects.equals(newScenarioState, that.newScenarioState) &&
+    		Objects.equals(postServeActions, that.postServeActions) &&
+    		Objects.equals(metadata, that.metadata);
+    }
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(uuid, request, response, priority, scenarioName, requiredScenarioState, newScenarioState, postServeActions, metadata, isDirty);
-	}
+    @Override
+    public int hashCode() {
+    	return Objects.hash(uuid, request, response, priority, scenarioName, requiredScenarioState, newScenarioState, postServeActions, metadata, isDirty);
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/stubbing/StubMappings.java
@@ -26,17 +26,17 @@ import java.util.UUID;
 
 public interface StubMappings {
 
-	ServeEvent serveFor(Request request);
-	void addMapping(StubMapping mapping);
-	void removeMapping(StubMapping mapping);
-	void editMapping(StubMapping stubMapping);
-	void reset();
-	void resetScenarios();
+    ServeEvent serveFor(Request request);
+    void addMapping(StubMapping mapping);
+    void removeMapping(StubMapping mapping);
+    void editMapping(StubMapping stubMapping);
+    void reset();
+    void resetScenarios();
 
     List<StubMapping> getAll();
-	Optional<StubMapping> get(UUID id);
+    Optional<StubMapping> get(UUID id);
 
-	List<Scenario> getAllScenarios();
+    List<Scenario> getAllScenarios();
 
     List<StubMapping> findByMetadata(StringValuePattern pattern);
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournal.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/InMemoryRequestJournal.java
@@ -37,114 +37,114 @@ import static com.google.common.collect.Iterables.*;
 
 public class InMemoryRequestJournal implements RequestJournal {
 
-	private final Queue<ServeEvent> serveEvents = new ConcurrentLinkedQueue<ServeEvent>();
+    private final Queue<ServeEvent> serveEvents = new ConcurrentLinkedQueue<ServeEvent>();
 
-	private final Optional<Integer> maxEntries;
+    private final Optional<Integer> maxEntries;
 
-	public InMemoryRequestJournal(Optional<Integer> maxEntries) {
-		if (maxEntries.isPresent() && maxEntries.get() < 0) {
-			throw new IllegalArgumentException("Maximum number of entries of journal must be greater than zero");
-		}
-		this.maxEntries = maxEntries;
-	}
+    public InMemoryRequestJournal(Optional<Integer> maxEntries) {
+    	if (maxEntries.isPresent() && maxEntries.get() < 0) {
+    		throw new IllegalArgumentException("Maximum number of entries of journal must be greater than zero");
+    	}
+    	this.maxEntries = maxEntries;
+    }
 
-	@Override
-	public int countRequestsMatching(RequestPattern requestPattern) {
-		return size(filter(getRequests(), thatMatch(requestPattern)));
-	}
+    @Override
+    public int countRequestsMatching(RequestPattern requestPattern) {
+    	return size(filter(getRequests(), thatMatch(requestPattern)));
+    }
 
-	@Override
-	public List<LoggedRequest> getRequestsMatching(RequestPattern requestPattern) {
-		return ImmutableList.copyOf(filter(getRequests(), thatMatch(requestPattern)));
-	}
+    @Override
+    public List<LoggedRequest> getRequestsMatching(RequestPattern requestPattern) {
+    	return ImmutableList.copyOf(filter(getRequests(), thatMatch(requestPattern)));
+    }
 
-	@Override
-	public void requestReceived(ServeEvent serveEvent) {
-		serveEvents.add(serveEvent);
+    @Override
+    public void requestReceived(ServeEvent serveEvent) {
+    	serveEvents.add(serveEvent);
         removeOldEntries();
-	}
+    }
 
-	@Override
-	public void removeEvent(final UUID eventId) {
-		removeServeEvents(new Predicate<ServeEvent>() {
-			@Override
-			public boolean apply(ServeEvent input) {
-				return input.getId().equals(eventId);
-			}
-		});
-	}
+    @Override
+    public void removeEvent(final UUID eventId) {
+    	removeServeEvents(new Predicate<ServeEvent>() {
+    		@Override
+    		public boolean apply(ServeEvent input) {
+    			return input.getId().equals(eventId);
+    		}
+    	});
+    }
 
-	@Override
-	public List<ServeEvent> removeEventsMatching(RequestPattern requestPattern) {
-		return removeServeEvents(withRequstMatching(requestPattern));
-	}
+    @Override
+    public List<ServeEvent> removeEventsMatching(RequestPattern requestPattern) {
+    	return removeServeEvents(withRequstMatching(requestPattern));
+    }
 
-	@Override
-	public List<ServeEvent> removeServeEventsForStubsMatchingMetadata(StringValuePattern metadataPattern) {
-		return removeServeEvents(withStubMetadataMatching(metadataPattern));
-	}
+    @Override
+    public List<ServeEvent> removeServeEventsForStubsMatchingMetadata(StringValuePattern metadataPattern) {
+    	return removeServeEvents(withStubMetadataMatching(metadataPattern));
+    }
 
-	private List<ServeEvent> removeServeEvents(Predicate<ServeEvent> predicate) {
-		List<ServeEvent> toDelete = FluentIterable.from(serveEvents)
-				.filter(predicate)
-				.toList();
+    private List<ServeEvent> removeServeEvents(Predicate<ServeEvent> predicate) {
+    	List<ServeEvent> toDelete = FluentIterable.from(serveEvents)
+    			.filter(predicate)
+    			.toList();
 
-		for (ServeEvent event: toDelete) {
-			serveEvents.remove(event);
-		}
+    	for (ServeEvent event: toDelete) {
+    		serveEvents.remove(event);
+    	}
 
-		return toDelete;
-	}
+    	return toDelete;
+    }
 
-	@Override
+    @Override
     public List<ServeEvent> getAllServeEvents() {
         return ImmutableList.copyOf(serveEvents).reverse();
     }
 
-	@Override
-	public Optional<ServeEvent> getServeEvent(final UUID id) {
-		return tryFind(serveEvents, new Predicate<ServeEvent>() {
-			@Override
-			public boolean apply(ServeEvent input) {
-				return input.getId().equals(id);
-			}
-		});
-	}
+    @Override
+    public Optional<ServeEvent> getServeEvent(final UUID id) {
+    	return tryFind(serveEvents, new Predicate<ServeEvent>() {
+    		@Override
+    		public boolean apply(ServeEvent input) {
+    			return input.getId().equals(id);
+    		}
+    	});
+    }
 
-	@Override
-	public void reset() {
-		serveEvents.clear();
-	}
+    @Override
+    public void reset() {
+    	serveEvents.clear();
+    }
 
-	private Iterable<LoggedRequest> getRequests() {
-		return transform(serveEvents, new Function<ServeEvent, LoggedRequest>() {
-			public LoggedRequest apply(ServeEvent input) {
-				return input.getRequest();
-			}
-		});
-	}
+    private Iterable<LoggedRequest> getRequests() {
+    	return transform(serveEvents, new Function<ServeEvent, LoggedRequest>() {
+    		public LoggedRequest apply(ServeEvent input) {
+    			return input.getRequest();
+    		}
+    	});
+    }
 
-	private void removeOldEntries() {
-		if (maxEntries.isPresent()) {
-			while (serveEvents.size() > maxEntries.get()) {
-				serveEvents.poll();
-			}
-		}
-	}
+    private void removeOldEntries() {
+    	if (maxEntries.isPresent()) {
+    		while (serveEvents.size() > maxEntries.get()) {
+    			serveEvents.poll();
+    		}
+    	}
+    }
 
-	private static Predicate<ServeEvent> withStubMetadataMatching(final StringValuePattern metadataPattern) {
-		return new Predicate<ServeEvent>() {
-			@Override
-			public boolean apply(ServeEvent serveEvent) {
-				StubMapping stub = serveEvent.getStubMapping();
-				if (stub != null) {
-					String metadataJson = Json.write(stub.getMetadata());
-					return metadataPattern.match(metadataJson).isExactMatch();
-				}
+    private static Predicate<ServeEvent> withStubMetadataMatching(final StringValuePattern metadataPattern) {
+    	return new Predicate<ServeEvent>() {
+    		@Override
+    		public boolean apply(ServeEvent serveEvent) {
+    			StubMapping stub = serveEvent.getStubMapping();
+    			if (stub != null) {
+    				String metadataJson = Json.write(stub.getMetadata());
+    				return metadataPattern.match(metadataJson).isExactMatch();
+    			}
 
-				return false;
-			}
-		};
-	}
+    			return false;
+    		}
+    	};
+    }
 
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/RequestJournal.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/RequestJournal.java
@@ -25,13 +25,13 @@ import java.util.UUID;
 
 public interface RequestJournal {
 
-	int countRequestsMatching(RequestPattern requestPattern);
+    int countRequestsMatching(RequestPattern requestPattern);
     List<LoggedRequest> getRequestsMatching(RequestPattern requestPattern);
 
     List<ServeEvent> getAllServeEvents();
     Optional<ServeEvent> getServeEvent(UUID id);
 
-	void reset();
+    void reset();
 
     void requestReceived(ServeEvent serveEvent);
 

--- a/src/main/java/com/github/tomakehurst/wiremock/verification/VerificationResult.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/verification/VerificationResult.java
@@ -21,7 +21,7 @@ import com.github.tomakehurst.wiremock.common.Json;
 
 public class VerificationResult extends JournalBasedResult {
 
-	private final Integer count;
+    private final Integer count;
 
     @JsonCreator
     public VerificationResult(@JsonProperty("count") Integer count,
@@ -31,8 +31,8 @@ public class VerificationResult extends JournalBasedResult {
     }
 
     public static VerificationResult from(String json) {
-		return Json.read(json, VerificationResult.class);
-	}
+    	return Json.read(json, VerificationResult.class);
+    }
 
     public static VerificationResult withCount(int count) {
         return new VerificationResult(count, false);
@@ -43,7 +43,7 @@ public class VerificationResult extends JournalBasedResult {
     }
 
     public int getCount() {
-		return count;
-	}
+    	return count;
+    }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AcceptanceTestBase.java
@@ -38,52 +38,52 @@ import static com.github.tomakehurst.wiremock.testsupport.TestFiles.filePath;
 
 public class AcceptanceTestBase {
 
-	protected static WireMockServer wireMockServer;
-	protected static WireMockTestClient testClient;
+    protected static WireMockServer wireMockServer;
+    protected static WireMockTestClient testClient;
 
-	protected static Stubbing wm;
+    protected static Stubbing wm;
 
-	@BeforeClass
-	public static void setupServer() {
-		setupServerWithEmptyFileRoot();
+    @BeforeClass
+    public static void setupServer() {
+    	setupServerWithEmptyFileRoot();
 
-		// We assert English XML parser error messages in some tests. So we set our default locale to English to make
-		// those tests succeed even for users with non-English default locales.
-		Locale.setDefault(Locale.ENGLISH);
-	}
+    	// We assert English XML parser error messages in some tests. So we set our default locale to English to make
+    	// those tests succeed even for users with non-English default locales.
+    	Locale.setDefault(Locale.ENGLISH);
+    }
 
-	@AfterClass
-	public static void serverShutdown() {
-		wireMockServer.stop();
-	}
+    @AfterClass
+    public static void serverShutdown() {
+    	wireMockServer.stop();
+    }
 
-	public static void setupServerWithEmptyFileRoot() {
-		setupServer(wireMockConfig().withRootDirectory(filePath("empty")));
-	}
+    public static void setupServerWithEmptyFileRoot() {
+    	setupServer(wireMockConfig().withRootDirectory(filePath("empty")));
+    }
 
-	public static void setupServerWithTempFileRoot() {
-		setupServer(wireMockConfig().withRootDirectory(setupTempFileRoot().getAbsolutePath()));
-	}
+    public static void setupServerWithTempFileRoot() {
+    	setupServer(wireMockConfig().withRootDirectory(setupTempFileRoot().getAbsolutePath()));
+    }
 
     public static File setupTempFileRoot() {
-		try {
+    	try {
             File root = Files.createTempDirectory("wiremock").toFile();
             new File(root, MAPPINGS_ROOT).mkdirs();
             new File(root, FILES_ROOT).mkdirs();
             return root;
-		} catch (IOException e) {
-			return throwUnchecked(e, File.class);
-		}
-	}
+    	} catch (IOException e) {
+    		return throwUnchecked(e, File.class);
+    	}
+    }
 
-	public static void setupServerWithMappingsInFileRoot() {
-		setupServer(wireMockConfig().withRootDirectory(defaultTestFilesRoot()));
-	}
+    public static void setupServerWithMappingsInFileRoot() {
+    	setupServer(wireMockConfig().withRootDirectory(defaultTestFilesRoot()));
+    }
 
     public static void setupServer(WireMockConfiguration options) {
         System.out.println("Configuring WireMockServer with root directory: " + options.filesRoot().getPath());
         if(options.portNumber() == Options.DEFAULT_PORT) {
-			options.dynamicPort();
+    		options.dynamicPort();
         }
 
         wireMockServer = new WireMockServer(options);
@@ -93,9 +93,9 @@ public class AcceptanceTestBase {
         wm = wireMockServer;
     }
 
-	@Before
-	public void init() throws InterruptedException {
-		WireMock.resetToDefault();
-	}
+    @Before
+    public void init() throws InterruptedException {
+    	WireMock.resetToDefault();
+    }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/EditMappingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/EditMappingAcceptanceTest.java
@@ -25,59 +25,59 @@ import static org.junit.Assert.assertThat;
 
 public class EditMappingAcceptanceTest extends AcceptanceTestBase {
 
-	public static final String MAPPING_REQUEST_WITH_UUID =
-			"{ 	" +
-			"	\"uuid\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n" +
-			"	\"request\": {										\n" +
-			"		\"method\": \"GET\",							\n" +
-			"		\"url\": \"/a/registered/resource\"				\n" +
-			"	},													\n" +
-			"	\"response\": {										\n" +
-			"		\"status\": 401,								\n" +
-			"		\"headers\": {									\n" +
-			"			\"Content-Type\": \"text/plain\"			\n" +
-			"		},												\n" +
-			"		\"body\": \"Not allowed!\"						\n" +
-			"	}													\n" +
-			"}														";
+    public static final String MAPPING_REQUEST_WITH_UUID =
+    		"{ 	" +
+    		"	\"uuid\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n" +
+    		"	\"request\": {										\n" +
+    		"		\"method\": \"GET\",							\n" +
+    		"		\"url\": \"/a/registered/resource\"				\n" +
+    		"	},													\n" +
+    		"	\"response\": {										\n" +
+    		"		\"status\": 401,								\n" +
+    		"		\"headers\": {									\n" +
+    		"			\"Content-Type\": \"text/plain\"			\n" +
+    		"		},												\n" +
+    		"		\"body\": \"Not allowed!\"						\n" +
+    		"	}													\n" +
+    		"}														";
 
-	public static final String MODIFY_MAPPING_REQUEST_WITH_UUID =
-			"{ 	" +
-			"	\"uuid\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n" +
-			"	\"request\": {										\n" +
-			"		\"method\": \"GET\",							\n" +
-			"		\"url\": \"/a/registered/resource\"				\n" +
-			"	},													\n" +
-			"	\"response\": {										\n" +
-			"		\"status\": 200,								\n" +
-			"		\"headers\": {									\n" +
-			"			\"Content-Type\": \"text/html\"				\n" +
-			"		},												\n" +
-			"		\"body\": \"OK\"								\n" +
-			"	}													\n" +
-			"}														";
+    public static final String MODIFY_MAPPING_REQUEST_WITH_UUID =
+    		"{ 	" +
+    		"	\"uuid\":\"bff18359-a74e-4c3e-95f0-dab304cd3a5a\",	\n" +
+    		"	\"request\": {										\n" +
+    		"		\"method\": \"GET\",							\n" +
+    		"		\"url\": \"/a/registered/resource\"				\n" +
+    		"	},													\n" +
+    		"	\"response\": {										\n" +
+    		"		\"status\": 200,								\n" +
+    		"		\"headers\": {									\n" +
+    		"			\"Content-Type\": \"text/html\"				\n" +
+    		"		},												\n" +
+    		"		\"body\": \"OK\"								\n" +
+    		"	}													\n" +
+    		"}														";
 
-	@Test
-	public void editMappingViaTheJsonApi() {
+    @Test
+    public void editMappingViaTheJsonApi() {
 
-		testClient.addResponse(MAPPING_REQUEST_WITH_UUID);
-		WireMockResponse response = testClient.get("/a/registered/resource");
+    	testClient.addResponse(MAPPING_REQUEST_WITH_UUID);
+    	WireMockResponse response = testClient.get("/a/registered/resource");
 
-		assertThat(response.statusCode(), is(401));
-		assertThat(response.content(), is("Not allowed!"));
-		assertThat(response.firstHeader("Content-Type"), is("text/plain"));
+    	assertThat(response.statusCode(), is(401));
+    	assertThat(response.content(), is("Not allowed!"));
+    	assertThat(response.firstHeader("Content-Type"), is("text/plain"));
 
-		testClient.editMapping(MODIFY_MAPPING_REQUEST_WITH_UUID);
+    	testClient.editMapping(MODIFY_MAPPING_REQUEST_WITH_UUID);
 
-		response = testClient.get("/a/registered/resource");
+    	response = testClient.get("/a/registered/resource");
 
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("OK"));
-		assertThat(response.firstHeader("Content-Type"), is("text/html"));
-	}
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("OK"));
+    	assertThat(response.firstHeader("Content-Type"), is("text/html"));
+    }
 
-	@Test
-	public void editMappingViaTheDsl() {
+    @Test
+    public void editMappingViaTheDsl() {
         StubMapping stubMapping = stubFor(get(urlEqualTo("/edit/this"))
             .willReturn(aResponse().withStatus(200)));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/GlobalSettingsAcceptanceTest.java
@@ -28,61 +28,61 @@ import static org.junit.Assert.assertThat;
 
 public class GlobalSettingsAcceptanceTest extends AcceptanceTestBase {
 
-	@Test
-	public void settingGlobalFixedResponseDelay() {
-		WireMock.setGlobalFixedDelay(500);
-		givenThat(get(urlEqualTo("/globally/delayed/resource")).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void settingGlobalFixedResponseDelay() {
+    	WireMock.setGlobalFixedDelay(500);
+    	givenThat(get(urlEqualTo("/globally/delayed/resource")).willReturn(aResponse().withStatus(200)));
         
-	    long start = System.currentTimeMillis();
+        long start = System.currentTimeMillis();
         testClient.get("/globally/delayed/resource");
         int duration = (int) (System.currentTimeMillis() - start);
         
         assertThat(duration, greaterThanOrEqualTo(500));
-	}
+    }
 
-	@Test
-	public void settingGlobalRandomDistributionDelayCausesADelay() {
-		WireMock.setGlobalRandomDelay(new LogNormal(90, 0.1));
-		givenThat(get(urlEqualTo("/globally/random/delayed/resource")).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void settingGlobalRandomDistributionDelayCausesADelay() {
+    	WireMock.setGlobalRandomDelay(new LogNormal(90, 0.1));
+    	givenThat(get(urlEqualTo("/globally/random/delayed/resource")).willReturn(aResponse().withStatus(200)));
 
-		long start = System.currentTimeMillis();
-		testClient.get("/globally/random/delayed/resource");
-		int duration = (int) (System.currentTimeMillis() - start);
+    	long start = System.currentTimeMillis();
+    	testClient.get("/globally/random/delayed/resource");
+    	int duration = (int) (System.currentTimeMillis() - start);
 
-		assertThat(duration, greaterThanOrEqualTo(60));
-	}
+    	assertThat(duration, greaterThanOrEqualTo(60));
+    }
 
-	@Test
-	public void canCombineFixedAndRandomDelays() {
-		WireMock.setGlobalRandomDelay(new LogNormal(90, 0.1));
-		WireMock.setGlobalFixedDelay(30);
-		givenThat(get(urlEqualTo("/globally/random/delayed/resource")).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void canCombineFixedAndRandomDelays() {
+    	WireMock.setGlobalRandomDelay(new LogNormal(90, 0.1));
+    	WireMock.setGlobalFixedDelay(30);
+    	givenThat(get(urlEqualTo("/globally/random/delayed/resource")).willReturn(aResponse().withStatus(200)));
 
-		long start = System.currentTimeMillis();
-		testClient.get("/globally/random/delayed/resource");
-		int duration = (int) (System.currentTimeMillis() - start);
+    	long start = System.currentTimeMillis();
+    	testClient.get("/globally/random/delayed/resource");
+    	int duration = (int) (System.currentTimeMillis() - start);
 
-		assertThat(duration, greaterThanOrEqualTo(90));
-	}
+    	assertThat(duration, greaterThanOrEqualTo(90));
+    }
 
-	@Test
-	public void fetchSettings() {
-		WireMock.setGlobalFixedDelay(30);
+    @Test
+    public void fetchSettings() {
+    	WireMock.setGlobalFixedDelay(30);
 
-		GlobalSettings settings = WireMock.getSettings();
+    	GlobalSettings settings = WireMock.getSettings();
 
-		assertThat(settings.getFixedDelay(), is(30));
-	}
+    	assertThat(settings.getFixedDelay(), is(30));
+    }
 
-	@Test
-	public void setAndRetrieveExtendedSettings() {
-		WireMock.updateSettings(GlobalSettings.builder()
-				.extended(Parameters.one("mySetting", "setting-value"))
-				.build());
+    @Test
+    public void setAndRetrieveExtendedSettings() {
+    	WireMock.updateSettings(GlobalSettings.builder()
+    			.extended(Parameters.one("mySetting", "setting-value"))
+    			.build());
 
-		GlobalSettings fetchedSettings = WireMock.getSettings();
+    	GlobalSettings fetchedSettings = WireMock.getSettings();
 
-		assertThat(fetchedSettings.getExtended().getString("mySetting"), is("setting-value"));
-	}
+    	assertThat(fetchedSettings.getExtended().getString("mySetting"), is("setting-value"));
+    }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/HeaderMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HeaderMatchingAcceptanceTest.java
@@ -25,39 +25,39 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class HeaderMatchingAcceptanceTest extends AcceptanceTestBase {
-	
-	@Test
-	public void mappingWithExactUrlMethodAndHeaderMatchingIsCreatedAndReturned() {
-		testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_WITH_EXACT_HEADERS);
-		
-		WireMockResponse response = testClient.get("/header/dependent",
-				withHeader("Accept", "text/xml"),
-				withHeader("If-None-Match", "abcd1234"));
-		
-		assertThat(response.statusCode(), is(304));
-	}
+    
+    @Test
+    public void mappingWithExactUrlMethodAndHeaderMatchingIsCreatedAndReturned() {
+    	testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_WITH_EXACT_HEADERS);
+    	
+    	WireMockResponse response = testClient.get("/header/dependent",
+    			withHeader("Accept", "text/xml"),
+    			withHeader("If-None-Match", "abcd1234"));
+    	
+    	assertThat(response.statusCode(), is(304));
+    }
 
-	@Test
-	public void mappingMatchedWithRegexHeaders() {
-		testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_WITH_REGEX_HEADERS);
-		
-		WireMockResponse response = testClient.get("/header/match/dependent",
-				withHeader("Accept", "text/xml"),
-				withHeader("If-None-Match", "abcd1234"));
-		
-		assertThat(response.statusCode(), is(304));
-	}
-	
-	@Test
-	public void mappingMatchedWithNegativeRegexHeader() {
-		testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_WITH_NEGATIVE_REGEX_HEADERS);
-		
-		WireMockResponse response = testClient.get("/header/match/dependent",
-				withHeader("Accept", "text/xml"));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
-		
-		response = testClient.get("/header/match/dependent",
-				withHeader("Accept", "application/json"));
-		assertThat(response.statusCode(), is(200));
-	}
+    @Test
+    public void mappingMatchedWithRegexHeaders() {
+    	testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_WITH_REGEX_HEADERS);
+    	
+    	WireMockResponse response = testClient.get("/header/match/dependent",
+    			withHeader("Accept", "text/xml"),
+    			withHeader("If-None-Match", "abcd1234"));
+    	
+    	assertThat(response.statusCode(), is(304));
+    }
+    
+    @Test
+    public void mappingMatchedWithNegativeRegexHeader() {
+    	testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_WITH_NEGATIVE_REGEX_HEADERS);
+    	
+    	WireMockResponse response = testClient.get("/header/match/dependent",
+    			withHeader("Accept", "text/xml"));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	
+    	response = testClient.get("/header/match/dependent",
+    			withHeader("Accept", "application/json"));
+    	assertThat(response.statusCode(), is(200));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsAcceptanceTest.java
@@ -31,77 +31,77 @@ import static org.junit.Assert.assertThat;
 
 public class MappingsAcceptanceTest extends AcceptanceTestBase {
 
-	@BeforeClass
-	public static void setupServer() {
-		setupServerWithMappingsInFileRoot();
-	}
-	
-	@Test
-	public void basicMappingCheckNonUtf8() {
-		testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8, "GB2312");
-		
-		WireMockResponse response = testClient.get("/test/nonutf8/");
-		
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("国家标准"));
-	}
+    @BeforeClass
+    public static void setupServer() {
+    	setupServerWithMappingsInFileRoot();
+    }
+    
+    @Test
+    public void basicMappingCheckNonUtf8() {
+    	testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8, "GB2312");
+    	
+    	WireMockResponse response = testClient.get("/test/nonutf8/");
+    	
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("国家标准"));
+    }
 
-	@Test
-	public void basicMappingCheckCharsetMismatch() {
-		testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8, "ISO-8859-8");
-		
-		WireMockResponse response = testClient.get("/test/nonutf8/");
-		
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("????")); // charset in request doesn't match body content
-	}
+    @Test
+    public void basicMappingCheckCharsetMismatch() {
+    	testClient.addResponse(MappingJsonSamples.MAPPING_REQUEST_FOR_NON_UTF8, "ISO-8859-8");
+    	
+    	WireMockResponse response = testClient.get("/test/nonutf8/");
+    	
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("????")); // charset in request doesn't match body content
+    }
 
-	@Test
-	public void basicMappingWithExactUrlAndMethodMatchIsCreatedAndReturned() {
-		testClient.addResponse(MappingJsonSamples.BASIC_MAPPING_REQUEST_WITH_RESPONSE_HEADER);
-		
-		WireMockResponse response = testClient.get("/a/registered/resource");
-		
-		assertThat(response.statusCode(), is(401));
-		assertThat(response.content(), is("Not allowed!"));
-		assertThat(response.firstHeader("Content-Type"), is("text/plain"));
-	}
-	
-	@Test
-	public void mappingWithStatusOnlyResponseIsCreatedAndReturned() {
-		testClient.addResponse(MappingJsonSamples.STATUS_ONLY_MAPPING_REQUEST);
-		
-		WireMockResponse response = testClient.put("/status/only");
-		
-		assertThat(response.statusCode(), is(204));
-		assertNull(response.content());
-	}
-	
-	@Test
-	public void notFoundResponseIsReturnedForUnregisteredUrl() {
-		WireMockResponse response = testClient.get("/non-existent/resource");
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
-	}
-	
-	@Test
-	public void multipleMappingsSupported() {
-		add200ResponseFor("/resource/1");
-		add200ResponseFor("/resource/2");
-		add200ResponseFor("/resource/3");
-		
-		getResponseAndAssert200Status("/resource/1");
-		getResponseAndAssert200Status("/resource/2");
-		getResponseAndAssert200Status("/resource/3");
-	}
+    @Test
+    public void basicMappingWithExactUrlAndMethodMatchIsCreatedAndReturned() {
+    	testClient.addResponse(MappingJsonSamples.BASIC_MAPPING_REQUEST_WITH_RESPONSE_HEADER);
+    	
+    	WireMockResponse response = testClient.get("/a/registered/resource");
+    	
+    	assertThat(response.statusCode(), is(401));
+    	assertThat(response.content(), is("Not allowed!"));
+    	assertThat(response.firstHeader("Content-Type"), is("text/plain"));
+    }
+    
+    @Test
+    public void mappingWithStatusOnlyResponseIsCreatedAndReturned() {
+    	testClient.addResponse(MappingJsonSamples.STATUS_ONLY_MAPPING_REQUEST);
+    	
+    	WireMockResponse response = testClient.put("/status/only");
+    	
+    	assertThat(response.statusCode(), is(204));
+    	assertNull(response.content());
+    }
+    
+    @Test
+    public void notFoundResponseIsReturnedForUnregisteredUrl() {
+    	WireMockResponse response = testClient.get("/non-existent/resource");
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    }
+    
+    @Test
+    public void multipleMappingsSupported() {
+    	add200ResponseFor("/resource/1");
+    	add200ResponseFor("/resource/2");
+    	add200ResponseFor("/resource/3");
+    	
+    	getResponseAndAssert200Status("/resource/1");
+    	getResponseAndAssert200Status("/resource/2");
+    	getResponseAndAssert200Status("/resource/3");
+    }
 
-	@Test
-	public void multipleInvocationsSupported() {
-		add200ResponseFor("/resource/100");
-		getResponseAndAssert200Status("/resource/100");
-		getResponseAndAssert200Status("/resource/100");
-		getResponseAndAssert200Status("/resource/100");
-	}
-	
+    @Test
+    public void multipleInvocationsSupported() {
+    	add200ResponseFor("/resource/100");
+    	getResponseAndAssert200Status("/resource/100");
+    	getResponseAndAssert200Status("/resource/100");
+    	getResponseAndAssert200Status("/resource/100");
+    }
+    
     @Test
     public void loadsDefaultMappingsOnStart() {
         getResponseAndAssert200Status("/testmapping");
@@ -141,26 +141,26 @@ public class MappingsAcceptanceTest extends AcceptanceTestBase {
         assertThat(testClient.get("/bytecompressed/resource/from/file").binaryContent(), is(BINARY_COMPRESSED_CONTENT));
     }
 
-	@Test
-	public void readsJsonMapping() {
-		WireMockResponse response = testClient.get("/testjsonmapping");
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("{\"key\":\"value\",\"array\":[1,2,3]}"));
-	}
+    @Test
+    public void readsJsonMapping() {
+    	WireMockResponse response = testClient.get("/testjsonmapping");
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("{\"key\":\"value\",\"array\":[1,2,3]}"));
+    }
 
     @Test
     public void appendsTransferEncodingHeaderIfNoContentLengthHeaderIsPresentInMapping() throws Exception {
         testClient.addResponse(
-                "{ 													\n" +
-                        "	\"request\": {									\n" +
-                        "		\"method\": \"GET\",						\n" +
-                        "		\"url\": \"/with/body\"						\n" +
-                        "	},												\n" +
-                        "	\"response\": {									\n" +
-                        "		\"status\": 200,							\n" +
-                        "		\"body\": \"Some content\"					\n" +
-                        "	}												\n" +
-                        "}													");
+                "{     												\n" +
+                        "    \"request\": {									\n" +
+                        "    	\"method\": \"GET\",						\n" +
+                        "    	\"url\": \"/with/body\"						\n" +
+                        "    },												\n" +
+                        "    \"response\": {									\n" +
+                        "    	\"status\": 200,							\n" +
+                        "    	\"body\": \"Some content\"					\n" +
+                        "    }												\n" +
+                        "}    												");
 
         WireMockResponse response = testClient.get("/with/body");
 
@@ -170,36 +170,36 @@ public class MappingsAcceptanceTest extends AcceptanceTestBase {
     @Test
     public void responseContainsContentLengthAndChunkedEncodingHeadersIfItIsDefinedInTheMapping() throws Exception {
         testClient.addResponse(
-                "{ 													\n" +
-                        "	\"request\": {									\n" +
-                        "		\"method\": \"GET\",						\n" +
-                        "		\"url\": \"/with/body\"						\n" +
-                        "	},												\n" +
-                        "	\"response\": {									\n" +
-                        "		\"status\": 200,							\n" +
-                        "		\"headers\": {								\n" +
-                        "			\"Content-Length\": \"12\"		        \n" +
-                        "		},											\n" +
-                        "		\"body\": \"Some content\"					\n" +
-                        "	}												\n" +
-                        "}													");
+                "{     												\n" +
+                        "    \"request\": {									\n" +
+                        "    	\"method\": \"GET\",						\n" +
+                        "    	\"url\": \"/with/body\"						\n" +
+                        "    },												\n" +
+                        "    \"response\": {									\n" +
+                        "    	\"status\": 200,							\n" +
+                        "    	\"headers\": {								\n" +
+                        "    		\"Content-Length\": \"12\"		        \n" +
+                        "    	},											\n" +
+                        "    	\"body\": \"Some content\"					\n" +
+                        "    }												\n" +
+                        "}    												");
         WireMockResponse response = testClient.get("/with/body");
 
         assertThat(response.firstHeader("Content-Length"), is("12"));
         assertFalse("expected Transfer-Encoding head to be absent", response.headers().containsKey("Transfer-Encoding"));
     }
 
-	private void getResponseAndAssert200Status(String url) {
-		WireMockResponse response = testClient.get(url);
-		assertThat(response.statusCode(), is(200));
-	}
-	
-	private void getResponseAndAssert404Status(String url) {
-		WireMockResponse response = testClient.get(url);
-		assertThat(response.statusCode(), is(404));
-	}
-	
-	private void add200ResponseFor(String url) {
-		testClient.addResponse(String.format(MappingJsonSamples.STATUS_ONLY_GET_MAPPING_TEMPLATE, url));
-	}
+    private void getResponseAndAssert200Status(String url) {
+    	WireMockResponse response = testClient.get(url);
+    	assertThat(response.statusCode(), is(200));
+    }
+    
+    private void getResponseAndAssert404Status(String url) {
+    	WireMockResponse response = testClient.get(url);
+    	assertThat(response.statusCode(), is(404));
+    }
+    
+    private void add200ResponseFor(String url) {
+    	testClient.addResponse(String.format(MappingJsonSamples.STATUS_ONLY_GET_MAPPING_TEMPLATE, url));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/MappingsLoaderAcceptanceTest.java
@@ -40,18 +40,18 @@ import static org.junit.Assert.assertThat;
 public class MappingsLoaderAcceptanceTest {
 
     private WireMockConfiguration configuration;
-	private WireMockServer wireMockServer;
-	private WireMockTestClient testClient;
+    private WireMockServer wireMockServer;
+    private WireMockTestClient testClient;
 
-	@Before
-	public void init() {
+    @Before
+    public void init() {
         configuration = wireMockConfig().dynamicPort();
-	}
+    }
 
-	@After
-	public void stopWireMock() {
-		wireMockServer.stop();
-	}
+    @After
+    public void stopWireMock() {
+    	wireMockServer.stop();
+    }
 
     private void buildWireMock(Options options) {
         wireMockServer = new WireMockServer(options);
@@ -60,16 +60,16 @@ public class MappingsLoaderAcceptanceTest {
     }
 
     @Test
-	public void mappingsLoadedFromJsonFiles() {
+    public void mappingsLoadedFromJsonFiles() {
         buildWireMock(configuration);
         wireMockServer.loadMappingsUsing(new JsonFileMappingsSource(new SingleRootFileSource(filePath("test-requests"))));
 
-		WireMockResponse response = testClient.get("/canned/resource/1");
-		assertThat(response.statusCode(), is(200));
+    	WireMockResponse response = testClient.get("/canned/resource/1");
+    	assertThat(response.statusCode(), is(200));
 
-		response = testClient.get("/canned/resource/2");
-		assertThat(response.statusCode(), is(401));
-	}
+    	response = testClient.get("/canned/resource/2");
+    	assertThat(response.statusCode(), is(401));
+    }
 
     @Test
     public void mappingsLoadedViaClasspath() {

--- a/src/test/java/com/github/tomakehurst/wiremock/NetworkTrafficListenerAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/NetworkTrafficListenerAcceptanceTest.java
@@ -24,19 +24,19 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
 public class NetworkTrafficListenerAcceptanceTest extends AcceptanceTestBase {
-	private static CollectingNetworkTrafficListener networkTrafficListener = new CollectingNetworkTrafficListener();
+    private static CollectingNetworkTrafficListener networkTrafficListener = new CollectingNetworkTrafficListener();
 
-	@BeforeClass
-	public static void setupServer() {
-		setupServer(new WireMockConfiguration().networkTrafficListener(networkTrafficListener));
-	}
-	
-	@Test
-	public void capturesRawTraffic() {
-		testClient.get("/a/non-registered/resource");
+    @BeforeClass
+    public static void setupServer() {
+    	setupServer(new WireMockConfiguration().networkTrafficListener(networkTrafficListener));
+    }
+    
+    @Test
+    public void capturesRawTraffic() {
+    	testClient.get("/a/non-registered/resource");
 
-		assertThat(networkTrafficListener.getAllRequests(), containsString("GET /a/non-registered/resource HTTP/1.1\r\n"));
-		assertThat(networkTrafficListener.getAllRequests(), containsString("Content-Length: 0\r\n"));
-		assertThat(networkTrafficListener.getAllResponses(), containsString("HTTP/1.1 404 Not Found\r\n"));
-	}
+    	assertThat(networkTrafficListener.getAllRequests(), containsString("GET /a/non-registered/resource HTTP/1.1\r\n"));
+    	assertThat(networkTrafficListener.getAllRequests(), containsString("Content-Length: 0\r\n"));
+    	assertThat(networkTrafficListener.getAllResponses(), containsString("HTTP/1.1 404 Not Found\r\n"));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ScenarioAcceptanceTest.java
@@ -34,68 +34,68 @@ import static org.junit.Assert.assertThat;
 
 public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 
-	@Test
-	public void createMappingsInScenarioAndChangeResponseWithStateChange() {
-		givenThat(get(urlEqualTo("/some/resource"))
-				.willReturn(aResponse().withBody("Initial"))
-				.inScenario("SomeResourceUpdate")
-				.whenScenarioStateIs(STARTED));
-		
-		givenThat(put(urlEqualTo("/some/resource"))
-				.willReturn(aResponse().withStatus(HTTP_OK))
-				.inScenario("SomeResourceUpdate")
-				.willSetStateTo("BodyModified")
-				.whenScenarioStateIs(STARTED));
-		
-		givenThat(get(urlEqualTo("/some/resource"))
-				.willReturn(aResponse().withBody("Modified"))
-				.inScenario("SomeResourceUpdate")
-				.whenScenarioStateIs("BodyModified"));
-		
-		assertThat(testClient.get("/some/resource").content(), is("Initial"));
-		testClient.put("/some/resource");
-		assertThat(testClient.get("/some/resource").content(), is("Modified"));
-	}
-	
-	@Test
-	public void mappingInScenarioIndependentOfCurrentState() {
-		givenThat(get(urlEqualTo("/state/independent/resource"))
-				.willReturn(aResponse().withBody("Some content"))
-				.inScenario("StateIndependent"));
-		
-		givenThat(put(urlEqualTo("/state/modifying/resource"))
-				.willReturn(aResponse().withStatus(HTTP_OK))
-				.inScenario("StateIndependent")
-				.willSetStateTo("BodyModified"));
-		
-		WireMockResponse response = testClient.get("/state/independent/resource");
-		assertThat(response.statusCode(), is(HTTP_OK));
-		assertThat(response.content(), is("Some content"));
-		
-		testClient.put("/state/modifying/resource");
-		
-		response = testClient.get("/state/independent/resource");
-		assertThat(response.statusCode(), is(HTTP_OK));
-		assertThat(response.content(), is("Some content"));
-	}
-	
-	@Test
-	public void resetAllScenariosState() {
-		givenThat(get(urlEqualTo("/stateful/resource"))
-				.willReturn(aResponse().withBody("Expected content"))
-				.inScenario("ResetScenario")
-				.whenScenarioStateIs(STARTED));
-		
-		givenThat(put(urlEqualTo("/stateful/resource"))
-				.willReturn(aResponse().withStatus(HTTP_OK))
-				.inScenario("ResetScenario")
-				.willSetStateTo("Changed"));
-		
-		testClient.put("/stateful/resource");
-		WireMock.resetAllScenarios();
-		
-		assertThat(testClient.get("/stateful/resource").content(), is("Expected content"));
-	}
+    @Test
+    public void createMappingsInScenarioAndChangeResponseWithStateChange() {
+    	givenThat(get(urlEqualTo("/some/resource"))
+    			.willReturn(aResponse().withBody("Initial"))
+    			.inScenario("SomeResourceUpdate")
+    			.whenScenarioStateIs(STARTED));
+    	
+    	givenThat(put(urlEqualTo("/some/resource"))
+    			.willReturn(aResponse().withStatus(HTTP_OK))
+    			.inScenario("SomeResourceUpdate")
+    			.willSetStateTo("BodyModified")
+    			.whenScenarioStateIs(STARTED));
+    	
+    	givenThat(get(urlEqualTo("/some/resource"))
+    			.willReturn(aResponse().withBody("Modified"))
+    			.inScenario("SomeResourceUpdate")
+    			.whenScenarioStateIs("BodyModified"));
+    	
+    	assertThat(testClient.get("/some/resource").content(), is("Initial"));
+    	testClient.put("/some/resource");
+    	assertThat(testClient.get("/some/resource").content(), is("Modified"));
+    }
+    
+    @Test
+    public void mappingInScenarioIndependentOfCurrentState() {
+    	givenThat(get(urlEqualTo("/state/independent/resource"))
+    			.willReturn(aResponse().withBody("Some content"))
+    			.inScenario("StateIndependent"));
+    	
+    	givenThat(put(urlEqualTo("/state/modifying/resource"))
+    			.willReturn(aResponse().withStatus(HTTP_OK))
+    			.inScenario("StateIndependent")
+    			.willSetStateTo("BodyModified"));
+    	
+    	WireMockResponse response = testClient.get("/state/independent/resource");
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    	assertThat(response.content(), is("Some content"));
+    	
+    	testClient.put("/state/modifying/resource");
+    	
+    	response = testClient.get("/state/independent/resource");
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    	assertThat(response.content(), is("Some content"));
+    }
+    
+    @Test
+    public void resetAllScenariosState() {
+    	givenThat(get(urlEqualTo("/stateful/resource"))
+    			.willReturn(aResponse().withBody("Expected content"))
+    			.inScenario("ResetScenario")
+    			.whenScenarioStateIs(STARTED));
+    	
+    	givenThat(put(urlEqualTo("/stateful/resource"))
+    			.willReturn(aResponse().withStatus(HTTP_OK))
+    			.inScenario("ResetScenario")
+    			.willSetStateTo("Changed"));
+    	
+    	testClient.put("/stateful/resource");
+    	WireMock.resetAllScenarios();
+    	
+    	assertThat(testClient.get("/stateful/resource").content(), is("Expected content"));
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void settingScenarioNameToNullCausesException() {
@@ -105,8 +105,8 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
     }
 
     @Test
-	public void canGetAllScenarios() {
-	    stubFor(get("/scenarios/1")
+    public void canGetAllScenarios() {
+        stubFor(get("/scenarios/1")
             .inScenario("scenario_one")
             .whenScenarioStateIs(STARTED)
             .willSetStateTo("state_2")
@@ -132,7 +132,7 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 
     @Test
     public void scenarioIsRemovedWhenLastMappingReferringToItIsRemoved() {
-	    final String NAME = "remove_this_scenario";
+        final String NAME = "remove_this_scenario";
 
         StubMapping stub1 = stubFor(get("/scenarios/22")
             .inScenario(NAME)
@@ -163,8 +163,8 @@ public class ScenarioAcceptanceTest extends AcceptanceTestBase {
 
     @Test
     public void scenarioIsRemovedWhenLastMappingReferringToHasItsScenarioNameChanged() {
-	    final UUID ID1 = UUID.randomUUID();
-	    final UUID ID2 = UUID.randomUUID();
+        final UUID ID1 = UUID.randomUUID();
+        final UUID ID2 = UUID.randomUUID();
         final String OLD_NAME = "old_scenario";
         final String NEW_NAME = "new_scenario";
 

--- a/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StandaloneAcceptanceTest.java
@@ -59,174 +59,174 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class StandaloneAcceptanceTest {
-	private static final String FILES = "__files";
-	private static final String MAPPINGS = "mappings";
+    private static final String FILES = "__files";
+    private static final String MAPPINGS = "mappings";
 
     private static final File FILE_SOURCE_ROOT = new File("build/standalone-files");
 
-	private WireMockServerRunner runner;
-	private WireMockTestClient testClient;
-	
-	private WireMockServer otherServer;
-	
-	private final PrintStream stdOut = System.out;
-	private ByteArrayOutputStream out;
+    private WireMockServerRunner runner;
+    private WireMockTestClient testClient;
+    
+    private WireMockServer otherServer;
+    
+    private final PrintStream stdOut = System.out;
+    private ByteArrayOutputStream out;
     private final PrintStream stdErr = System.err;
     private ByteArrayOutputStream err;
 
-	private File mappingsDirectory;
-	private File filesDirectory;
+    private File mappingsDirectory;
+    private File filesDirectory;
 
-	@Rule
+    @Rule
     public ExpectedException expectException = ExpectedException.none();
-	
-	@Before
-	public void init() throws Exception {
-		if (FILE_SOURCE_ROOT.exists()) {
+    
+    @Before
+    public void init() throws Exception {
+    	if (FILE_SOURCE_ROOT.exists()) {
             FileUtils.deleteDirectory(FILE_SOURCE_ROOT);
-		}
-		
-		FILE_SOURCE_ROOT.mkdirs();
-		
-		mappingsDirectory = new File(FILE_SOURCE_ROOT, MAPPINGS);
-		filesDirectory = new File(FILE_SOURCE_ROOT, FILES);
-		
-		runner = new WireMockServerRunner();
+    	}
+    	
+    	FILE_SOURCE_ROOT.mkdirs();
+    	
+    	mappingsDirectory = new File(FILE_SOURCE_ROOT, MAPPINGS);
+    	filesDirectory = new File(FILE_SOURCE_ROOT, FILES);
+    	
+    	runner = new WireMockServerRunner();
 
-		WireMock.configure();
-	}
-	
-	@After
-	public void stopServerRunner() {
-		runner.stop();
-		if (otherServer != null) {
-			otherServer.stop();
-		}
-		System.setOut(stdOut);
+    	WireMock.configure();
+    }
+    
+    @After
+    public void stopServerRunner() {
+    	runner.stop();
+    	if (otherServer != null) {
+    		otherServer.stop();
+    	}
+    	System.setOut(stdOut);
         System.setErr(stdErr);
-	}
+    }
 
-	@Test
-	public void acceptsMappingRequestOnDefaultPort() throws Exception {
-		startRunner();
-		givenThat(get(urlEqualTo("/standalone/test/resource")).willReturn(aResponse().withStatus(200).withBody("Content")));
-		assertThat(testClient.get("/standalone/test/resource").content(), is("Content"));
-	}
+    @Test
+    public void acceptsMappingRequestOnDefaultPort() throws Exception {
+    	startRunner();
+    	givenThat(get(urlEqualTo("/standalone/test/resource")).willReturn(aResponse().withStatus(200).withBody("Content")));
+    	assertThat(testClient.get("/standalone/test/resource").content(), is("Content"));
+    }
 
-	private static final String MAPPING_REQUEST =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/resource/from/file\"			\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 200,							\n" +
-		"		\"body\": \"Body from mapping file\"		\n" +
-		"	}												\n" +
-		"}													";
-	
-	@Test
-	public void readsMappingFromMappingsDir() {
-		writeMappingFile("test-mapping-1.json", MAPPING_REQUEST);
-		startRunner();
-		assertThat(testClient.get("/resource/from/file").content(), is("Body from mapping file"));
-	}
-	
-	@Test
-	public void readsMappingFromSpecifiedRecordingsPath() {
-		String differentRoot = FILE_SOURCE_ROOT + separator + "differentRoot";
-		writeFile(differentRoot + separator + underMappings("test-mapping-1.json"), MAPPING_REQUEST);
-		startRunner("--root-dir", differentRoot);
-		assertThat(testClient.get("/resource/from/file").content(), is("Body from mapping file"));
-	}
+    private static final String MAPPING_REQUEST =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/resource/from/file\"			\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 200,							\n" +
+    	"		\"body\": \"Body from mapping file\"		\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    @Test
+    public void readsMappingFromMappingsDir() {
+    	writeMappingFile("test-mapping-1.json", MAPPING_REQUEST);
+    	startRunner();
+    	assertThat(testClient.get("/resource/from/file").content(), is("Body from mapping file"));
+    }
+    
+    @Test
+    public void readsMappingFromSpecifiedRecordingsPath() {
+    	String differentRoot = FILE_SOURCE_ROOT + separator + "differentRoot";
+    	writeFile(differentRoot + separator + underMappings("test-mapping-1.json"), MAPPING_REQUEST);
+    	startRunner("--root-dir", differentRoot);
+    	assertThat(testClient.get("/resource/from/file").content(), is("Body from mapping file"));
+    }
 
-	@Test
-	public void servesFileFromFilesDir() {
-		writeFileToFilesDir("test-1.xml", "<content>Blah</content>");
-		startRunner();
-		WireMockResponse response = testClient.get("/test-1.xml");
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("<content>Blah</content>"));
-		assertThat(response.firstHeader("Content-Type"), is("application/xml"));
-	}
-	
-	@Test
-	public void servesFileFromSpecifiedRecordingsPath() {
-		String differentRoot = FILE_SOURCE_ROOT + separator + "differentRoot";
-		writeFile(differentRoot + separator + underFiles("test-1.xml"), "<content>Blah</content>");
-		startRunner("--root-dir", differentRoot);
-		WireMockResponse response = testClient.get("/test-1.xml");
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("<content>Blah</content>"));
-		assertThat(response.firstHeader("Content-Type"), is("application/xml"));
-	}
+    @Test
+    public void servesFileFromFilesDir() {
+    	writeFileToFilesDir("test-1.xml", "<content>Blah</content>");
+    	startRunner();
+    	WireMockResponse response = testClient.get("/test-1.xml");
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("<content>Blah</content>"));
+    	assertThat(response.firstHeader("Content-Type"), is("application/xml"));
+    }
+    
+    @Test
+    public void servesFileFromSpecifiedRecordingsPath() {
+    	String differentRoot = FILE_SOURCE_ROOT + separator + "differentRoot";
+    	writeFile(differentRoot + separator + underFiles("test-1.xml"), "<content>Blah</content>");
+    	startRunner("--root-dir", differentRoot);
+    	WireMockResponse response = testClient.get("/test-1.xml");
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("<content>Blah</content>"));
+    	assertThat(response.firstHeader("Content-Type"), is("application/xml"));
+    }
 
-	@Test
-	public void servesFileAsJsonWhenNoFileExtension() {
-		writeFileToFilesDir("json/12345", "{ \"key\": \"value\" }");
-		startRunner();
-		WireMockResponse response = testClient.get("/json/12345");
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("{ \"key\": \"value\" }"));
-		assertThat(response.firstHeader("Content-Type"), is("application/json"));
-	}
-	
-	@Test
-	public void shouldNotSend302WhenPathIsDirAndTrailingSlashNotPresent() {
-	    writeFileToFilesDir("json/wire & mock directory/index.json", "{ \"key\": \"index page value\" }");
-	    startRunner();
+    @Test
+    public void servesFileAsJsonWhenNoFileExtension() {
+    	writeFileToFilesDir("json/12345", "{ \"key\": \"value\" }");
+    	startRunner();
+    	WireMockResponse response = testClient.get("/json/12345");
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("{ \"key\": \"value\" }"));
+    	assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    }
+    
+    @Test
+    public void shouldNotSend302WhenPathIsDirAndTrailingSlashNotPresent() {
+        writeFileToFilesDir("json/wire & mock directory/index.json", "{ \"key\": \"index page value\" }");
+        startRunner();
         WireMockResponse response = testClient.get("/json/wire%20&%20mock%20directory");
         assertThat(response.statusCode(), is(200));
         assertThat(response.content(), is("{ \"key\": \"index page value\" }"));
-	}
-	
-	@Test
-	public void servesJsonIndexFileWhenTrailingSlashPresent() {
-		writeFileToFilesDir("json/23456/index.json", "{ \"key\": \"new value\" }");
-		startRunner();
-		WireMockResponse response = testClient.get("/json/23456/");
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("{ \"key\": \"new value\" }"));
-		assertThat(response.firstHeader("Content-Type"), is("application/json"));
-	}
-	
-	@Test
-	public void servesXmlIndexFileWhenTrailingSlashPresent() {
-		writeFileToFilesDir("json/34567/index.xml", "<blob>BLAB</blob>");
-		startRunner();
-		WireMockResponse response = testClient.get("/json/34567/");
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("<blob>BLAB</blob>"));
-		assertThat(response.firstHeader("Content-Type"), is("application/xml"));
-	}
-	
-	@Test
-	public void doesNotServeFileFromFilesDirWhenNotGET() {
-		writeFileToFilesDir("json/should-not-see-this.json", "{}");
-		startRunner();
-		WireMockResponse response = testClient.put("/json/should-not-see-this.json");
-		assertThat(response.statusCode(), is(404)); //Default servlet returns 405 if PUT is forwarded to it
-	}
-	
-	private static final String BODY_FILE_MAPPING_REQUEST =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/body/file\"						\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 200,							\n" +
-		"		\"bodyFileName\": \"body-test.xml\"			\n" +
-		"	}												\n" +
-		"}													";
-	
-	@Test
-	public void readsBodyFileFromFilesDir() {
-		writeMappingFile("test-mapping-2.json", BODY_FILE_MAPPING_REQUEST);
-		writeFileToFilesDir("body-test.xml", "<body>Content</body>");
-		startRunner();
-		assertThat(testClient.get("/body/file").content(), is("<body>Content</body>"));
-	}
+    }
+    
+    @Test
+    public void servesJsonIndexFileWhenTrailingSlashPresent() {
+    	writeFileToFilesDir("json/23456/index.json", "{ \"key\": \"new value\" }");
+    	startRunner();
+    	WireMockResponse response = testClient.get("/json/23456/");
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("{ \"key\": \"new value\" }"));
+    	assertThat(response.firstHeader("Content-Type"), is("application/json"));
+    }
+    
+    @Test
+    public void servesXmlIndexFileWhenTrailingSlashPresent() {
+    	writeFileToFilesDir("json/34567/index.xml", "<blob>BLAB</blob>");
+    	startRunner();
+    	WireMockResponse response = testClient.get("/json/34567/");
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("<blob>BLAB</blob>"));
+    	assertThat(response.firstHeader("Content-Type"), is("application/xml"));
+    }
+    
+    @Test
+    public void doesNotServeFileFromFilesDirWhenNotGET() {
+    	writeFileToFilesDir("json/should-not-see-this.json", "{}");
+    	startRunner();
+    	WireMockResponse response = testClient.put("/json/should-not-see-this.json");
+    	assertThat(response.statusCode(), is(404)); //Default servlet returns 405 if PUT is forwarded to it
+    }
+    
+    private static final String BODY_FILE_MAPPING_REQUEST =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/body/file\"						\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 200,							\n" +
+    	"		\"bodyFileName\": \"body-test.xml\"			\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    @Test
+    public void readsBodyFileFromFilesDir() {
+    	writeMappingFile("test-mapping-2.json", BODY_FILE_MAPPING_REQUEST);
+    	writeFileToFilesDir("body-test.xml", "<body>Content</body>");
+    	startRunner();
+    	assertThat(testClient.get("/body/file").content(), is("<body>Content</body>"));
+    }
 
     @Test
     public void readsBinaryBodyFileFromFilesDir() {
@@ -238,103 +238,103 @@ public class StandaloneAcceptanceTest {
         assertThat(decompress(returnedContent), is(MappingJsonSamples.BINARY_COMPRESSED_CONTENT_AS_STRING));
     }
 
-	@Test
-	public void logsVerboselyWhenVerboseSetInCommandLine() {
-		startRecordingSystemOutAndErr();
-		startRunner("--verbose");
-		assertThat(systemOutText(), containsString("Verbose logging enabled"));
-	}
-	
-	@Test
-	public void doesNotLogVerboselyWhenVerboseNotSetInCommandLine() {
-		startRecordingSystemOutAndErr();
-		startRunner();
-		assertThat(systemOutText(), not(containsString("Verbose logging enabled")));
-	}
-	
-	@Test
-	public void startsOnPortSpecifiedOnCommandLine() throws Exception {
+    @Test
+    public void logsVerboselyWhenVerboseSetInCommandLine() {
+    	startRecordingSystemOutAndErr();
+    	startRunner("--verbose");
+    	assertThat(systemOutText(), containsString("Verbose logging enabled"));
+    }
+    
+    @Test
+    public void doesNotLogVerboselyWhenVerboseNotSetInCommandLine() {
+    	startRecordingSystemOutAndErr();
+    	startRunner();
+    	assertThat(systemOutText(), not(containsString("Verbose logging enabled")));
+    }
+    
+    @Test
+    public void startsOnPortSpecifiedOnCommandLine() throws Exception {
         int port = findFreePort();
-		startRunner("--port", "" + port);
-		WireMock client = WireMock.create().host("localhost").port(port).build();
-		client.verifyThat(0, getRequestedFor(urlEqualTo("/bling/blang/blong"))); //Would throw an exception if couldn't connect
-	}
-	
-	@Test
-	public void proxiesToHostSpecifiedOnCommandLine() throws Exception {
-		WireMock otherServerClient = startOtherServerAndClient();
-		otherServerClient.register(get(urlEqualTo("/proxy/ok?working=yes")).willReturn(aResponse().withStatus(HTTP_OK)));
-		startRunner("--proxy-all", "http://localhost:" + otherServer.port());
-		
-		WireMockResponse response = testClient.get("/proxy/ok?working=yes");
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	startRunner("--port", "" + port);
+    	WireMock client = WireMock.create().host("localhost").port(port).build();
+    	client.verifyThat(0, getRequestedFor(urlEqualTo("/bling/blang/blong"))); //Would throw an exception if couldn't connect
+    }
+    
+    @Test
+    public void proxiesToHostSpecifiedOnCommandLine() throws Exception {
+    	WireMock otherServerClient = startOtherServerAndClient();
+    	otherServerClient.register(get(urlEqualTo("/proxy/ok?working=yes")).willReturn(aResponse().withStatus(HTTP_OK)));
+    	startRunner("--proxy-all", "http://localhost:" + otherServer.port());
+    	
+    	WireMockResponse response = testClient.get("/proxy/ok?working=yes");
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void respondsWithPreExistingRecordingInProxyMode() throws Exception {
-		writeMappingFile("test-mapping-2.json", BODY_FILE_MAPPING_REQUEST);
-		writeFileToFilesDir("body-test.xml", "Existing recorded body");
+    @Test
+    public void respondsWithPreExistingRecordingInProxyMode() throws Exception {
+    	writeMappingFile("test-mapping-2.json", BODY_FILE_MAPPING_REQUEST);
+    	writeFileToFilesDir("body-test.xml", "Existing recorded body");
 
-		WireMock otherServerClient = startOtherServerAndClient();
-		otherServerClient.register(
+    	WireMock otherServerClient = startOtherServerAndClient();
+    	otherServerClient.register(
                 get(urlEqualTo("/body/file"))
                         .willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
 
-		startRunner("--proxy-all", "http://localhost:" + otherServer.port());
+    	startRunner("--proxy-all", "http://localhost:" + otherServer.port());
 
-		assertThat(testClient.get("/body/file").content(), is("Existing recorded body"));
-	}
+    	assertThat(testClient.get("/body/file").content(), is("Existing recorded body"));
+    }
 
-	@Test
-	public void recordsProxiedRequestsWhenSpecifiedOnCommandLine() throws Exception {
-	    WireMock otherServerClient = startOtherServerAndClient();
-		startRunner("--record-mappings");
-		givenThat(get(urlEqualTo("/please/record-this"))
-				.willReturn(aResponse().proxiedFrom("http://localhost:" + otherServer.port())));
-		otherServerClient.register(
-				get(urlEqualTo("/please/record-this"))
-						.willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
+    @Test
+    public void recordsProxiedRequestsWhenSpecifiedOnCommandLine() throws Exception {
+        WireMock otherServerClient = startOtherServerAndClient();
+    	startRunner("--record-mappings");
+    	givenThat(get(urlEqualTo("/please/record-this"))
+    			.willReturn(aResponse().proxiedFrom("http://localhost:" + otherServer.port())));
+    	otherServerClient.register(
+    			get(urlEqualTo("/please/record-this"))
+    					.willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
 
-		testClient.get("/please/record-this");
-		
-		assertThat(mappingsDirectory, containsAFileContaining("/please/record-this"));
-		assertThat(contentsOfFirstFileNamedLike("please-record-this"),
-		        containsString("bodyFileName\" : \"body-please-record-this"));
-	}
-	
-	@Test
-	public void recordsRequestHeadersWhenSpecifiedOnCommandLine() throws Exception {
-	    WireMock otherServerClient = startOtherServerAndClient();
-		startRunner("--record-mappings", "--match-headers", "Accept");
-		givenThat(get(urlEqualTo("/please/record-headers"))
-		        .willReturn(aResponse().proxiedFrom("http://localhost:" + otherServer.port())));
-		otherServerClient.register(
-		        get(urlEqualTo("/please/record-headers"))
-		        .willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
-		
-		testClient.get("/please/record-headers", withHeader("accept", "application/json"));
-		
-		assertThat(mappingsDirectory, containsAFileContaining("/please/record-headers"));
-		assertThat(contentsOfFirstFileNamedLike("please-record-headers"), containsString("\"Accept\" : {"));
-	}
+    	testClient.get("/please/record-this");
+    	
+    	assertThat(mappingsDirectory, containsAFileContaining("/please/record-this"));
+    	assertThat(contentsOfFirstFileNamedLike("please-record-this"),
+    	        containsString("bodyFileName\" : \"body-please-record-this"));
+    }
+    
+    @Test
+    public void recordsRequestHeadersWhenSpecifiedOnCommandLine() throws Exception {
+        WireMock otherServerClient = startOtherServerAndClient();
+    	startRunner("--record-mappings", "--match-headers", "Accept");
+    	givenThat(get(urlEqualTo("/please/record-headers"))
+    	        .willReturn(aResponse().proxiedFrom("http://localhost:" + otherServer.port())));
+    	otherServerClient.register(
+    	        get(urlEqualTo("/please/record-headers"))
+    	        .willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
+    	
+    	testClient.get("/please/record-headers", withHeader("accept", "application/json"));
+    	
+    	assertThat(mappingsDirectory, containsAFileContaining("/please/record-headers"));
+    	assertThat(contentsOfFirstFileNamedLike("please-record-headers"), containsString("\"Accept\" : {"));
+    }
 
-	@Test
-	public void recordsGzippedResponseBodiesDecompressed() throws Exception {
-		WireMock otherServerClient = startOtherServerAndClient();
-		startRunner("--record-mappings");
-		givenThat(get(urlEqualTo("/record-zip"))
-				.willReturn(aResponse().proxiedFrom("http://localhost:" + otherServer.port())));
-		otherServerClient.register(
-				get(urlEqualTo("/record-zip"))
-						.willReturn(aResponse()
-								.withStatus(HTTP_OK)
-								.withBody("gzipped body")));
+    @Test
+    public void recordsGzippedResponseBodiesDecompressed() throws Exception {
+    	WireMock otherServerClient = startOtherServerAndClient();
+    	startRunner("--record-mappings");
+    	givenThat(get(urlEqualTo("/record-zip"))
+    			.willReturn(aResponse().proxiedFrom("http://localhost:" + otherServer.port())));
+    	otherServerClient.register(
+    			get(urlEqualTo("/record-zip"))
+    					.willReturn(aResponse()
+    							.withStatus(HTTP_OK)
+    							.withBody("gzipped body")));
 
-		testClient.get("/record-zip", withHeader("Accept-Encoding", "gzip,deflate"));
+    	testClient.get("/record-zip", withHeader("Accept-Encoding", "gzip,deflate"));
 
-		assertThat(mappingsDirectory, containsAFileContaining("/record-zip"));
-		assertThat(filesDirectory, containsAFileContaining("gzipped body"));
-	}
+    	assertThat(mappingsDirectory, containsAFileContaining("/record-zip"));
+    	assertThat(filesDirectory, containsAFileContaining("gzipped body"));
+    }
 
     @Test
     public void matchesVeryLongHeader() {
@@ -342,35 +342,35 @@ public class StandaloneAcceptanceTest {
 
         String veryLongHeader = padRight("", 16336).replace(' ', 'h');
         givenThat(get(urlEqualTo("/some/big/header"))
-				.withHeader("ExpectedHeader", equalTo(veryLongHeader))
-				.willReturn(aResponse().withStatus(200)));
+    			.withHeader("ExpectedHeader", equalTo(veryLongHeader))
+    			.willReturn(aResponse().withStatus(200)));
 
-		WireMockResponse response = testClient.get("/some/big/header",
+    	WireMockResponse response = testClient.get("/some/big/header",
                 withHeader("ExpectedHeader", veryLongHeader));
 
         assertThat(response.statusCode(), is(200));
     }
 
-	@Test
-	public void performsBrowserProxyingWhenEnabled() throws Exception {
-		WireMock otherServerClient = startOtherServerAndClient();
-		startRunner("--enable-browser-proxying");
-		otherServerClient.register(
-		        get(urlEqualTo("/from/browser/proxy"))
-		        .willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
+    @Test
+    public void performsBrowserProxyingWhenEnabled() throws Exception {
+    	WireMock otherServerClient = startOtherServerAndClient();
+    	startRunner("--enable-browser-proxying");
+    	otherServerClient.register(
+    	        get(urlEqualTo("/from/browser/proxy"))
+    	        .willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
 
-		assertThat(testClient.getViaProxy("http://localhost:" + otherServer.port() + "/from/browser/proxy").content(), is("Proxied body"));
-	}
+    	assertThat(testClient.getViaProxy("http://localhost:" + otherServer.port() + "/from/browser/proxy").content(), is("Proxied body"));
+    }
 
-	@Test
-	public void doesNotRecordRequestWhenNotProxied() {
-	    startRunner("--record-mappings");
-	    testClient.get("/try-to/record-this");
-	    assertThat(mappingsDirectory, doesNotContainAFileWithNameContaining("try-to-record"));
-	}
+    @Test
+    public void doesNotRecordRequestWhenNotProxied() {
+        startRunner("--record-mappings");
+        testClient.get("/try-to/record-this");
+        assertThat(mappingsDirectory, doesNotContainAFileWithNameContaining("try-to-record"));
+    }
 
-	@Test
-	public void doesNotRecordRequestWhenAlreadySeen() {
+    @Test
+    public void doesNotRecordRequestWhenAlreadySeen() {
         WireMock otherServerClient = startOtherServerAndClient();
         startRunner("--record-mappings");
         givenThat(get(urlEqualTo("/try-to/record-this"))
@@ -379,11 +379,11 @@ public class StandaloneAcceptanceTest {
             get(urlEqualTo("/try-to/record-this"))
                 .willReturn(aResponse().withStatus(HTTP_OK).withBody("Proxied body")));
 
-		testClient.get("/try-to/record-this");
-		testClient.get("/try-to/record-this");
+    	testClient.get("/try-to/record-this");
+    	testClient.get("/try-to/record-this");
 
-		assertThat(mappingsDirectory, containsExactlyOneFileWithNameContaining("try-to-record"));
-	}
+    	assertThat(mappingsDirectory, containsExactlyOneFileWithNameContaining("try-to-record"));
+    }
 
     @Test
     public void canBeShutDownRemotely() {
@@ -408,16 +408,16 @@ public class StandaloneAcceptanceTest {
     }
 
     private static final String BAD_MAPPING =
-        "{ 													\n" +
-            "	\"requesttttt\": {      						\n" +
-            "		\"method\": \"GET\",						\n" +
-            "		\"url\": \"/resource/from/file\"			\n" +
-            "	},												\n" +
-            "	\"response\": {									\n" +
-            "		\"status\": 200,							\n" +
-            "		\"body\": \"Body from mapping file\"		\n" +
-            "	}												\n" +
-            "}													";
+        "{     												\n" +
+            "    \"requesttttt\": {      						\n" +
+            "    	\"method\": \"GET\",						\n" +
+            "    	\"url\": \"/resource/from/file\"			\n" +
+            "    },												\n" +
+            "    \"response\": {									\n" +
+            "    	\"status\": 200,							\n" +
+            "    	\"body\": \"Body from mapping file\"		\n" +
+            "    }												\n" +
+            "}    												";
 
     @Test
     public void failsWithUsefulErrorMessageWhenMappingFileIsInvalid() {
@@ -437,87 +437,87 @@ public class StandaloneAcceptanceTest {
         return Files.toString(firstFileWithNameLike(mappingsDirectory, namePart), UTF_8);
     }
 
-	private File firstFileWithNameLike(File directory, String namePart) {
-	    for (File file: directory.listFiles(namedLike(namePart))) {
-	        return file;
-	    }
+    private File firstFileWithNameLike(File directory, String namePart) {
+        for (File file: directory.listFiles(namedLike(namePart))) {
+            return file;
+        }
 
-	    fail(String.format("Couldn't find a file under %s named like %s", directory.getPath(), namePart));
-	    return null;
-	}
+        fail(String.format("Couldn't find a file under %s named like %s", directory.getPath(), namePart));
+        return null;
+    }
 
-	private FilenameFilter namedLike(final String namePart) {
-	    return new FilenameFilter() {
+    private FilenameFilter namedLike(final String namePart) {
+        return new FilenameFilter() {
             @Override
-			public boolean accept(File file, String name) {
+    		public boolean accept(File file, String name) {
                 return name.contains(namePart);
             }
         };
-	}
+    }
 
-	private WireMock startOtherServerAndClient() {
+    private WireMock startOtherServerAndClient() {
         otherServer = new WireMockServer(Options.DYNAMIC_PORT);
         otherServer.start();
         return WireMock.create().port(otherServer.port()).build();
     }
 
-	private void writeFileToFilesDir(String name, String contents) {
-		writeFile(underFileSourceRoot(underFiles(name)), contents);
+    private void writeFileToFilesDir(String name, String contents) {
+    	writeFile(underFileSourceRoot(underFiles(name)), contents);
     }
 
     private void writeFileToFilesDir(String name, byte[] contents) {
-		try {
-			String filePath = underFileSourceRoot(underFiles(name));
-			File file = new File(filePath);
-			createParentDirs(file);
-			write(contents, file);
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
-	}
+    	try {
+    		String filePath = underFileSourceRoot(underFiles(name));
+    		File file = new File(filePath);
+    		createParentDirs(file);
+    		write(contents, file);
+    	} catch (IOException e) {
+    		throw new RuntimeException(e);
+    	}
+    }
 
-	private void writeMappingFile(String name, String contents) {
-		writeFile(underFileSourceRoot(underMappings(name)), contents);
-	}
+    private void writeMappingFile(String name, String contents) {
+    	writeFile(underFileSourceRoot(underMappings(name)), contents);
+    }
 
-	private void writeFile(String absolutePath, String contents) {
+    private void writeFile(String absolutePath, String contents) {
         try {
-			File file = new File(absolutePath);
+    		File file = new File(absolutePath);
             createParentDirs(file);
-			write(contents, file, Charsets.UTF_8);
+    		write(contents, file, Charsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-	private String underFiles(String name) {
-		return FILES + separator + name;
-	}
+    private String underFiles(String name) {
+    	return FILES + separator + name;
+    }
 
-	private String underMappings(String name) {
-		return MAPPINGS + separator + name;
-	}
+    private String underMappings(String name) {
+    	return MAPPINGS + separator + name;
+    }
 
-	private String underFileSourceRoot(String relativePath) {
-		return FILE_SOURCE_ROOT + separator + relativePath;
-	}
+    private String underFileSourceRoot(String relativePath) {
+    	return FILE_SOURCE_ROOT + separator + relativePath;
+    }
 
-	private void startRunner(String... args) {
+    private void startRunner(String... args) {
         runner = new WireMockServerRunner();
-		runner.run(argsWithPort(argsWithRecordingsPath(args)));
+    	runner.run(argsWithPort(argsWithRecordingsPath(args)));
 
         int port = runner.port();
         testClient = new WireMockTestClient(port);
         WireMock.configureFor(port);
-	}
+    }
 
-	private String[] argsWithRecordingsPath(String[] args) {
-		List<String> argsAsList = new ArrayList<String>(asList(args));
-		if (!argsAsList.contains("--root-dir")) {
-			argsAsList.addAll(asList("--root-dir", FILE_SOURCE_ROOT.getPath()));
-		}
-		return argsAsList.toArray(new String[]{});
-	}
+    private String[] argsWithRecordingsPath(String[] args) {
+    	List<String> argsAsList = new ArrayList<String>(asList(args));
+    	if (!argsAsList.contains("--root-dir")) {
+    		argsAsList.addAll(asList("--root-dir", FILE_SOURCE_ROOT.getPath()));
+    	}
+    	return argsAsList.toArray(new String[]{});
+    }
 
     private String[] argsWithPort(String[] args) {
         List<String> argsAsList = new ArrayList<String>(asList(args));
@@ -527,50 +527,50 @@ public class StandaloneAcceptanceTest {
         return argsAsList.toArray(new String[]{});
     }
 
-	private void startRecordingSystemOutAndErr() {
-		out = new ByteArrayOutputStream();
+    private void startRecordingSystemOutAndErr() {
+    	out = new ByteArrayOutputStream();
         err = new ByteArrayOutputStream();
 
-		System.setOut(new PrintStream(out));
+    	System.setOut(new PrintStream(out));
         System.setErr(new PrintStream(err));
-	}
+    }
 
-	private String systemOutText() {
-		return new String(out.toByteArray());
-	}
+    private String systemOutText() {
+    	return new String(out.toByteArray());
+    }
 
     private String systemErrText() {
         return new String(err.toByteArray());
     }
 
-	private Matcher<File> containsAFileContaining(final String expectedContents) {
-		return new TypeSafeMatcher<File>() {
+    private Matcher<File> containsAFileContaining(final String expectedContents) {
+    	return new TypeSafeMatcher<File>() {
 
-			@Override
-			public void describeTo(Description desc) {
-				desc.appendText("a file containing " + expectedContents);
+    		@Override
+    		public void describeTo(Description desc) {
+    			desc.appendText("a file containing " + expectedContents);
 
-			}
+    		}
 
-			@Override
-			public boolean matchesSafely(File dir) {
-				for (File file: dir.listFiles()) {
-					try {
-						if (Files.toString(file, Charsets.UTF_8).contains(expectedContents)) {
-							return true;
-						}
-					} catch (IOException e) {
-						throw new RuntimeException(e);
-					}
-				}
+    		@Override
+    		public boolean matchesSafely(File dir) {
+    			for (File file: dir.listFiles()) {
+    				try {
+    					if (Files.toString(file, Charsets.UTF_8).contains(expectedContents)) {
+    						return true;
+    					}
+    				} catch (IOException e) {
+    					throw new RuntimeException(e);
+    				}
+    			}
 
-				return false;
-			}
+    			return false;
+    		}
 
-		};
-	}
+    	};
+    }
 
-	private Matcher<File> doesNotContainAFileWithNameContaining(final String namePart) {
+    private Matcher<File> doesNotContainAFileWithNameContaining(final String namePart) {
         return new TypeSafeMatcher<File>() {
 
             @Override
@@ -606,7 +606,7 @@ public class StandaloneAcceptanceTest {
     }
 
     private static Predicate<String> contains(final String part) {
-	    return new Predicate<String>() {
+        return new Predicate<String>() {
             @Override
             public boolean apply(String s) {
                 return s.contains(part);
@@ -646,9 +646,9 @@ public class StandaloneAcceptanceTest {
         }
     }
 
-	public static String padRight(String s, int paddingLength) {
-		return String.format("%1$-" + paddingLength + "s", s);
-	}
+    public static String padRight(String s, int paddingLength) {
+    	return String.format("%1$-" + paddingLength + "s", s);
+    }
 
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/StubbingAcceptanceTest.java
@@ -56,69 +56,69 @@ import static org.junit.Assert.assertTrue;
 
 public class StubbingAcceptanceTest extends AcceptanceTestBase {
 
-	@BeforeClass
-	public static void setupServer() {
-		setupServerWithMappingsInFileRoot();
-	}
+    @BeforeClass
+    public static void setupServer() {
+    	setupServerWithMappingsInFileRoot();
+    }
 
-	@Test
-	public void mappingWithExactUrlAndMethodMatch() {
-		stubFor(get(urlEqualTo("/a/registered/resource")).willReturn(
-				aResponse()
-				.withStatus(401)
-				.withHeader("Content-Type", "text/plain")
-				.withBody("Not allowed!")));
+    @Test
+    public void mappingWithExactUrlAndMethodMatch() {
+    	stubFor(get(urlEqualTo("/a/registered/resource")).willReturn(
+    			aResponse()
+    			.withStatus(401)
+    			.withHeader("Content-Type", "text/plain")
+    			.withBody("Not allowed!")));
 
-		WireMockResponse response = testClient.get("/a/registered/resource");
+    	WireMockResponse response = testClient.get("/a/registered/resource");
 
-		assertThat(response.statusCode(), is(401));
-		assertThat(response.content(), is("Not allowed!"));
-		assertThat(response.firstHeader("Content-Type"), is("text/plain"));
-	}
+    	assertThat(response.statusCode(), is(401));
+    	assertThat(response.content(), is("Not allowed!"));
+    	assertThat(response.firstHeader("Content-Type"), is("text/plain"));
+    }
 
-	@Test
-	public void mappingWithUrlContainingQueryParameters() {
-		stubFor(get(urlEqualTo("/search?name=John&postcode=N44LL")).willReturn(
-				aResponse()
-						.withHeader("Location", "/nowhere")
-						.withStatus(302)));
+    @Test
+    public void mappingWithUrlContainingQueryParameters() {
+    	stubFor(get(urlEqualTo("/search?name=John&postcode=N44LL")).willReturn(
+    			aResponse()
+    					.withHeader("Location", "/nowhere")
+    					.withStatus(302)));
 
-		WireMockResponse response = testClient.get("/search?name=John&postcode=N44LL");
+    	WireMockResponse response = testClient.get("/search?name=John&postcode=N44LL");
 
-		assertThat(response.statusCode(), is(302));
-	}
+    	assertThat(response.statusCode(), is(302));
+    }
 
-	@Test
-	public void mappingWithHeaderMatchers() {
-		stubFor(put(urlEqualTo("/some/url"))
-			.withHeader("One", equalTo("abcd1234"))
-			.withHeader("Two", matching("[a-z]{5}"))
-			.withHeader("Three", notMatching("[A-Z]+"))
-			.willReturn(aResponse().withStatus(204)));
+    @Test
+    public void mappingWithHeaderMatchers() {
+    	stubFor(put(urlEqualTo("/some/url"))
+    		.withHeader("One", equalTo("abcd1234"))
+    		.withHeader("Two", matching("[a-z]{5}"))
+    		.withHeader("Three", notMatching("[A-Z]+"))
+    		.willReturn(aResponse().withStatus(204)));
 
-		WireMockResponse response = testClient.put("/some/url",
-				withHeader("One", "abcd1234"),
-				withHeader("Two", "thing"),
-				withHeader("Three", "something"));
+    	WireMockResponse response = testClient.put("/some/url",
+    			withHeader("One", "abcd1234"),
+    			withHeader("Two", "thing"),
+    			withHeader("Three", "something"));
 
-		assertThat(response.statusCode(), is(204));
-	}
+    	assertThat(response.statusCode(), is(204));
+    }
 
-	@Test
-	public void mappingWithCaseInsensitiveHeaderMatchers() {
-		stubFor(put(urlEqualTo("/case/insensitive"))
-			.withHeader("ONE", equalTo("abcd1234"))
-			.withHeader("two", matching("[a-z]{5}"))
-			.withHeader("Three", notMatching("[A-Z]+"))
-			.willReturn(aResponse().withStatus(204)));
+    @Test
+    public void mappingWithCaseInsensitiveHeaderMatchers() {
+    	stubFor(put(urlEqualTo("/case/insensitive"))
+    		.withHeader("ONE", equalTo("abcd1234"))
+    		.withHeader("two", matching("[a-z]{5}"))
+    		.withHeader("Three", notMatching("[A-Z]+"))
+    		.willReturn(aResponse().withStatus(204)));
 
-		WireMockResponse response = testClient.put("/case/insensitive",
-			withHeader("one", "abcd1234"),
-			withHeader("TWO", "thing"),
-			withHeader("tHrEe", "something"));
+    	WireMockResponse response = testClient.put("/case/insensitive",
+    		withHeader("one", "abcd1234"),
+    		withHeader("TWO", "thing"),
+    		withHeader("tHrEe", "something"));
 
-		assertThat(response.statusCode(), is(204));
-	}
+    	assertThat(response.statusCode(), is(204));
+    }
 
     @Test
     public void doesNotMatchOnAbsentHeader() {
@@ -137,8 +137,8 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
                 .willReturn(aResponse().withStatus(200)));
 
         WireMockResponse response = testClient.get("/some/extra/header",
-			withHeader("ExpectedHeader", "expected-value"),
-			withHeader("UnexpectedHeader", "unexpected-value"));
+    		withHeader("ExpectedHeader", "expected-value"),
+    		withHeader("UnexpectedHeader", "unexpected-value"));
 
         assertThat(response.statusCode(), is(200));
     }
@@ -166,29 +166,29 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(testClient.get("/path-and-query/match?since=2018-03-02&search=WireMock%20stubbing").statusCode(), is(200));
     }
 
-	@Test
-	public void doesNotMatchOnUrlPathWhenExtraPathElementsPresent() {
-		stubFor(get(urlPathEqualTo("/matching-path")).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void doesNotMatchOnUrlPathWhenExtraPathElementsPresent() {
+    	stubFor(get(urlPathEqualTo("/matching-path")).willReturn(aResponse().withStatus(200)));
 
-		assertThat(testClient.get("/matching-path/extra").statusCode(), is(404));
-	}
+    	assertThat(testClient.get("/matching-path/extra").statusCode(), is(404));
+    }
 
-	@Test
-	public void doesNotMatchOnUrlPathWhenPathShorter() {
-	    stubFor(get(urlPathEqualTo("/matching-path")).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void doesNotMatchOnUrlPathWhenPathShorter() {
+        stubFor(get(urlPathEqualTo("/matching-path")).willReturn(aResponse().withStatus(200)));
 
-	    assertThat(testClient.get("/matching").statusCode(), is(404));
-	}
+        assertThat(testClient.get("/matching").statusCode(), is(404));
+    }
 
-	@Test
-	public void matchesOnUrlPathPatternAndQueryParameters() {
-		stubFor(get(urlPathMatching("/path(.*)/match"))
-				.withQueryParam("search", containing("WireMock"))
-				.withQueryParam("since", equalTo("2014-10-14"))
-				.willReturn(aResponse().withStatus(200)));
+    @Test
+    public void matchesOnUrlPathPatternAndQueryParameters() {
+    	stubFor(get(urlPathMatching("/path(.*)/match"))
+    			.withQueryParam("search", containing("WireMock"))
+    			.withQueryParam("since", equalTo("2014-10-14"))
+    			.willReturn(aResponse().withStatus(200)));
 
-		assertThat(testClient.get("/path-and-query/match?since=2014-10-14&search=WireMock%20stubbing").statusCode(), is(200));
-	}
+    	assertThat(testClient.get("/path-and-query/match?since=2014-10-14&search=WireMock%20stubbing").statusCode(), is(200));
+    }
 
     @Test
     public void matchesOnUrlPathPatternAndMultipleQueryParameters() {
@@ -203,28 +203,28 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(testClient.get("/path-and-query/match?since=2018-03-02&search=WireMock%20stubbing").statusCode(), is(200));
     }
 
-	@Test
-	public void doesNotMatchOnUrlPathPatternWhenPathShorter() {
-	    stubFor(get(urlPathMatching("/matching-path")).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void doesNotMatchOnUrlPathPatternWhenPathShorter() {
+        stubFor(get(urlPathMatching("/matching-path")).willReturn(aResponse().withStatus(200)));
 
-	    assertThat(testClient.get("/matching").statusCode(), is(404));
-	}
+        assertThat(testClient.get("/matching").statusCode(), is(404));
+    }
 
-	@Test
-	public void doesNotMatchOnUrlPathPatternWhenExtraPathPresent() {
-	    stubFor(get(urlPathMatching("/matching-path")).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void doesNotMatchOnUrlPathPatternWhenExtraPathPresent() {
+        stubFor(get(urlPathMatching("/matching-path")).willReturn(aResponse().withStatus(200)));
 
-	    assertThat(testClient.get("/matching-path/extra").statusCode(), is(404));
-	}
+        assertThat(testClient.get("/matching-path/extra").statusCode(), is(404));
+    }
 
-	@Test
-	public void doesNotMatchIfSpecifiedQueryParameterNotInRequest() {
-		stubFor(get(urlPathEqualTo("/path-and-query/match"))
-				.withQueryParam("search", containing("WireMock"))
-				.willReturn(aResponse().withStatus(200)));
+    @Test
+    public void doesNotMatchIfSpecifiedQueryParameterNotInRequest() {
+    	stubFor(get(urlPathEqualTo("/path-and-query/match"))
+    			.withQueryParam("search", containing("WireMock"))
+    			.willReturn(aResponse().withStatus(200)));
 
-		assertThat(testClient.get("/path-and-query/match?wrongParam=wrongVal").statusCode(), is(404));
-	}
+    	assertThat(testClient.get("/path-and-query/match?wrongParam=wrongVal").statusCode(), is(404));
+    }
 
     @Test
     public void doesNotMatchIfSpecifiedAbsentQueryParameterIsPresentInRequest() {
@@ -245,23 +245,23 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
     }
 
     @Test
-	public void responseBodyLoadedFromFile() {
-		stubFor(get(urlEqualTo("/my/file")).willReturn(
-			aResponse()
-				.withStatus(200)
-				.withBodyFile("plain-example.txt")));
+    public void responseBodyLoadedFromFile() {
+    	stubFor(get(urlEqualTo("/my/file")).willReturn(
+    		aResponse()
+    			.withStatus(200)
+    			.withBodyFile("plain-example.txt")));
 
-		WireMockResponse response = testClient.get("/my/file");
+    	WireMockResponse response = testClient.get("/my/file");
 
-		assertThat(response.content(), is("Some example test from a file"));
-	}
+    	assertThat(response.content(), is("Some example test from a file"));
+    }
 
-	@Test
-	public void matchingOnRequestBodyWithTwoRegexes() {
-		stubFor(put(urlEqualTo("/match/this/body"))
-	            .withRequestBody(matching(".*Blah.*"))
-	            .withRequestBody(matching(".*@[0-9]{5}@.*"))
-	            .willReturn(aResponse()
+    @Test
+    public void matchingOnRequestBodyWithTwoRegexes() {
+    	stubFor(put(urlEqualTo("/match/this/body"))
+                .withRequestBody(matching(".*Blah.*"))
+                .withRequestBody(matching(".*@[0-9]{5}@.*"))
+                .willReturn(aResponse()
                 .withStatus(HTTP_OK)
                 .withBodyFile("plain-example.txt")));
 
@@ -272,11 +272,11 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
 
         response = testClient.putWithBody("/match/this/body", "BlahBlah@56565@Blah", "text/plain");
         assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    }
 
-	@Test
+    @Test
     public void matchingOnRequestBodyWithAContainsAndANegativeRegex() {
-		stubFor(put(urlEqualTo("/match/this/body/too"))
+    	stubFor(put(urlEqualTo("/match/this/body/too"))
                 .withRequestBody(containing("Blah"))
                 .withRequestBody(notMatching(".*[0-9]+.*"))
                 .willReturn(aResponse()
@@ -290,7 +290,7 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(response.statusCode(), is(HTTP_OK));
     }
 
-	@Test
+    @Test
     public void matchingOnRequestBodyWithEqualTo() {
         stubFor(put(urlEqualTo("/match/this/body/too"))
                 .withRequestBody(equalTo("BlahBlahBlah"))
@@ -305,119 +305,119 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(response.statusCode(), is(HTTP_OK));
     }
 
-	@Test
-	public void matchingOnRequestBodyWithBinaryEqualTo() {
-		byte[] requestBody = new byte[] { 1, 2, 3 };
+    @Test
+    public void matchingOnRequestBodyWithBinaryEqualTo() {
+    	byte[] requestBody = new byte[] { 1, 2, 3 };
 
-		stubFor(post("/match/binary")
-			.withRequestBody(binaryEqualTo(requestBody))
-			.willReturn(ok("Matched binary"))
+    	stubFor(post("/match/binary")
+    		.withRequestBody(binaryEqualTo(requestBody))
+    		.willReturn(ok("Matched binary"))
         );
 
         WireMockResponse response = testClient.post("/match/binary", new ByteArrayEntity(new byte[] { 9 }, APPLICATION_OCTET_STREAM));
         assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.post("/match/binary", new ByteArrayEntity(requestBody, APPLICATION_OCTET_STREAM));
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.post("/match/binary", new ByteArrayEntity(requestBody, APPLICATION_OCTET_STREAM));
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingOnRequestBodyWithAdvancedJsonPath() {
-		stubFor(post("/jsonpath/advanced")
-			.withRequestBody(matchingJsonPath("$.counter", equalTo("123")))
-			.withRequestBody(matchingJsonPath("$.wrong", absent()))
-			.willReturn(ok())
-		);
+    @Test
+    public void matchingOnRequestBodyWithAdvancedJsonPath() {
+    	stubFor(post("/jsonpath/advanced")
+    		.withRequestBody(matchingJsonPath("$.counter", equalTo("123")))
+    		.withRequestBody(matchingJsonPath("$.wrong", absent()))
+    		.willReturn(ok())
+    	);
 
-		WireMockResponse response = testClient.postJson("/jsonpath/advanced", "{ \"counter\": 234 }");
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postJson("/jsonpath/advanced", "{ \"counter\": 234 }");
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
         response = testClient.postJson("/jsonpath/advanced", "{ \"counter\": 123 }");
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingOnRequestBodyWithAdvancedXPath() {
-		stubFor(post("/xpath/advanced")
-			.withRequestBody(matchingXPath("//counter/text()", equalTo("123")))
-			.willReturn(ok())
-		);
+    @Test
+    public void matchingOnRequestBodyWithAdvancedXPath() {
+    	stubFor(post("/xpath/advanced")
+    		.withRequestBody(matchingXPath("//counter/text()", equalTo("123")))
+    		.willReturn(ok())
+    	);
 
-		WireMockResponse response = testClient.postXml("/xpath/advanced", "<counter>6666</counter>");
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postXml("/xpath/advanced", "<counter>6666</counter>");
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.postXml("/xpath/advanced", "<counter>123</counter>");
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.postXml("/xpath/advanced", "<counter>123</counter>");
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void highPriorityMappingMatchedFirst() {
-		stubFor(get(urlMatching("/priority/.*")).atPriority(10)
-				.willReturn(aResponse()
-						.withStatus(500)));
-		stubFor(get(urlEqualTo("/priority/resource")).atPriority(2).willReturn(aResponse().withStatus(200)));
+    @Test
+    public void highPriorityMappingMatchedFirst() {
+    	stubFor(get(urlMatching("/priority/.*")).atPriority(10)
+    			.willReturn(aResponse()
+    					.withStatus(500)));
+    	stubFor(get(urlEqualTo("/priority/resource")).atPriority(2).willReturn(aResponse().withStatus(200)));
 
-		assertThat(testClient.get("/priority/resource").statusCode(), is(200));
-	}
+    	assertThat(testClient.get("/priority/resource").statusCode(), is(200));
+    }
 
-	@Rule
-	public final ExpectedException exception = ExpectedException.none();
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
-	@Test
-	public void connectionResetByPeerFault() {
-		stubFor(get(urlEqualTo("/connection/reset")).willReturn(
+    @Test
+    public void connectionResetByPeerFault() {
+    	stubFor(get(urlEqualTo("/connection/reset")).willReturn(
                 aResponse()
                 .withFault(Fault.CONNECTION_RESET_BY_PEER)));
 
-		exception.expectCause(IsInstanceOf.<Throwable>instanceOf(SocketException.class));
-		exception.expectMessage("java.net.SocketException: Connection reset");
-		testClient.get("/connection/reset");
-	}
+    	exception.expectCause(IsInstanceOf.<Throwable>instanceOf(SocketException.class));
+    	exception.expectMessage("java.net.SocketException: Connection reset");
+    	testClient.get("/connection/reset");
+    }
 
-	@Test
-	public void emptyResponseFault() {
-		stubFor(get(urlEqualTo("/empty/response")).willReturn(
+    @Test
+    public void emptyResponseFault() {
+    	stubFor(get(urlEqualTo("/empty/response")).willReturn(
                 aResponse()
                 .withFault(Fault.EMPTY_RESPONSE)));
 
-		getAndAssertUnderlyingExceptionInstanceClass("/empty/response", NoHttpResponseException.class);
-	}
+    	getAndAssertUnderlyingExceptionInstanceClass("/empty/response", NoHttpResponseException.class);
+    }
 
-	@Test
-	public void malformedResponseChunkFault() {
-		stubFor(get(urlEqualTo("/malformed/response")).willReturn(
+    @Test
+    public void malformedResponseChunkFault() {
+    	stubFor(get(urlEqualTo("/malformed/response")).willReturn(
                 aResponse()
                 .withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
 
-		getAndAssertUnderlyingExceptionInstanceClass("/malformed/response", MalformedChunkCodingException.class);
-	}
+    	getAndAssertUnderlyingExceptionInstanceClass("/malformed/response", MalformedChunkCodingException.class);
+    }
 
-	@Test
-	public void randomDataOnSocketFault() {
-		stubFor(get(urlEqualTo("/random/data")).willReturn(
+    @Test
+    public void randomDataOnSocketFault() {
+    	stubFor(get(urlEqualTo("/random/data")).willReturn(
                 aResponse()
                 .withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
 
-		getAndAssertUnderlyingExceptionInstanceClass("/random/data", ClientProtocolException.class);
-	}
+    	getAndAssertUnderlyingExceptionInstanceClass("/random/data", ClientProtocolException.class);
+    }
 
-	@Test
-	public void matchingUrlsWithEscapeCharacters() {
-		stubFor(get(urlEqualTo("/%26%26The%20Lord%20of%20the%20Rings%26%26")).willReturn(aResponse().withStatus(HTTP_OK)));
-		assertThat(testClient.get("/%26%26The%20Lord%20of%20the%20Rings%26%26").statusCode(), is(HTTP_OK));
-	}
+    @Test
+    public void matchingUrlsWithEscapeCharacters() {
+    	stubFor(get(urlEqualTo("/%26%26The%20Lord%20of%20the%20Rings%26%26")).willReturn(aResponse().withStatus(HTTP_OK)));
+    	assertThat(testClient.get("/%26%26The%20Lord%20of%20the%20Rings%26%26").statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingUrlPathsWithEscapeCharacters() {
-	    stubFor(get(urlPathEqualTo("/%26%26The%20Lord%20of%20the%20Rings%26%26")).willReturn(aResponse().withStatus(HTTP_OK)));
-	    assertThat(testClient.get("/%26%26The%20Lord%20of%20the%20Rings%26%26").statusCode(), is(HTTP_OK));
-	}
+    @Test
+    public void matchingUrlPathsWithEscapeCharacters() {
+        stubFor(get(urlPathEqualTo("/%26%26The%20Lord%20of%20the%20Rings%26%26")).willReturn(aResponse().withStatus(HTTP_OK)));
+        assertThat(testClient.get("/%26%26The%20Lord%20of%20the%20Rings%26%26").statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void default200ResponseWhenStatusCodeNotSpecified() {
-		stubFor(get(urlEqualTo("/default/two-hundred")).willReturn(aResponse()));
-		assertThat(testClient.get("/default/two-hundred").statusCode(), is(HTTP_OK));
-	}
+    @Test
+    public void default200ResponseWhenStatusCodeNotSpecified() {
+    	stubFor(get(urlEqualTo("/default/two-hundred")).willReturn(aResponse()));
+    	assertThat(testClient.get("/default/two-hundred").statusCode(), is(HTTP_OK));
+    }
 
     @Test
     public void returningBinaryBody() {
@@ -448,35 +448,35 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
     @Test
     public void stubbingPatch() {
         stubFor(patch(urlEqualTo("/a/registered/resource")).withRequestBody(equalTo("some body"))
-				.willReturn(aResponse().withStatus(204)));
+    			.willReturn(aResponse().withStatus(204)));
 
         WireMockResponse response = testClient.patchWithBody("/a/registered/resource", "some body", "text/plain");
 
         assertThat(response.statusCode(), is(204));
     }
 
-	@Test
-	public void stubbingArbitraryMethod() {
-		stubFor(request("KILL", urlEqualTo("/some/url"))
-				.willReturn(aResponse().withStatus(204)));
+    @Test
+    public void stubbingArbitraryMethod() {
+    	stubFor(request("KILL", urlEqualTo("/some/url"))
+    			.willReturn(aResponse().withStatus(204)));
 
-		WireMockResponse response = testClient.request("KILL", "/some/url");
+    	WireMockResponse response = testClient.request("KILL", "/some/url");
 
-		assertThat(response.statusCode(), is(204));
-	}
+    	assertThat(response.statusCode(), is(204));
+    }
 
-	@Test
-	public void settingStatusMessage() {
-		stubFor(get(urlEqualTo("/status-message")).willReturn(
-			aResponse()
-				.withStatus(500)
-				.withStatusMessage("The bees! They're in my eyes!")));
+    @Test
+    public void settingStatusMessage() {
+    	stubFor(get(urlEqualTo("/status-message")).willReturn(
+    		aResponse()
+    			.withStatus(500)
+    			.withStatusMessage("The bees! They're in my eyes!")));
 
-		assertThat(testClient.get("/status-message").statusMessage(), is("The bees! They're in my eyes!"));
-	}
+    	assertThat(testClient.get("/status-message").statusMessage(), is("The bees! They're in my eyes!"));
+    }
 
-	@Test
-	public void doesNotAttemptToMatchXmlBodyWhenStubMappingDoesNotHaveOne() {
+    @Test
+    public void doesNotAttemptToMatchXmlBodyWhenStubMappingDoesNotHaveOne() {
         stubFor(options(urlEqualTo("/no-body")).willReturn(aResponse().withStatus(200)));
         stubFor(post(urlEqualTo("/no-body"))
             .withRequestBody(equalToXml("<some-xml />"))
@@ -486,27 +486,27 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(response.statusCode(), is(200));
     }
 
-	@Test
-	public void matchXmlBodyWhenTextNodeIsIgnored() {
-		String url = "/ignore/my/xml";
+    @Test
+    public void matchXmlBodyWhenTextNodeIsIgnored() {
+    	String url = "/ignore/my/xml";
 
-		stubFor(post(url)
-				.withRequestBody(equalToXml("<a>#{xmlunit.ignore}</a>", true, "#\\{", "}"))
-				.willReturn(ok()));
+    	stubFor(post(url)
+    			.withRequestBody(equalToXml("<a>#{xmlunit.ignore}</a>", true, "#\\{", "}"))
+    			.willReturn(ok()));
 
-		assertThat(testClient.postXml(url, "<a>123</a>").statusCode(), is(200));
-	}
+    	assertThat(testClient.postXml(url, "<a>123</a>").statusCode(), is(200));
+    }
 
-	@Test
-	public void doesNotIgnoreXmlWhenPlaceholderMatchingIsFalse() {
-		String url = "/do-not-ignore/my/xml";
+    @Test
+    public void doesNotIgnoreXmlWhenPlaceholderMatchingIsFalse() {
+    	String url = "/do-not-ignore/my/xml";
 
-		stubFor(post(url)
-				.withRequestBody(equalToXml("<a>#{xmlunit.ignore}</a>", false, "#\\{", "}"))
-				.willReturn(ok()));
+    	stubFor(post(url)
+    			.withRequestBody(equalToXml("<a>#{xmlunit.ignore}</a>", false, "#\\{", "}"))
+    			.willReturn(ok()));
 
-		assertThat(testClient.postXml(url, "<a>123</a>").statusCode(), is(404));
-	}
+    	assertThat(testClient.postXml(url, "<a>123</a>").statusCode(), is(404));
+    }
 
     @Test
     public void matchesQueryParamsUnencoded() {
@@ -518,7 +518,7 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(response.statusCode(), is(200));
     }
 
-	@Test
+    @Test
     public void copesWithEmptyRequestHeaderValueWhenMatchingOnEqualTo() {
         stubFor(get(urlPathEqualTo("/empty-header"))
             .withHeader("X-My-Header", equalTo(""))
@@ -529,8 +529,8 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(response.statusCode(), is(200));
     }
 
-	@Test
-	public void assignsAnIdAndReturnsNewlyCreatedStubMapping() {
+    @Test
+    public void assignsAnIdAndReturnsNewlyCreatedStubMapping() {
         StubMapping stubMapping = stubFor(get(anyUrl()).willReturn(aResponse()));
         assertThat(stubMapping.getId(), notNullValue());
 
@@ -538,8 +538,8 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         assertThat(localStubMapping.getId(), notNullValue());
     }
 
-	@Test
-	public void getsASingleStubMappingById() {
+    @Test
+    public void getsASingleStubMappingById() {
         UUID id = UUID.randomUUID();
         stubFor(get(anyUrl())
             .withId(id)
@@ -558,135 +558,135 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
     }
 
     @Test
-	public void stubMappingsCanOptionallyBeNamed() {
-	    stubFor(any(urlPathEqualTo("/things"))
+    public void stubMappingsCanOptionallyBeNamed() {
+        stubFor(any(urlPathEqualTo("/things"))
             .withName("Get all the things")
             .willReturn(aResponse().withBody("Named stub")));
 
-	    assertThat(listAllStubMappings().getMappings(), hasItem(named("Get all the things")));
+        assertThat(listAllStubMappings().getMappings(), hasItem(named("Get all the things")));
     }
 
-	@Test
-	public void matchingOnMultipartRequestBodyWithTwoRegexes() {
-		stubFor(post(urlEqualTo("/match/this/part"))
-				.withMultipartRequestBody(
-						aMultipart().withBody(matching(".*Blah.*"))
-				)
-				.withMultipartRequestBody(
-						aMultipart().withBody(matching(".*@[0-9]{5}@.*"))
-				)
-				.willReturn(aResponse()
-						.withStatus(HTTP_OK)
-						.withBodyFile("plain-example.txt")));
+    @Test
+    public void matchingOnMultipartRequestBodyWithTwoRegexes() {
+    	stubFor(post(urlEqualTo("/match/this/part"))
+    			.withMultipartRequestBody(
+    					aMultipart().withBody(matching(".*Blah.*"))
+    			)
+    			.withMultipartRequestBody(
+    					aMultipart().withBody(matching(".*@[0-9]{5}@.*"))
+    			)
+    			.willReturn(aResponse()
+    					.withStatus(HTTP_OK)
+    					.withBodyFile("plain-example.txt")));
 
-		WireMockResponse response = testClient.postWithMultiparts("/match/this/part", singletonList(part("part-1", "Blah...but not the rest", TEXT_PLAIN)));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
-		response = testClient.postWithMultiparts("/match/this/part", singletonList(part("part-1", "@12345@...but not the rest", TEXT_PLAIN)));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postWithMultiparts("/match/this/part", singletonList(part("part-1", "Blah...but not the rest", TEXT_PLAIN)));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	response = testClient.postWithMultiparts("/match/this/part", singletonList(part("part-1", "@12345@...but not the rest", TEXT_PLAIN)));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.postWithMultiparts("/match/this/part", singletonList(part("good-part", "BlahBlah@56565@Blah", TEXT_PLAIN)));
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.postWithMultiparts("/match/this/part", singletonList(part("good-part", "BlahBlah@56565@Blah", TEXT_PLAIN)));
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingOnMultipartRequestBodyWithAContainsAndANegativeRegex() {
-		stubFor(post(urlEqualTo("/match/this/part/too"))
-				.withMultipartRequestBody(
-						aMultipart()
-								.withName("part-name")
-								.withBody(containing("Blah"))
-								.withBody(notMatching(".*[0-9]+.*"))
-				)
-				.willReturn(aResponse()
-						.withStatus(HTTP_OK)
-						.withBodyFile("plain-example.txt")));
+    @Test
+    public void matchingOnMultipartRequestBodyWithAContainsAndANegativeRegex() {
+    	stubFor(post(urlEqualTo("/match/this/part/too"))
+    			.withMultipartRequestBody(
+    					aMultipart()
+    							.withName("part-name")
+    							.withBody(containing("Blah"))
+    							.withBody(notMatching(".*[0-9]+.*"))
+    			)
+    			.willReturn(aResponse()
+    					.withStatus(HTTP_OK)
+    					.withBodyFile("plain-example.txt")));
 
-		WireMockResponse response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part-name", "Blah12345", TEXT_PLAIN)));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part-name", "Blah12345", TEXT_PLAIN)));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part-name", "BlahBlahBlah", TEXT_PLAIN)));
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part-name", "BlahBlahBlah", TEXT_PLAIN)));
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingOnMultipartRequestBodyWithEqualTo() {
-		stubFor(post(urlEqualTo("/match/this/part/too"))
-				.withMultipartRequestBody(
-						aMultipart()
-								.withHeader("Content-Type", containing("text/plain"))
-								.withBody(equalTo("BlahBlahBlah"))
-				)
-				.willReturn(aResponse()
-						.withStatus(HTTP_OK)
-						.withBodyFile("plain-example.txt")));
+    @Test
+    public void matchingOnMultipartRequestBodyWithEqualTo() {
+    	stubFor(post(urlEqualTo("/match/this/part/too"))
+    			.withMultipartRequestBody(
+    					aMultipart()
+    							.withHeader("Content-Type", containing("text/plain"))
+    							.withBody(equalTo("BlahBlahBlah"))
+    			)
+    			.willReturn(aResponse()
+    					.withStatus(HTTP_OK)
+    					.withBodyFile("plain-example.txt")));
 
-		WireMockResponse response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part", "Blah12345", TEXT_PLAIN)));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part", "Blah12345", TEXT_PLAIN)));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part", "BlahBlahBlah", TEXT_PLAIN)));
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.postWithMultiparts("/match/this/part/too", singletonList(part("part", "BlahBlahBlah", TEXT_PLAIN)));
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingOnMultipartRequestBodyWithBinaryEqualTo() {
-		byte[] requestBody = new byte[] { 1, 2, 3 };
+    @Test
+    public void matchingOnMultipartRequestBodyWithBinaryEqualTo() {
+    	byte[] requestBody = new byte[] { 1, 2, 3 };
 
-		stubFor(post("/match/part/binary")
-				.withMultipartRequestBody(
-						aMultipart()
-								.withBody(binaryEqualTo(requestBody))
-								.withName("file")
-				)
-				.willReturn(ok("Matched binary"))
-		);
+    	stubFor(post("/match/part/binary")
+    			.withMultipartRequestBody(
+    					aMultipart()
+    							.withBody(binaryEqualTo(requestBody))
+    							.withName("file")
+    			)
+    			.willReturn(ok("Matched binary"))
+    	);
 
-		WireMockResponse response = testClient.postWithMultiparts("/match/part/binary", singletonList(part("file", new byte[] { 9 })));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postWithMultiparts("/match/part/binary", singletonList(part("file", new byte[] { 9 })));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.postWithMultiparts("/match/part/binary", singletonList(part("file", requestBody)));
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.postWithMultiparts("/match/part/binary", singletonList(part("file", requestBody)));
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingOnMultipartRequestBodyWithAdvancedJsonPath() {
-		stubFor(post("/jsonpath/advanced/part")
-				.withMultipartRequestBody(
-						aMultipart()
-								.withName("json")
-								.withHeader("Content-Type", containing("application/json"))
-								.withBody(matchingJsonPath("$.counter", equalTo("123")))
-				)
-				.willReturn(ok())
-		);
+    @Test
+    public void matchingOnMultipartRequestBodyWithAdvancedJsonPath() {
+    	stubFor(post("/jsonpath/advanced/part")
+    			.withMultipartRequestBody(
+    					aMultipart()
+    							.withName("json")
+    							.withHeader("Content-Type", containing("application/json"))
+    							.withBody(matchingJsonPath("$.counter", equalTo("123")))
+    			)
+    			.willReturn(ok())
+    	);
 
-		WireMockResponse response = testClient.postWithMultiparts("/jsonpath/advanced/part", singletonList(part("json", "{ \"counter\": 234 }", APPLICATION_JSON)));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postWithMultiparts("/jsonpath/advanced/part", singletonList(part("json", "{ \"counter\": 234 }", APPLICATION_JSON)));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.postWithMultiparts("/jsonpath/advanced/part", singletonList(part("json", "{ \"counter\": 123 }", APPLICATION_JSON)));
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.postWithMultiparts("/jsonpath/advanced/part", singletonList(part("json", "{ \"counter\": 123 }", APPLICATION_JSON)));
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
-	@Test
-	public void matchingOnMultipartRequestBodyWithAdvancedXPath() {
-		stubFor(post("/xpath/advanced/part")
-				.withMultipartRequestBody(
-						aMultipart()
-								.withName("xml")
-								.withHeader("Content-Type", containing("application/xml"))
-								.withBody(matchingXPath("//counter/text()", equalTo("123")))
-				)
-				.willReturn(ok())
-		);
+    @Test
+    public void matchingOnMultipartRequestBodyWithAdvancedXPath() {
+    	stubFor(post("/xpath/advanced/part")
+    			.withMultipartRequestBody(
+    					aMultipart()
+    							.withName("xml")
+    							.withHeader("Content-Type", containing("application/xml"))
+    							.withBody(matchingXPath("//counter/text()", equalTo("123")))
+    			)
+    			.willReturn(ok())
+    	);
 
-		WireMockResponse response = testClient.postWithMultiparts("/xpath/advanced/part", singletonList(part("xml", "<counter>6666</counter>", APPLICATION_XML)));
-		assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
+    	WireMockResponse response = testClient.postWithMultiparts("/xpath/advanced/part", singletonList(part("xml", "<counter>6666</counter>", APPLICATION_XML)));
+    	assertThat(response.statusCode(), is(HTTP_NOT_FOUND));
 
-		response = testClient.postWithMultiparts("/xpath/advanced/part", singletonList(part("xml", "<counter>123</counter>", APPLICATION_XML)));
-		assertThat(response.statusCode(), is(HTTP_OK));
-	}
+    	response = testClient.postWithMultiparts("/xpath/advanced/part", singletonList(part("xml", "<counter>123</counter>", APPLICATION_XML)));
+    	assertThat(response.statusCode(), is(HTTP_OK));
+    }
 
     private Matcher<StubMapping> named(final String name) {
-	    return new TypeSafeMatcher<StubMapping>() {
+        return new TypeSafeMatcher<StubMapping>() {
             @Override
             public void describeTo(Description description) {
                 description.appendText("named " + name);
@@ -699,16 +699,16 @@ public class StubbingAcceptanceTest extends AcceptanceTestBase {
         };
     }
 
-	private void getAndAssertUnderlyingExceptionInstanceClass(String url, Class<?> expectedClass) {
-		boolean thrown = false;
-		try {
-			WireMockResponse response = testClient.get(url);
-			response.content();
-		} catch (Exception e) {
-			assertThat(e.getCause(), instanceOf(expectedClass));
-			thrown = true;
-		}
+    private void getAndAssertUnderlyingExceptionInstanceClass(String url, Class<?> expectedClass) {
+    	boolean thrown = false;
+    	try {
+    		WireMockResponse response = testClient.get(url);
+    		response.content();
+    	} catch (Exception e) {
+    		assertThat(e.getCause(), instanceOf(expectedClass));
+    		thrown = true;
+    	}
 
-		assertTrue("No exception was thrown", thrown);
-	}
+    	assertTrue("No exception was thrown", thrown);
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/UrlMatchingAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/UrlMatchingAcceptanceTest.java
@@ -23,23 +23,23 @@ import static org.junit.Assert.assertThat;
 
 public class UrlMatchingAcceptanceTest extends AcceptanceTestBase {
 
-	@Test
-	public void mappingMatchedWithRegexUrl() {
-		String REGEX_URL_MAPPING_REQUEST =
-			"{ 													\n" +
-			"	\"request\": {									\n" +
-			"		\"method\": \"GET\",						\n" +
-			"		\"urlPattern\": \"/one/(.*?)/three\"		\n" +
-			"	},												\n" +
-			"	\"response\": {									\n" +
-			"		\"body\": \"Matched!\"						\n" +
-			"	}												\n" +
-			"}													  ";
-		
-		testClient.addResponse(REGEX_URL_MAPPING_REQUEST);
-		WireMockResponse response = testClient.get("/one/two/three");
-		
-		assertThat(response.statusCode(), is(200));
-		assertThat(response.content(), is("Matched!"));
-	}
+    @Test
+    public void mappingMatchedWithRegexUrl() {
+    	String REGEX_URL_MAPPING_REQUEST =
+    		"{ 													\n" +
+    		"	\"request\": {									\n" +
+    		"		\"method\": \"GET\",						\n" +
+    		"		\"urlPattern\": \"/one/(.*?)/three\"		\n" +
+    		"	},												\n" +
+    		"	\"response\": {									\n" +
+    		"		\"body\": \"Matched!\"						\n" +
+    		"	}												\n" +
+    		"}													  ";
+    	
+    	testClient.addResponse(REGEX_URL_MAPPING_REQUEST);
+    	WireMockResponse response = testClient.get("/one/two/three");
+    	
+    	assertThat(response.statusCode(), is(200));
+    	assertThat(response.content(), is("Matched!"));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/VerificationAcceptanceTest.java
@@ -179,11 +179,11 @@ public class VerificationAcceptanceTest {
         }
 
         private static final String SAMPLE_JSON =
-            "{ 													\n" +
-            "	\"thing\": {									\n" +
-            "		\"importantKey\": \"Important value\"		\n" +
-            "	}												\n" +
-            "}													";
+            "{     												\n" +
+            "    \"thing\": {									\n" +
+            "    	\"importantKey\": \"Important value\"		\n" +
+            "    }												\n" +
+            "}    												";
 
 
         @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/WarDeploymentAcceptanceTest.java
@@ -43,63 +43,63 @@ public class WarDeploymentAcceptanceTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-	private Server jetty;
-	
-	private WireMockTestClient testClient;
-	
-	@Before
-	public void init() throws Exception {
+    private Server jetty;
+    
+    private WireMockTestClient testClient;
+    
+    @Before
+    public void init() throws Exception {
         String webAppRootPath = sampleWarRootDir() + "/src/main/webapp";
-		WebAppContext context = new WebAppContext(webAppRootPath, "/wiremock");
+    	WebAppContext context = new WebAppContext(webAppRootPath, "/wiremock");
 
-		int port = attemptToStartOnRandomPort(context);
+    	int port = attemptToStartOnRandomPort(context);
 
-		WireMock.configureFor("localhost", port, "/wiremock");
-		testClient = new WireMockTestClient(port);
-	}
+    	WireMock.configureFor("localhost", port, "/wiremock");
+    	testClient = new WireMockTestClient(port);
+    }
 
-	private int attemptToStartOnRandomPort(WebAppContext context) throws Exception {
-		int port;
+    private int attemptToStartOnRandomPort(WebAppContext context) throws Exception {
+    	int port;
 
-		int attemptsRemaining = 3;
-		while (true) {
-			port = Network.findFreePort();
-			jetty = new Server(port);
-			jetty.setHandler(context);
-			try {
-				jetty.start();
-				break;
-			} catch (Exception e) {
-				attemptsRemaining--;
-				if (attemptsRemaining > 0) {
-					continue;
-				}
+    	int attemptsRemaining = 3;
+    	while (true) {
+    		port = Network.findFreePort();
+    		jetty = new Server(port);
+    		jetty.setHandler(context);
+    		try {
+    			jetty.start();
+    			break;
+    		} catch (Exception e) {
+    			attemptsRemaining--;
+    			if (attemptsRemaining > 0) {
+    				continue;
+    			}
 
-				throw e;
-			}
-		}
-		return port;
-	}
+    			throw e;
+    		}
+    	}
+    	return port;
+    }
 
-	@After
-	public void cleanup() throws Exception {
-		jetty.stop();
-		WireMock.configure();
-	}
-	
-	@Test
-	public void servesBakedInStubResponse() {
-		WireMockResponse response = testClient.get("/wiremock/api/mytest");
-		assertThat(response.content(), containsString("YES"));
-	}
-	
-	@Test
-	public void acceptsAndReturnsStubMapping() {
-		givenThat(get(urlEqualTo("/war/stub")).willReturn(
-				aResponse().withStatus(HTTP_OK).withBody("War stub OK")));
-		
-		assertThat(testClient.get("/wiremock/war/stub").content(), is("War stub OK"));
-	}
+    @After
+    public void cleanup() throws Exception {
+    	jetty.stop();
+    	WireMock.configure();
+    }
+    
+    @Test
+    public void servesBakedInStubResponse() {
+    	WireMockResponse response = testClient.get("/wiremock/api/mytest");
+    	assertThat(response.content(), containsString("YES"));
+    }
+    
+    @Test
+    public void acceptsAndReturnsStubMapping() {
+    	givenThat(get(urlEqualTo("/war/stub")).willReturn(
+    			aResponse().withStatus(HTTP_OK).withBody("War stub OK")));
+    	
+    	assertThat(testClient.get("/wiremock/war/stub").content(), is("War stub OK"));
+    }
 
     @Test
     public void tryingToShutDownGives500() {

--- a/src/test/java/com/github/tomakehurst/wiremock/admin/OldEditStubMappingTaskTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/admin/OldEditStubMappingTaskTest.java
@@ -34,48 +34,48 @@ import static org.junit.Assert.assertThat;
 
 public class OldEditStubMappingTaskTest {
 
-	private static final StubMapping MOCK_MAPPING = new StubMapping(null, new ResponseDefinition());
+    private static final StubMapping MOCK_MAPPING = new StubMapping(null, new ResponseDefinition());
 
-	private Mockery context;
-	private Admin mockAdmin;
+    private Mockery context;
+    private Admin mockAdmin;
 
-	private Request mockRequest;
+    private Request mockRequest;
 
-	private OldEditStubMappingTask editStubMappingTask;
+    private OldEditStubMappingTask editStubMappingTask;
 
-	@Before
-	public void setUp() {
+    @Before
+    public void setUp() {
 
-		context = new Mockery();
-		mockAdmin = context.mock(Admin.class);
-		mockRequest = context.mock(Request.class);
+    	context = new Mockery();
+    	mockAdmin = context.mock(Admin.class);
+    	mockRequest = context.mock(Request.class);
 
-		editStubMappingTask = new OldEditStubMappingTask();
-	}
+    	editStubMappingTask = new OldEditStubMappingTask();
+    }
 
-	@Test
-	public void delegatesSavingMappingsToAdmin() {
+    @Test
+    public void delegatesSavingMappingsToAdmin() {
 
-		context.checking(new Expectations() {{
-			oneOf(mockRequest).getBodyAsString();
-			will(returnValue(buildJsonStringFor(MOCK_MAPPING)));
-			oneOf(mockAdmin).editStubMapping(with(any(StubMapping.class)));
-		}});
+    	context.checking(new Expectations() {{
+    		oneOf(mockRequest).getBodyAsString();
+    		will(returnValue(buildJsonStringFor(MOCK_MAPPING)));
+    		oneOf(mockAdmin).editStubMapping(with(any(StubMapping.class)));
+    	}});
 
-		editStubMappingTask.execute(mockAdmin, mockRequest, PathParams.empty());
-	}
+    	editStubMappingTask.execute(mockAdmin, mockRequest, PathParams.empty());
+    }
 
-	@Test
-	public void returnsNoContentResponse() {
+    @Test
+    public void returnsNoContentResponse() {
 
-		context.checking(new Expectations() {{
-			oneOf(mockRequest).getBodyAsString();
-			will(returnValue(buildJsonStringFor(MOCK_MAPPING)));
-			oneOf(mockAdmin).editStubMapping(with(any(StubMapping.class)));
-		}});
+    	context.checking(new Expectations() {{
+    		oneOf(mockRequest).getBodyAsString();
+    		will(returnValue(buildJsonStringFor(MOCK_MAPPING)));
+    		oneOf(mockAdmin).editStubMapping(with(any(StubMapping.class)));
+    	}});
 
-		ResponseDefinition response = editStubMappingTask.execute(mockAdmin, mockRequest, PathParams.empty());
+    	ResponseDefinition response = editStubMappingTask.execute(mockAdmin, mockRequest, PathParams.empty());
 
-		assertThat(response.getStatus(), is(HttpURLConnection.HTTP_NO_CONTENT));
-	}
+    	assertThat(response.getStatus(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientAcceptanceTest.java
@@ -28,54 +28,54 @@ import static org.junit.Assert.assertThat;
 
 
 public class WireMockClientAcceptanceTest {
-	
-	private WireMockServer wireMockServer;
-	private WireMockTestClient testClient;
+    
+    private WireMockServer wireMockServer;
+    private WireMockTestClient testClient;
 
-	@Before
-	public void init() {
-		wireMockServer = new WireMockServer(Options.DYNAMIC_PORT);
-		wireMockServer.start();
-		WireMock.configureFor(wireMockServer.port());
-		testClient = new WireMockTestClient(wireMockServer.port());
-	}
-	
-	@After
-	public void stopServer() {
-		wireMockServer.stop();
-	}
+    @Before
+    public void init() {
+    	wireMockServer = new WireMockServer(Options.DYNAMIC_PORT);
+    	wireMockServer.start();
+    	WireMock.configureFor(wireMockServer.port());
+    	testClient = new WireMockTestClient(wireMockServer.port());
+    }
+    
+    @After
+    public void stopServer() {
+    	wireMockServer.stop();
+    }
 
-	@Test
-	public void buildsMappingWithUrlOnlyRequestAndStatusOnlyResponse() {
-		WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
-		wireMock.register(
-				get(urlEqualTo("/my/new/resource"))
-				.willReturn(
-						aResponse()
-						.withStatus(304)));
-		
-		assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
-	}
-	
-	@Test
-	public void buildsMappingFromStaticSyntax() {
-		givenThat(get(urlEqualTo("/my/new/resource"))
-					.willReturn(aResponse()
-						.withStatus(304)));
-		
-		assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
-	}
-	
-	@Test
-	public void buildsMappingWithUrlOnyRequestAndResponseWithJsonBodyWithDiacriticSigns() {
-		WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
-		wireMock.register(
-				get(urlEqualTo("/my/new/resource"))
-				.willReturn(
-						aResponse()
-						.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
-						.withStatus(200)));
+    @Test
+    public void buildsMappingWithUrlOnlyRequestAndStatusOnlyResponse() {
+    	WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    	wireMock.register(
+    			get(urlEqualTo("/my/new/resource"))
+    			.willReturn(
+    					aResponse()
+    					.withStatus(304)));
+    	
+    	assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
+    }
+    
+    @Test
+    public void buildsMappingFromStaticSyntax() {
+    	givenThat(get(urlEqualTo("/my/new/resource"))
+    				.willReturn(aResponse()
+    					.withStatus(304)));
+    	
+    	assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
+    }
+    
+    @Test
+    public void buildsMappingWithUrlOnyRequestAndResponseWithJsonBodyWithDiacriticSigns() {
+    	WireMock wireMock = WireMock.create().port(wireMockServer.port()).build();
+    	wireMock.register(
+    			get(urlEqualTo("/my/new/resource"))
+    			.willReturn(
+    					aResponse()
+    					.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
+    					.withStatus(200)));
 
-		assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
-	}
+    	assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/WireMockClientWithProxyAcceptanceTest.java
@@ -30,40 +30,40 @@ import static org.junit.Assert.assertThat;
 
 
 public class WireMockClientWithProxyAcceptanceTest {
-	
-	private static WireMockServer wireMockServer;
-	private static WireMockTestClient testClient;
-	private static HttpProxyServer proxyServer;
+    
+    private static WireMockServer wireMockServer;
+    private static WireMockTestClient testClient;
+    private static HttpProxyServer proxyServer;
 
-	@BeforeClass
-	public static void init() {
-		wireMockServer = new WireMockServer(DYNAMIC_PORT);
-		wireMockServer.start();
-		proxyServer = DefaultHttpProxyServer.bootstrap().withPort(0).start();
+    @BeforeClass
+    public static void init() {
+    	wireMockServer = new WireMockServer(DYNAMIC_PORT);
+    	wireMockServer.start();
+    	proxyServer = DefaultHttpProxyServer.bootstrap().withPort(0).start();
 
-		testClient = new WireMockTestClient(wireMockServer.port());
-	}
-	
-	@AfterClass
-	public static void stopServer() {
-		wireMockServer.stop();
-		proxyServer.stop();
-	}
+    	testClient = new WireMockTestClient(wireMockServer.port());
+    }
+    
+    @AfterClass
+    public static void stopServer() {
+    	wireMockServer.stop();
+    	proxyServer.stop();
+    }
 
-	@Test
-	public void supportsProxyingWithTheStaticClient() {
+    @Test
+    public void supportsProxyingWithTheStaticClient() {
         WireMock.configureFor("http", "localhost", wireMockServer.port(), proxyServer.getListenAddress().getHostString(), proxyServer.getListenAddress().getPort());
 
-		givenThat(get(urlEqualTo("/my/new/resource"))
-					.willReturn(aResponse()
-						.withStatus(304)));
+    	givenThat(get(urlEqualTo("/my/new/resource"))
+    				.willReturn(aResponse()
+    					.withStatus(304)));
 
-		assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
-	}
+    	assertThat(testClient.get("/my/new/resource").statusCode(), is(304));
+    }
 
-	@Test
-	public void supportsProxyingWithTheInstanceClient() {
-		WireMock wireMock = WireMock.create()
+    @Test
+    public void supportsProxyingWithTheInstanceClient() {
+    	WireMock wireMock = WireMock.create()
                 .scheme("http")
                 .host("localhost")
                 .port(wireMockServer.port())
@@ -73,13 +73,13 @@ public class WireMockClientWithProxyAcceptanceTest {
                 .proxyPort(proxyServer.getListenAddress().getPort())
                 .build();
 
-		wireMock.register(
-				get(urlEqualTo("/my/new/resource"))
-				.willReturn(
-						aResponse()
-						.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
-						.withStatus(200)));
+    	wireMock.register(
+    			get(urlEqualTo("/my/new/resource"))
+    			.willReturn(
+    					aResponse()
+    					.withBody("{\"address\":\"Puerto Banús, Málaga\"}")
+    					.withStatus(200)));
 
-		assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
-	}
+    	assertThat(testClient.get("/my/new/resource").content(), is("{\"address\":\"Puerto Banús, Málaga\"}"));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/SingleRootFileSourceTest.java
@@ -38,17 +38,17 @@ public class SingleRootFileSourceTest {
     public static final String ROOT_PATH = filePath("filesource");
 
     @SuppressWarnings("unchecked")
-	@Test
-	public void listsTextFilesRecursively() {
-		SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-		
-		List<TextFile> files = fileSource.listFilesRecursively();
-		
-		assertThat(files, hasExactlyIgnoringOrder(
-				fileNamed("one"), fileNamed("two"), fileNamed("three"), 
-				fileNamed("four"), fileNamed("five"), fileNamed("six"), 
-				fileNamed("seven"), fileNamed("eight"), fileNamed("deepfile.json")));
-	}
+    @Test
+    public void listsTextFilesRecursively() {
+    	SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+    	
+    	List<TextFile> files = fileSource.listFilesRecursively();
+    	
+    	assertThat(files, hasExactlyIgnoringOrder(
+    			fileNamed("one"), fileNamed("two"), fileNamed("three"), 
+    			fileNamed("four"), fileNamed("five"), fileNamed("six"), 
+    			fileNamed("seven"), fileNamed("eight"), fileNamed("deepfile.json")));
+    }
 
     @Test
     public void writesTextFileEvenWhenRootIsARelativePath() throws IOException {
@@ -61,23 +61,23 @@ public class SingleRootFileSourceTest {
         assertThat(Files.exists(fileAbsolutePath), is(true));
     }
 
-	@Test(expected = RuntimeException.class)
-	public void listFilesRecursivelyThrowsExceptionWhenRootIsNotDir() {
-		SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
-		fileSource.listFilesRecursively();
-	}
+    @Test(expected = RuntimeException.class)
+    public void listFilesRecursivelyThrowsExceptionWhenRootIsNotDir() {
+    	SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
+    	fileSource.listFilesRecursively();
+    }
 
-	@Test(expected = RuntimeException.class)
-	public void writeThrowsExceptionWhenRootIsNotDir() {
-		SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
-		fileSource.writeTextFile("thing", "stuff");
-	}
+    @Test(expected = RuntimeException.class)
+    public void writeThrowsExceptionWhenRootIsNotDir() {
+    	SingleRootFileSource fileSource = new SingleRootFileSource("src/test/resources/filesource/one");
+    	fileSource.writeTextFile("thing", "stuff");
+    }
 
-	@Test(expected = NotAuthorisedException.class)
-	public void writeTextFileThrowsExceptionWhenGivenRelativePathNotUnderRoot() {
-		SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
-		fileSource.writeTextFile("..", "stuff");
-	}
+    @Test(expected = NotAuthorisedException.class)
+    public void writeTextFileThrowsExceptionWhenGivenRelativePathNotUnderRoot() {
+    	SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+    	fileSource.writeTextFile("..", "stuff");
+    }
 
     @Test(expected = NotAuthorisedException.class)
     public void writeTextFileThrowsExceptionWhenGivenAbsolutePathNotUnderRoot() {
@@ -99,15 +99,15 @@ public class SingleRootFileSourceTest {
         fileSource.writeBinaryFile(badPath, "stuff".getBytes());
     }
 
-	@Test(expected = NotAuthorisedException.class)
-	public void deleteThrowsExceptionWhenGivenPathNotUnderRoot() {
-		SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
+    @Test(expected = NotAuthorisedException.class)
+    public void deleteThrowsExceptionWhenGivenPathNotUnderRoot() {
+    	SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
         String badPath = Paths.get("..", "not-under-root").toAbsolutePath().toString();
-		fileSource.deleteFile(badPath);
-	}
+    	fileSource.deleteFile(badPath);
+    }
 
-	@Test(expected = NotAuthorisedException.class)
-	public void readBinaryFileThrowsExceptionWhenRelativePathIsOutsideRoot() {
+    @Test(expected = NotAuthorisedException.class)
+    public void readBinaryFileThrowsExceptionWhenRelativePathIsOutsideRoot() {
         SingleRootFileSource fileSource = new SingleRootFileSource(ROOT_PATH);
         fileSource.getBinaryFileNamed("../illegal.file");
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ContentTypeHeaderTest.java
@@ -34,42 +34,42 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JMock.class)
 public class ContentTypeHeaderTest {
-	
-	private Mockery context;
-	
-	@Before
-	public void init() {
-		context = new Mockery();
-	}
+    
+    private Mockery context;
+    
+    @Before
+    public void init() {
+    	context = new Mockery();
+    }
 
-	@Test
-	public void returnsMimeTypeAndCharsetWhenBothPresent() {
-		ContentTypeHeader header = new ContentTypeHeader("text/plain; charset=utf-8");
-		assertThat(header.mimeTypePart(), is("text/plain"));
-		Optional<String> encoding = header.encodingPart();
-		assertTrue(encoding.isPresent());
-		assertThat(encoding.get(), is("utf-8"));
-	}
-	
-	@Test
-	public void returnsMimeTypeWhenNoCharsetPresent() {
-		ContentTypeHeader header = new ContentTypeHeader("text/plain");
-		assertThat(header.mimeTypePart(), is("text/plain"));
-	}
-	
-	@Test
-	public void returnsCharsetWhenNotFirstParameter() {
-		ContentTypeHeader header = new ContentTypeHeader("text/plain; param=value; charset=utf-8");
-		Optional<String> encoding = header.encodingPart();
-		assertTrue(encoding.isPresent());
-		assertThat(encoding.get(), is("utf-8"));
-	}
-	
-	@Test
-	public void returnsAbsentOptionalEncodingPartWhenNotPresent() {
-		ContentTypeHeader header = new ContentTypeHeader("text/plain");
-		assertFalse(header.encodingPart().isPresent());
-	}
+    @Test
+    public void returnsMimeTypeAndCharsetWhenBothPresent() {
+    	ContentTypeHeader header = new ContentTypeHeader("text/plain; charset=utf-8");
+    	assertThat(header.mimeTypePart(), is("text/plain"));
+    	Optional<String> encoding = header.encodingPart();
+    	assertTrue(encoding.isPresent());
+    	assertThat(encoding.get(), is("utf-8"));
+    }
+    
+    @Test
+    public void returnsMimeTypeWhenNoCharsetPresent() {
+    	ContentTypeHeader header = new ContentTypeHeader("text/plain");
+    	assertThat(header.mimeTypePart(), is("text/plain"));
+    }
+    
+    @Test
+    public void returnsCharsetWhenNotFirstParameter() {
+    	ContentTypeHeader header = new ContentTypeHeader("text/plain; param=value; charset=utf-8");
+    	Optional<String> encoding = header.encodingPart();
+    	assertTrue(encoding.isPresent());
+    	assertThat(encoding.get(), is("utf-8"));
+    }
+    
+    @Test
+    public void returnsAbsentOptionalEncodingPartWhenNotPresent() {
+    	ContentTypeHeader header = new ContentTypeHeader("text/plain");
+    	assertFalse(header.encodingPart().isPresent());
+    }
 
     @Test
     public void stripsDoubleQuotesFromEncodingPart() {
@@ -78,47 +78,47 @@ public class ContentTypeHeaderTest {
         assertTrue(encoding.isPresent());
         assertThat(encoding.get(), is("UTF-8"));
     }
-	
-	@Test
-	public void fetchesFromRequest() {
-		Request request = new MockRequestBuilder(context)
-			.withHeader("Content-Type", "text/xml")
-			.build();
-		
-		ContentTypeHeader contentTypeHeader = request.contentTypeHeader();
-		assertThat(contentTypeHeader.mimeTypePart(), is("text/xml"));
-	}
+    
+    @Test
+    public void fetchesFromRequest() {
+    	Request request = new MockRequestBuilder(context)
+    		.withHeader("Content-Type", "text/xml")
+    		.build();
+    	
+    	ContentTypeHeader contentTypeHeader = request.contentTypeHeader();
+    	assertThat(contentTypeHeader.mimeTypePart(), is("text/xml"));
+    }
 
-	@Test(expected=NullPointerException.class)
-	public void throwsExceptionOnAttemptToSetNullHeaderValue() {
-		Request request = new MockRequestBuilder(context)
-			.withHeader("Content-Type", null)
-			.build();
-	
+    @Test(expected=NullPointerException.class)
+    public void throwsExceptionOnAttemptToSetNullHeaderValue() {
+    	Request request = new MockRequestBuilder(context)
+    		.withHeader("Content-Type", null)
+    		.build();
+    
         request.contentTypeHeader();
-	}
-	
-	@Test
-	public void returnsNullFromMimeTypePartWhenContentTypeIsAbsent() {
-		ContentTypeHeader header = ContentTypeHeader.absent();
-		assertThat(header.mimeTypePart(), is(nullValue()));
-	}
+    }
+    
+    @Test
+    public void returnsNullFromMimeTypePartWhenContentTypeIsAbsent() {
+    	ContentTypeHeader header = ContentTypeHeader.absent();
+    	assertThat(header.mimeTypePart(), is(nullValue()));
+    }
 
-	@Test
-	public void returnsCharsetWhenPresent() {
-		ContentTypeHeader header = new ContentTypeHeader("text/plain; charset=iso-8859-1");
-		assertThat(header.charset(), is(StandardCharsets.ISO_8859_1));
-	}
+    @Test
+    public void returnsCharsetWhenPresent() {
+    	ContentTypeHeader header = new ContentTypeHeader("text/plain; charset=iso-8859-1");
+    	assertThat(header.charset(), is(StandardCharsets.ISO_8859_1));
+    }
 
-	@Test
-	public void returnsDefaultCharsetWhenEncodingNotPresent() {
-		ContentTypeHeader header = new ContentTypeHeader("text/plain");
-		assertThat(header.charset(), is(Strings.DEFAULT_CHARSET));
-	}
+    @Test
+    public void returnsDefaultCharsetWhenEncodingNotPresent() {
+    	ContentTypeHeader header = new ContentTypeHeader("text/plain");
+    	assertThat(header.charset(), is(Strings.DEFAULT_CHARSET));
+    }
 
-	@Test
-	public void returnsDefaultCharsetWhenAbsent() {
-		ContentTypeHeader header = ContentTypeHeader.absent();
-		assertThat(header.charset(), is(Strings.DEFAULT_CHARSET));
-	}
+    @Test
+    public void returnsDefaultCharsetWhenAbsent() {
+    	ContentTypeHeader header = ContentTypeHeader.absent();
+    	assertThat(header.charset(), is(Strings.DEFAULT_CHARSET));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
@@ -60,8 +60,8 @@ public class HttpHeadersTest {
     }
 
     private static final String SINGLE_VALUE_HEADER =
-            "{                	    	    		        \n" +
-            "	\"Header-1\": \"only-value\"                \n" +
+            "{                        	    		        \n" +
+            "    \"Header-1\": \"only-value\"                \n" +
             "}                                               ";
 
     @Test
@@ -85,13 +85,13 @@ public class HttpHeadersTest {
     }
 
     private static final String MULTI_VALUE_HEADER =
-            "{    	                         	    		        \n" +
-            "		    \"Header-1\": [                             \n" +
-            "		        \"value-1\",                            \n" +
+            "{                                 	    		        \n" +
+            "    	    \"Header-1\": [                             \n" +
+            "    	        \"value-1\",                            \n" +
             "               \"value-2\"                             \n" +
             "           ],                                          \n" +
-            "		    \"Header-2\": [                             \n" +
-            "		        \"value-3\",                            \n" +
+            "    	    \"Header-2\": [                             \n" +
+            "    	        \"value-3\",                            \n" +
             "               \"value-4\"                             \n" +
             "           ]                                           \n" +
             "}                                                        ";

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/RequestPatternTest.java
@@ -131,10 +131,10 @@ public class RequestPatternTest {
         String actualJson = Json.write(requestPattern);
 
         JSONAssert.assertEquals(
-            "{									                \n" +
-                "		\"method\": \"GET\",						\n" +
-                "		\"url\": \"/my/url\"                		\n" +
-                "}												    ",
+            "{    								                \n" +
+                "    	\"method\": \"GET\",						\n" +
+                "    	\"url\": \"/my/url\"                		\n" +
+                "}    											    ",
             actualJson,
             true);
     }
@@ -148,10 +148,10 @@ public class RequestPatternTest {
         String actualJson = Json.write(requestPattern);
 
         JSONAssert.assertEquals(
-            "{									                \n" +
-            "		\"method\": \"GET\",						\n" +
-            "		\"urlPattern\": \"/my/url\"           		\n" +
-            "}												    ",
+            "{    								                \n" +
+            "    	\"method\": \"GET\",						\n" +
+            "    	\"urlPattern\": \"/my/url\"           		\n" +
+            "}    											    ",
             actualJson,
             true);
     }
@@ -165,10 +165,10 @@ public class RequestPatternTest {
         String actualJson = Json.write(requestPattern);
 
         JSONAssert.assertEquals(
-            "{									                \n" +
-            "		\"method\": \"GET\",						\n" +
-            "		\"urlPathPattern\": \"/my/url\"             \n" +
-            "}												    ",
+            "{    								                \n" +
+            "    	\"method\": \"GET\",						\n" +
+            "    	\"urlPathPattern\": \"/my/url\"             \n" +
+            "}    											    ",
             actualJson,
             true);
     }
@@ -190,18 +190,18 @@ public class RequestPatternTest {
     }
 
     static final String URL_PATH_AND_HEADERS_EXAMPLE =
-        "{									                \n" +
-        "		\"method\": \"GET\",						\n" +
-        "		\"urlPath\": \"/my/url\",             		\n" +
-        "		\"headers\": {								\n" +
-        "			\"Accept\": {							\n" +
-        "				\"matches\": \"(.*)xml(.*)\"		\n" +
-        "			},										\n" +
-        "			\"If-None-Match\": {					\n" +
-        "				\"matches\": \"([a-z0-9]*)\"		\n" +
-        "			}										\n" +
-        "		}											\n" +
-        "}												    ";
+        "{    								                \n" +
+        "    	\"method\": \"GET\",						\n" +
+        "    	\"urlPath\": \"/my/url\",             		\n" +
+        "    	\"headers\": {								\n" +
+        "    		\"Accept\": {							\n" +
+        "    			\"matches\": \"(.*)xml(.*)\"		\n" +
+        "    		},										\n" +
+        "    		\"If-None-Match\": {					\n" +
+        "    			\"matches\": \"([a-z0-9]*)\"		\n" +
+        "    		}										\n" +
+        "    	}											\n" +
+        "}    											    ";
 
     @Test
     public void matchesExactlyWith0DistanceWhenAllRequiredQueryParametersMatch() {

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -42,38 +42,38 @@ import static org.junit.Assert.assertThat;
 
 public class CommandLineOptionsTest {
 
-	@Test
-	public void returnsVerboseTrueWhenOptionPresent() {
-		CommandLineOptions options = new CommandLineOptions("--verbose");
-		assertThat(options.verboseLoggingEnabled(), is(true));
-	}
-	
-	@Test
-	public void returnsVerboseFalseWhenOptionNotPresent() {
-		CommandLineOptions options = new CommandLineOptions("");
-		assertThat(options.verboseLoggingEnabled(), is(false));
-	}
+    @Test
+    public void returnsVerboseTrueWhenOptionPresent() {
+    	CommandLineOptions options = new CommandLineOptions("--verbose");
+    	assertThat(options.verboseLoggingEnabled(), is(true));
+    }
+    
+    @Test
+    public void returnsVerboseFalseWhenOptionNotPresent() {
+    	CommandLineOptions options = new CommandLineOptions("");
+    	assertThat(options.verboseLoggingEnabled(), is(false));
+    }
 
-	@Test
-	public void returnsRecordMappingsTrueWhenOptionPresent() {
-		CommandLineOptions options = new CommandLineOptions("--record-mappings");
-		assertThat(options.recordMappingsEnabled(), is(true));
-	}
+    @Test
+    public void returnsRecordMappingsTrueWhenOptionPresent() {
+    	CommandLineOptions options = new CommandLineOptions("--record-mappings");
+    	assertThat(options.recordMappingsEnabled(), is(true));
+    }
 
     @Test
     public void returnsHeaderMatchingEnabledWhenOptionPresent() {
-    	CommandLineOptions options =  new CommandLineOptions("--match-headers", "Accept,Content-Type");
-    	assertThat(options.matchingHeaders(),
+        CommandLineOptions options =  new CommandLineOptions("--match-headers", "Accept,Content-Type");
+        assertThat(options.matchingHeaders(),
                 hasItems(CaseInsensitiveKey.from("Accept"), CaseInsensitiveKey.from("Content-Type")));
     }
 
-	@Test
-	public void returnsRecordMappingsFalseWhenOptionNotPresent() {
-		CommandLineOptions options = new CommandLineOptions("");
-		assertThat(options.recordMappingsEnabled(), is(false));
-	}
+    @Test
+    public void returnsRecordMappingsFalseWhenOptionNotPresent() {
+    	CommandLineOptions options = new CommandLineOptions("");
+    	assertThat(options.recordMappingsEnabled(), is(false));
+    }
 
-	@Test
+    @Test
      public void setsPortNumberWhenOptionPresent() {
         CommandLineOptions options = new CommandLineOptions("--port", "8086");
         assertThat(options.portNumber(), is(8086));
@@ -123,10 +123,10 @@ public class CommandLineOptionsTest {
         new CommandLineOptions("--https-keystore", "/my/keystore");
     }
 
-	@Test(expected=Exception.class)
-	public void throwsExceptionWhenPortNumberSpecifiedWithoutNumber() {
-		new CommandLineOptions("--port");
-	}
+    @Test(expected=Exception.class)
+    public void throwsExceptionWhenPortNumberSpecifiedWithoutNumber() {
+    	new CommandLineOptions("--port");
+    }
 
     @Test
     public void returnsCorrecteyParsedBindAddress(){
@@ -134,12 +134,12 @@ public class CommandLineOptionsTest {
         assertThat(options.bindAddress(), is("127.0.0.1"));
     }
 
-	@Test
-	public void setsProxyAllRootWhenOptionPresent() {
-		CommandLineOptions options = new CommandLineOptions("--proxy-all", "http://someotherhost.com/site");
-		assertThat(options.specifiesProxyUrl(), is(true));
-		assertThat(options.proxyUrl(), is("http://someotherhost.com/site"));
-	}
+    @Test
+    public void setsProxyAllRootWhenOptionPresent() {
+    	CommandLineOptions options = new CommandLineOptions("--proxy-all", "http://someotherhost.com/site");
+    	assertThat(options.specifiesProxyUrl(), is(true));
+    	assertThat(options.proxyUrl(), is("http://someotherhost.com/site"));
+    }
 
     @Test
     public void setsProxyHostHeaderWithTrailingPortInformation() {
@@ -148,32 +148,32 @@ public class CommandLineOptionsTest {
     }
 
     @Test(expected=Exception.class)
-	public void throwsExceptionWhenProxyAllSpecifiedWithoutUrl() {
-		new CommandLineOptions("--proxy-all");
-	}
+    public void throwsExceptionWhenProxyAllSpecifiedWithoutUrl() {
+    	new CommandLineOptions("--proxy-all");
+    }
 
-	@Test
-	public void returnsBrowserProxyingEnabledWhenOptionSet() {
-		CommandLineOptions options = new CommandLineOptions("--enable-browser-proxying");
-		assertThat(options.browserProxyingEnabled(), is(true));
-	}
+    @Test
+    public void returnsBrowserProxyingEnabledWhenOptionSet() {
+    	CommandLineOptions options = new CommandLineOptions("--enable-browser-proxying");
+    	assertThat(options.browserProxyingEnabled(), is(true));
+    }
 
-	@Test
-	public void setsAll() {
-		CommandLineOptions options = new CommandLineOptions("--verbose", "--record-mappings", "--port", "8088", "--proxy-all", "http://somewhere.com");
-		assertThat(options.verboseLoggingEnabled(), is(true));
-		assertThat(options.recordMappingsEnabled(), is(true));
-		assertThat(options.portNumber(), is(8088));
-		assertThat(options.specifiesProxyUrl(), is(true));
-		assertThat(options.proxyUrl(), is("http://somewhere.com"));
-	}
+    @Test
+    public void setsAll() {
+    	CommandLineOptions options = new CommandLineOptions("--verbose", "--record-mappings", "--port", "8088", "--proxy-all", "http://somewhere.com");
+    	assertThat(options.verboseLoggingEnabled(), is(true));
+    	assertThat(options.recordMappingsEnabled(), is(true));
+    	assertThat(options.portNumber(), is(8088));
+    	assertThat(options.specifiesProxyUrl(), is(true));
+    	assertThat(options.proxyUrl(), is("http://somewhere.com"));
+    }
 
-	@SuppressWarnings("unchecked")
-	@Test
-	public void returnsHelpText() {
-		CommandLineOptions options = new CommandLineOptions("--help");
-		assertThat(options.helpText(), allOf(containsString("verbose")));
-	}
+    @SuppressWarnings("unchecked")
+    @Test
+    public void returnsHelpText() {
+    	CommandLineOptions options = new CommandLineOptions("--help");
+    	assertThat(options.helpText(), allOf(containsString("verbose")));
+    }
 
     @Test
     public void returnsCorrectlyParsedProxyViaParameter() {

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSourceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/JsonFileMappingsSourceTest.java
@@ -46,51 +46,51 @@ public class JsonFileMappingsSourceTest {
 
     InMemoryStubMappings stubMappings;
     JsonFileMappingsSource source;
-	File stubMappingFile;
+    File stubMappingFile;
 
     @Before
-	public void init() throws Exception {
-		stubMappings = new InMemoryStubMappings();
-	}
+    public void init() throws Exception {
+    	stubMappings = new InMemoryStubMappings();
+    }
 
-	private void configureWithMultipleMappingFile() throws Exception {
-		stubMappingFile = tempDir.newFile("multi.json");
-		Files.copy(new File(filePath("multi-stub/multi.json")), stubMappingFile);
-		load();
-	}
+    private void configureWithMultipleMappingFile() throws Exception {
+    	stubMappingFile = tempDir.newFile("multi.json");
+    	Files.copy(new File(filePath("multi-stub/multi.json")), stubMappingFile);
+    	load();
+    }
 
-	private void configureWithSingleMappingFile() throws Exception {
-    	stubMappingFile = tempDir.newFile("single.json");
-		Files.copy(new File(filePath("multi-stub/single.json")), stubMappingFile);
-		load();
-	}
+    private void configureWithSingleMappingFile() throws Exception {
+        stubMappingFile = tempDir.newFile("single.json");
+    	Files.copy(new File(filePath("multi-stub/single.json")), stubMappingFile);
+    	load();
+    }
 
-	private void load() {
-		source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir.getRoot()));
-		source.loadMappingsInto(stubMappings);
-	}
+    private void load() {
+    	source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir.getRoot()));
+    	source.loadMappingsInto(stubMappings);
+    }
 
-	@Test
-	public void loadsMappingsViaClasspathFileSource() {
-		ClasspathFileSource fileSource = new ClasspathFileSource("jar-filesource");
-		JsonFileMappingsSource source = new JsonFileMappingsSource(fileSource);
-		InMemoryStubMappings stubMappings = new InMemoryStubMappings();
+    @Test
+    public void loadsMappingsViaClasspathFileSource() {
+    	ClasspathFileSource fileSource = new ClasspathFileSource("jar-filesource");
+    	JsonFileMappingsSource source = new JsonFileMappingsSource(fileSource);
+    	InMemoryStubMappings stubMappings = new InMemoryStubMappings();
 
-		source.loadMappingsInto(stubMappings);
+    	source.loadMappingsInto(stubMappings);
 
-		List<StubMapping> allMappings = stubMappings.getAll();
-		assertThat(allMappings, hasSize(2));
+    	List<StubMapping> allMappings = stubMappings.getAll();
+    	assertThat(allMappings, hasSize(2));
 
-		List<String> mappingRequestUrls = asList(
-			allMappings.get(0).getRequest().getUrl(),
-			allMappings.get(1).getRequest().getUrl()
-		);
-		assertThat(mappingRequestUrls, is(asList("/second_test", "/test")));
-	}
+    	List<String> mappingRequestUrls = asList(
+    		allMappings.get(0).getRequest().getUrl(),
+    		allMappings.get(1).getRequest().getUrl()
+    	);
+    	assertThat(mappingRequestUrls, is(asList("/second_test", "/test")));
+    }
 
-	@Test
-	public void stubMappingFilesAreWrittenWithInsertionIndex() throws Exception {
-	    JsonFileMappingsSource source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir.getRoot()));
+    @Test
+    public void stubMappingFilesAreWrittenWithInsertionIndex() throws Exception {
+        JsonFileMappingsSource source = new JsonFileMappingsSource(new SingleRootFileSource(tempDir.getRoot()));
 
         StubMapping stub = get("/saveable").willReturn(ok()).build();
         source.save(stub);
@@ -102,73 +102,73 @@ public class JsonFileMappingsSourceTest {
     }
 
     @Test
-	public void refusesToRemoveStubMappingContainedInMultiFile() throws Exception {
-		configureWithMultipleMappingFile();
-
-		StubMapping firstStub = stubMappings.getAll().get(0);
-
-		try {
-			source.remove(firstStub);
-			fail("Expected an exception to be thrown");
-		} catch (Exception e) {
-			assertThat(e, Matchers.instanceOf(NotWritableException.class));
-			assertThat(e.getMessage(), is("Stubs loaded from multi-mapping files are read-only, and therefore cannot be removed"));
-		}
-
-		assertThat(stubMappingFile.exists(), is(true));
-	}
-
-	@Test
-	public void refusesToRemoveAllWhenMultiMappingFilesArePresent() throws Exception {
-		configureWithMultipleMappingFile();
-
-		try {
-			source.removeAll();
-			fail("Expected an exception to be thrown");
-		} catch (Exception e) {
-			assertThat(e, Matchers.instanceOf(NotWritableException.class));
-			assertThat(e.getMessage(), is("Some stubs were loaded from multi-mapping files which are read-only, so remove all cannot be performed"));
-		}
-
-		assertThat(stubMappingFile.exists(), is(true));
-	}
-
-	@Test
-	public void refusesToSaveStubMappingOriginallyLoadedFromMultiMappingFile() throws Exception {
+    public void refusesToRemoveStubMappingContainedInMultiFile() throws Exception {
     	configureWithMultipleMappingFile();
 
-		StubMapping firstStub = stubMappings.getAll().get(0);
+    	StubMapping firstStub = stubMappings.getAll().get(0);
 
-		try {
-			source.save(firstStub);
-			fail("Expected an exception to be thrown");
-		} catch (Exception e) {
-			assertThat(e, Matchers.instanceOf(NotWritableException.class));
-			assertThat(e.getMessage(), is("Stubs loaded from multi-mapping files are read-only, and therefore cannot be saved"));
-		}
+    	try {
+    		source.remove(firstStub);
+    		fail("Expected an exception to be thrown");
+    	} catch (Exception e) {
+    		assertThat(e, Matchers.instanceOf(NotWritableException.class));
+    		assertThat(e.getMessage(), is("Stubs loaded from multi-mapping files are read-only, and therefore cannot be removed"));
+    	}
 
-		assertThat(stubMappingFile.exists(), is(true));
-	}
+    	assertThat(stubMappingFile.exists(), is(true));
+    }
 
-	@Test
-	public void savesStubMappingOriginallyLoadedFromSingleMappingFile() throws Exception {
-		configureWithSingleMappingFile();
+    @Test
+    public void refusesToRemoveAllWhenMultiMappingFilesArePresent() throws Exception {
+    	configureWithMultipleMappingFile();
 
-		StubMapping firstStub = stubMappings.getAll().get(0);
-		firstStub.setName("New name");
-		source.save(firstStub);
+    	try {
+    		source.removeAll();
+    		fail("Expected an exception to be thrown");
+    	} catch (Exception e) {
+    		assertThat(e, Matchers.instanceOf(NotWritableException.class));
+    		assertThat(e.getMessage(), is("Some stubs were loaded from multi-mapping files which are read-only, so remove all cannot be performed"));
+    	}
 
-		assertThat(Files.toString(stubMappingFile, UTF_8), containsString("New name"));
-	}
+    	assertThat(stubMappingFile.exists(), is(true));
+    }
 
-	@Test
-	public void removesStubMappingOriginallyLoadedFromSingleMappingFile() throws Exception {
-		configureWithSingleMappingFile();
+    @Test
+    public void refusesToSaveStubMappingOriginallyLoadedFromMultiMappingFile() throws Exception {
+        configureWithMultipleMappingFile();
 
-		StubMapping firstStub = stubMappings.getAll().get(0);
-		source.remove(firstStub);
+    	StubMapping firstStub = stubMappings.getAll().get(0);
 
-		assertThat(stubMappingFile.exists(), is(false));
-	}
+    	try {
+    		source.save(firstStub);
+    		fail("Expected an exception to be thrown");
+    	} catch (Exception e) {
+    		assertThat(e, Matchers.instanceOf(NotWritableException.class));
+    		assertThat(e.getMessage(), is("Stubs loaded from multi-mapping files are read-only, and therefore cannot be saved"));
+    	}
+
+    	assertThat(stubMappingFile.exists(), is(true));
+    }
+
+    @Test
+    public void savesStubMappingOriginallyLoadedFromSingleMappingFile() throws Exception {
+    	configureWithSingleMappingFile();
+
+    	StubMapping firstStub = stubMappings.getAll().get(0);
+    	firstStub.setName("New name");
+    	source.save(firstStub);
+
+    	assertThat(Files.toString(stubMappingFile, UTF_8), containsString("New name"));
+    }
+
+    @Test
+    public void removesStubMappingOriginallyLoadedFromSingleMappingFile() throws Exception {
+    	configureWithSingleMappingFile();
+
+    	StubMapping firstStub = stubMappings.getAll().get(0);
+    	source.remove(firstStub);
+
+    	assertThat(stubMappingFile.exists(), is(false));
+    }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/AdminRequestHandlerTest.java
@@ -45,22 +45,22 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(JMock.class)
 public class AdminRequestHandlerTest {
-	private Mockery context;
-	private Admin admin;
+    private Mockery context;
+    private Admin admin;
     private MockHttpResponder httpResponder;
 
     private AdminRequestHandler handler;
 
-	@Before
-	public void init() {
-		context = new Mockery();
+    @Before
+    public void init() {
+    	context = new Mockery();
         admin = context.mock(Admin.class);
         httpResponder = new MockHttpResponder();
 
 
-		handler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer(), new NoAuthenticator(), false, Collections.<RequestFilter>emptyList());
-	}
-	
+    	handler = new AdminRequestHandler(AdminRoutes.defaults(), admin, new BasicResponseRenderer(), new NoAuthenticator(), false, Collections.<RequestFilter>emptyList());
+    }
+    
     @Test
     public void shouldSaveMappingsWhenSaveCalled() {
         Request request = aRequest(context)
@@ -77,84 +77,84 @@ public class AdminRequestHandlerTest {
 
         assertThat(response.getStatus(), is(HTTP_OK));
     }
-	
-	@Test
-	public void shouldClearMappingsJournalAndRequestDelayWhenResetCalled() {
-		Request request = aRequest(context)
-			.withUrl("/reset")
-			.withMethod(POST)
-			.build();
-		
-		context.checking(new Expectations() {{
-			one(admin).resetAll();
-		}});
+    
+    @Test
+    public void shouldClearMappingsJournalAndRequestDelayWhenResetCalled() {
+    	Request request = aRequest(context)
+    		.withUrl("/reset")
+    		.withMethod(POST)
+    		.build();
+    	
+    	context.checking(new Expectations() {{
+    		one(admin).resetAll();
+    	}});
 
         handler.handle(request, httpResponder);
         Response response = httpResponder.response;
-		
-		assertThat(response.getStatus(), is(HTTP_OK));
-	}
+    	
+    	assertThat(response.getStatus(), is(HTTP_OK));
+    }
 
-	@Test
-	public void shouldClearJournalWhenResetRequestsCalled() {
-		Request request = aRequest(context)
-				.withUrl("/requests/reset")
-				.withMethod(POST)
-				.build();
+    @Test
+    public void shouldClearJournalWhenResetRequestsCalled() {
+    	Request request = aRequest(context)
+    			.withUrl("/requests/reset")
+    			.withMethod(POST)
+    			.build();
 
-		context.checking(new Expectations() {{
-			one(admin).resetRequests();
-		}});
+    	context.checking(new Expectations() {{
+    		one(admin).resetRequests();
+    	}});
 
         handler.handle(request, httpResponder);
         Response response = httpResponder.response;
 
-		assertThat(response.getStatus(), is(HTTP_OK));
-	}
+    	assertThat(response.getStatus(), is(HTTP_OK));
+    }
 
-	private static final String REQUEST_PATTERN_SAMPLE = 
-		"{												\n" +
-		"	\"method\": \"DELETE\",						\n" +
-		"	\"url\": \"/some/resource\"					\n" +
-		"}												";
-	
-	@Test
-	public void shouldReturnCountOfMatchingRequests() {
-		context.checking(new Expectations() {{
-			RequestPattern requestPattern = newRequestPattern(DELETE, urlEqualTo("/some/resource")).build();
-			allowing(admin).countRequestsMatching(requestPattern); will(returnValue(VerificationResult.withCount(5)));
-		}});
-		
-		handler.handle(aRequest(context)
-				.withUrl("/requests/count")
-				.withMethod(POST)
-				.withBody(REQUEST_PATTERN_SAMPLE)
-				.build(),
+    private static final String REQUEST_PATTERN_SAMPLE = 
+    	"{												\n" +
+    	"	\"method\": \"DELETE\",						\n" +
+    	"	\"url\": \"/some/resource\"					\n" +
+    	"}												";
+    
+    @Test
+    public void shouldReturnCountOfMatchingRequests() {
+    	context.checking(new Expectations() {{
+    		RequestPattern requestPattern = newRequestPattern(DELETE, urlEqualTo("/some/resource")).build();
+    		allowing(admin).countRequestsMatching(requestPattern); will(returnValue(VerificationResult.withCount(5)));
+    	}});
+    	
+    	handler.handle(aRequest(context)
+    			.withUrl("/requests/count")
+    			.withMethod(POST)
+    			.withBody(REQUEST_PATTERN_SAMPLE)
+    			.build(),
             httpResponder);
         Response response = httpResponder.response;
-		
-		assertThat(response.getStatus(), is(HTTP_OK));
-		assertThat(response.getBodyAsString(), equalToJson("{ \"count\": 5, \"requestJournalDisabled\" : false}"));
+    	
+    	assertThat(response.getStatus(), is(HTTP_OK));
+    	assertThat(response.getBodyAsString(), equalToJson("{ \"count\": 5, \"requestJournalDisabled\" : false}"));
     }
-	
-	private static final String GLOBAL_SETTINGS_JSON =
-		"{												\n" +
-		"	\"fixedDelay\": 2000						\n" +
-		"}												";
-	
-	@Test
-	public void shouldUpdateGlobalSettings() {
+    
+    private static final String GLOBAL_SETTINGS_JSON =
+    	"{												\n" +
+    	"	\"fixedDelay\": 2000						\n" +
+    	"}												";
+    
+    @Test
+    public void shouldUpdateGlobalSettings() {
         context.checking(new Expectations() {{
             GlobalSettings expectedSettings = GlobalSettings.builder().fixedDelay(2000).build();
             allowing(admin).updateGlobalSettings(expectedSettings);
         }});
 
-		handler.handle(aRequest(context)
-				.withUrl("/settings")
-				.withMethod(POST)
-				.withBody(GLOBAL_SETTINGS_JSON)
-				.build(),
+    	handler.handle(aRequest(context)
+    			.withUrl("/settings")
+    			.withMethod(POST)
+    			.withBody(GLOBAL_SETTINGS_JSON)
+    			.build(),
             httpResponder);
 
-	}
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/InMemoryStubMappingsTest.java
@@ -33,71 +33,71 @@ import static org.junit.Assert.fail;
 
 public class InMemoryStubMappingsTest {
 
-	private InMemoryStubMappings inMemoryStubMappings;
+    private InMemoryStubMappings inMemoryStubMappings;
 
-	@Before
-	public void setUp() throws Exception {
-		inMemoryStubMappings = new InMemoryStubMappings();
-	}
+    @Before
+    public void setUp() throws Exception {
+    	inMemoryStubMappings = new InMemoryStubMappings();
+    }
 
-	@Test
-	public void testEditMapping() throws Exception {
+    @Test
+    public void testEditMapping() throws Exception {
 
-		StubMapping existingMapping = aMapping(1, "/priority1/1");
-		inMemoryStubMappings.addMapping(existingMapping);
+    	StubMapping existingMapping = aMapping(1, "/priority1/1");
+    	inMemoryStubMappings.addMapping(existingMapping);
 
-		StubMapping newMapping = aMapping(1, "/priority1/2");
-		newMapping.setUuid(existingMapping.getUuid());
+    	StubMapping newMapping = aMapping(1, "/priority1/2");
+    	newMapping.setUuid(existingMapping.getUuid());
 
-		inMemoryStubMappings.editMapping(newMapping);
+    	inMemoryStubMappings.editMapping(newMapping);
 
-		List<StubMapping> allMappings = inMemoryStubMappings.getAll();
+    	List<StubMapping> allMappings = inMemoryStubMappings.getAll();
 
-		assertThat(allMappings, hasSize(1));
-		assertThat(allMappings.get(0), is(newMapping));
-		assertThat(newMapping.getInsertionIndex(), is(existingMapping.getInsertionIndex()));
-	}
-	@Test
-	public void testRemoveMapping() throws Exception{
+    	assertThat(allMappings, hasSize(1));
+    	assertThat(allMappings.get(0), is(newMapping));
+    	assertThat(newMapping.getInsertionIndex(), is(existingMapping.getInsertionIndex()));
+    }
+    @Test
+    public void testRemoveMapping() throws Exception{
 
-		List<StubMapping> allMappings = inMemoryStubMappings.getAll();
-		assertThat(allMappings,hasSize(0));
+    	List<StubMapping> allMappings = inMemoryStubMappings.getAll();
+    	assertThat(allMappings,hasSize(0));
 
-		StubMapping existingMapping = aMapping(1,"priority1/1");
-		inMemoryStubMappings.addMapping(existingMapping);
-		existingMapping = aMapping(2,"priority2/2");
-		StubMapping mappingToRemove = existingMapping;
-		inMemoryStubMappings.addMapping(existingMapping);
-		existingMapping = aMapping(3,"priority3/3");
-		inMemoryStubMappings.addMapping(existingMapping);
-		allMappings = inMemoryStubMappings.getAll();
-		assertThat(allMappings,hasSize(3));
+    	StubMapping existingMapping = aMapping(1,"priority1/1");
+    	inMemoryStubMappings.addMapping(existingMapping);
+    	existingMapping = aMapping(2,"priority2/2");
+    	StubMapping mappingToRemove = existingMapping;
+    	inMemoryStubMappings.addMapping(existingMapping);
+    	existingMapping = aMapping(3,"priority3/3");
+    	inMemoryStubMappings.addMapping(existingMapping);
+    	allMappings = inMemoryStubMappings.getAll();
+    	assertThat(allMappings,hasSize(3));
 
-		inMemoryStubMappings.removeMapping(mappingToRemove);
+    	inMemoryStubMappings.removeMapping(mappingToRemove);
 
-		allMappings = inMemoryStubMappings.getAll();
-		assertThat(allMappings,hasSize(2));
-	}
-	@Test
-	public void testEditMappingNotPresent() throws Exception {
+    	allMappings = inMemoryStubMappings.getAll();
+    	assertThat(allMappings,hasSize(2));
+    }
+    @Test
+    public void testEditMappingNotPresent() throws Exception {
 
-		StubMapping existingMapping = aMapping(1, "/priority1/1");
-		inMemoryStubMappings.addMapping(existingMapping);
+    	StubMapping existingMapping = aMapping(1, "/priority1/1");
+    	inMemoryStubMappings.addMapping(existingMapping);
 
-		StubMapping newMapping = aMapping(1, "/priority1/2");
+    	StubMapping newMapping = aMapping(1, "/priority1/2");
 
-		try {
-			inMemoryStubMappings.editMapping(newMapping);
-			fail("Expected Exception");
-		} catch (RuntimeException e) {
-			assertThat(e.getMessage(), containsString(newMapping.getUuid().toString()));
-		}
-	}
+    	try {
+    		inMemoryStubMappings.editMapping(newMapping);
+    		fail("Expected Exception");
+    	} catch (RuntimeException e) {
+    		assertThat(e.getMessage(), containsString(newMapping.getUuid().toString()));
+    	}
+    }
 
-	private StubMapping aMapping(Integer priority, String url) {
-		RequestPattern requestPattern = newRequestPattern(ANY, urlEqualTo(url)).build();
-		StubMapping mapping = new StubMapping(requestPattern, new ResponseDefinition());
-		mapping.setPriority(priority);
-		return mapping;
-	}
+    private StubMapping aMapping(Integer priority, String url) {
+    	RequestPattern requestPattern = newRequestPattern(ANY, urlEqualTo(url)).build();
+    	StubMapping mapping = new StubMapping(requestPattern, new ResponseDefinition());
+    	mapping.setPriority(priority);
+    	return mapping;
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/JsonTest.java
@@ -24,47 +24,47 @@ import static org.junit.Assert.assertThat;
 
 public class JsonTest {
 
-	private static final String TEST_VALUE = "test-value";
-	private static final String JSON_WITH_NO_COMMENTS = 
-			"{                                          \n" +
+    private static final String TEST_VALUE = "test-value";
+    private static final String JSON_WITH_NO_COMMENTS = 
+    		"{                                          \n" +
                 "\"property\": \"" + TEST_VALUE + "\"   \n" +
             "}";
 
-	private static final String JSON_WITH_SINGLE_QUOTES =
-			"{                                            \n" +
-				"'property': '" + TEST_VALUE + "'         \n" +
-			"}";
+    private static final String JSON_WITH_SINGLE_QUOTES =
+    		"{                                            \n" +
+    			"'property': '" + TEST_VALUE + "'         \n" +
+    		"}";
 
-	private static final String JSON_WITH_COMMENTS =
-			"// this is the first comment                                                   \n" +
+    private static final String JSON_WITH_COMMENTS =
+    		"// this is the first comment                                                   \n" +
             "{                                                                              \n" +
                     "//this is a comment                                                    \n" +
                     "\"property\": \"" + TEST_VALUE + "\"// comment on same line as code    \n" +
             "}                                                                              \n" +
              "//this is the last comment";
 
-	@Test
-	public void testReadNoComments() {
-		TestPojo pojo = Json.read(JSON_WITH_NO_COMMENTS, TestPojo.class);
-		assertNotNull(pojo);
-		assertThat(TEST_VALUE, is(pojo.property));
-	}
-	
-	@Test
-	public void testReadWithComments() {
-		TestPojo pojo = Json.read(JSON_WITH_COMMENTS, TestPojo.class);
-		assertNotNull(pojo);
-		assertThat(TEST_VALUE, is(pojo.property));
-	}
+    @Test
+    public void testReadNoComments() {
+    	TestPojo pojo = Json.read(JSON_WITH_NO_COMMENTS, TestPojo.class);
+    	assertNotNull(pojo);
+    	assertThat(TEST_VALUE, is(pojo.property));
+    }
+    
+    @Test
+    public void testReadWithComments() {
+    	TestPojo pojo = Json.read(JSON_WITH_COMMENTS, TestPojo.class);
+    	assertNotNull(pojo);
+    	assertThat(TEST_VALUE, is(pojo.property));
+    }
 
-	@Test
-	public void testReadWithSingleQuotes() {
-		TestPojo pojo = Json.read(JSON_WITH_SINGLE_QUOTES, TestPojo.class);
-		assertNotNull(pojo);
-		assertThat(TEST_VALUE, is(pojo.property));
-	}
+    @Test
+    public void testReadWithSingleQuotes() {
+    	TestPojo pojo = Json.read(JSON_WITH_SINGLE_QUOTES, TestPojo.class);
+    	assertNotNull(pojo);
+    	assertThat(TEST_VALUE, is(pojo.property));
+    }
 
-	@Test
+    @Test
     public void countsAllNodesInADocument() {
         int count = Json.deepSize(Json.node(
             "{\n" +
@@ -106,8 +106,8 @@ public class JsonTest {
 
         assertThat(count, is(1));
     }
-	
-	private static class TestPojo {
-		public String property;
-	}
+    
+    private static class TestPojo {
+    	public String property;
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -69,10 +69,10 @@ public class ResponseDefinitionTest {
     }
 
     private static final String STRING_BODY =
-            "{	        								\n" +
-            "		\"status\": 200,    				\n" +
-            "		\"body\": \"String content\" 		\n" +
-            "}											";
+            "{            								\n" +
+            "    	\"status\": 200,    				\n" +
+            "    	\"body\": \"String content\" 		\n" +
+            "}    										";
 
     @Test
     public void correctlyUnmarshalsFromJsonWhenBodyIsAString() {
@@ -83,10 +83,10 @@ public class ResponseDefinitionTest {
     }
 
     private static final String JSON_BODY =
-            "{	        								\n" +
-                    "		\"status\": 200,    				\n" +
-                    "		\"jsonBody\": {\"name\":\"wirmock\",\"isCool\":true} \n" +
-                    "}											";
+            "{            								\n" +
+                    "    	\"status\": 200,    				\n" +
+                    "    	\"jsonBody\": {\"name\":\"wirmock\",\"isCool\":true} \n" +
+                    "}    										";
 
     @Test
     public void correctlyUnmarshalsFromJsonWhenBodyIsJson() {
@@ -112,10 +112,10 @@ public class ResponseDefinitionTest {
     private static final byte[] BODY = new byte[] {1, 2, 3};
     private static final String BASE64_BODY = "AQID";
     private static final String BINARY_BODY =
-            "{	        								        \n" +
-            "		\"status\": 200,    				        \n" +
-            "		\"base64Body\": \"" + BASE64_BODY + "\"     \n" +
-            "}											        ";
+            "{            								        \n" +
+            "    	\"status\": 200,    				        \n" +
+            "    	\"base64Body\": \"" + BASE64_BODY + "\"     \n" +
+            "}    										        ";
 
     @Test
     public void correctlyUnmarshalsFromJsonWhenBodyIsBinary() {

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSetTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/SortedConcurrentMappingSetTest.java
@@ -33,127 +33,127 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class SortedConcurrentMappingSetTest {
-	
-	private SortedConcurrentMappingSet mappingSet;
-	
-	@Before
-	public void init() {
-		mappingSet = new SortedConcurrentMappingSet();
-	}
+    
+    private SortedConcurrentMappingSet mappingSet;
+    
+    @Before
+    public void init() {
+    	mappingSet = new SortedConcurrentMappingSet();
+    }
 
-	@SuppressWarnings("unchecked")
-	@Test
-	public void returnsMappingsInPriorityThenInsertionOrder() {
-		mappingSet.add(aMapping(3, "/priority3/1"));
-		mappingSet.add(aMapping(3, "/priority3/2"));
-		mappingSet.add(aMapping(6, "/priority6/1"));
-		mappingSet.add(aMapping(1, "/priority1/1"));
-		mappingSet.add(aMapping(1, "/priority1/2"));
-		mappingSet.add(aMapping(1, "/priority1/3"));
-		
-		assertThat(mappingSet, hasExactly(
-				requestUrlIs("/priority1/3"),
-				requestUrlIs("/priority1/2"),
-				requestUrlIs("/priority1/1"),
-				requestUrlIs("/priority3/2"),
-				requestUrlIs("/priority3/1"),
-				requestUrlIs("/priority6/1")));
-	}
-	
-	@SuppressWarnings("unchecked")
-	@Test
-	public void supportsNullPriority() {
-		mappingSet.add(aMapping(null, "/1"));
-		mappingSet.add(aMapping(null, "/2"));
-		mappingSet.add(aMapping(null, "/3"));
-		mappingSet.add(aMapping(null, "/4"));
-		
-		assertThat(mappingSet, hasExactly(
-				requestUrlIs("/4"),
-				requestUrlIs("/3"),
-				requestUrlIs("/2"),
-				requestUrlIs("/1")));
-	}
-	
-	@Test
-	public void clearsCorrectly() {
-		mappingSet.add(aMapping(3, "/priority3/1"));
-		mappingSet.add(aMapping(3, "/priority3/2"));
-		mappingSet.add(aMapping(6, "/priority6/1"));
-		mappingSet.add(aMapping(1, "/priority1/1"));
-		
-		mappingSet.clear();
-		
-		assertThat("Mapping set should be empty", mappingSet.iterator().hasNext(), is(false));
-	}
+    @SuppressWarnings("unchecked")
+    @Test
+    public void returnsMappingsInPriorityThenInsertionOrder() {
+    	mappingSet.add(aMapping(3, "/priority3/1"));
+    	mappingSet.add(aMapping(3, "/priority3/2"));
+    	mappingSet.add(aMapping(6, "/priority6/1"));
+    	mappingSet.add(aMapping(1, "/priority1/1"));
+    	mappingSet.add(aMapping(1, "/priority1/2"));
+    	mappingSet.add(aMapping(1, "/priority1/3"));
+    	
+    	assertThat(mappingSet, hasExactly(
+    			requestUrlIs("/priority1/3"),
+    			requestUrlIs("/priority1/2"),
+    			requestUrlIs("/priority1/1"),
+    			requestUrlIs("/priority3/2"),
+    			requestUrlIs("/priority3/1"),
+    			requestUrlIs("/priority6/1")));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void supportsNullPriority() {
+    	mappingSet.add(aMapping(null, "/1"));
+    	mappingSet.add(aMapping(null, "/2"));
+    	mappingSet.add(aMapping(null, "/3"));
+    	mappingSet.add(aMapping(null, "/4"));
+    	
+    	assertThat(mappingSet, hasExactly(
+    			requestUrlIs("/4"),
+    			requestUrlIs("/3"),
+    			requestUrlIs("/2"),
+    			requestUrlIs("/1")));
+    }
+    
+    @Test
+    public void clearsCorrectly() {
+    	mappingSet.add(aMapping(3, "/priority3/1"));
+    	mappingSet.add(aMapping(3, "/priority3/2"));
+    	mappingSet.add(aMapping(6, "/priority6/1"));
+    	mappingSet.add(aMapping(1, "/priority1/1"));
+    	
+    	mappingSet.clear();
+    	
+    	assertThat("Mapping set should be empty", mappingSet.iterator().hasNext(), is(false));
+    }
 
-	@Test
-	public void testRemove() throws Exception {
+    @Test
+    public void testRemove() throws Exception {
 
-		StubMapping stubMapping = aMapping(1, "/priority1/1");
+    	StubMapping stubMapping = aMapping(1, "/priority1/1");
 
-		mappingSet.add(stubMapping);
-		assertThat(mappingSet.iterator().hasNext(), is(true));
+    	mappingSet.add(stubMapping);
+    	assertThat(mappingSet.iterator().hasNext(), is(true));
 
-		mappingSet.remove(stubMapping);
-		assertThat(mappingSet.iterator().hasNext(), is(false));
-	}
+    	mappingSet.remove(stubMapping);
+    	assertThat(mappingSet.iterator().hasNext(), is(false));
+    }
 
-	@Test
-	public void testReplace() throws Exception {
+    @Test
+    public void testReplace() throws Exception {
 
-		StubMapping existingMapping = aMapping(1, "/priority1/1");
-		mappingSet.add(existingMapping);
+    	StubMapping existingMapping = aMapping(1, "/priority1/1");
+    	mappingSet.add(existingMapping);
 
-		existingMapping.setNewScenarioState("New Scenario State");
+    	existingMapping.setNewScenarioState("New Scenario State");
 
-		StubMapping newMapping = aMapping(2, "/priority2/1");
-		boolean result = mappingSet.replace(existingMapping, newMapping);
+    	StubMapping newMapping = aMapping(2, "/priority2/1");
+    	boolean result = mappingSet.replace(existingMapping, newMapping);
 
-		Iterator<StubMapping> it = mappingSet.iterator();
+    	Iterator<StubMapping> it = mappingSet.iterator();
 
-		assertThat(result, is(true));
-		assertThat(it.hasNext(), is(true));
-		assertThat(it.next(), is(newMapping));
-		assertThat(it.hasNext(), is(false));
-	}
+    	assertThat(result, is(true));
+    	assertThat(it.hasNext(), is(true));
+    	assertThat(it.next(), is(newMapping));
+    	assertThat(it.hasNext(), is(false));
+    }
 
-	@Test
-	public void testReplaceNotExists() throws Exception {
+    @Test
+    public void testReplaceNotExists() throws Exception {
 
-		StubMapping existingMapping = aMapping(1, "/priority1/1");
-		mappingSet.add(existingMapping);
+    	StubMapping existingMapping = aMapping(1, "/priority1/1");
+    	mappingSet.add(existingMapping);
 
-		StubMapping newMapping = aMapping(2, "/priority2/1");
-		boolean result = mappingSet.replace(aMapping(2, "/priority2/2"), newMapping);
+    	StubMapping newMapping = aMapping(2, "/priority2/1");
+    	boolean result = mappingSet.replace(aMapping(2, "/priority2/2"), newMapping);
 
-		Iterator<StubMapping> it = mappingSet.iterator();
+    	Iterator<StubMapping> it = mappingSet.iterator();
 
-		assertThat(result, is(false));
-		assertThat(it.hasNext(), is(true));
-		assertThat(it.next(), is(existingMapping));
-		assertThat(it.hasNext(), is(false));
-	}
+    	assertThat(result, is(false));
+    	assertThat(it.hasNext(), is(true));
+    	assertThat(it.next(), is(existingMapping));
+    	assertThat(it.hasNext(), is(false));
+    }
 
-	private StubMapping aMapping(Integer priority, String url) {
-		RequestPattern requestPattern = newRequestPattern(ANY, urlEqualTo(url)).build();
-		StubMapping mapping = new StubMapping(requestPattern, new ResponseDefinition());
-		mapping.setPriority(priority);
-		return mapping;
-	}
-	
-	private Matcher<StubMapping> requestUrlIs(final String expectedUrl) {
-		return new TypeSafeMatcher<StubMapping>() {
+    private StubMapping aMapping(Integer priority, String url) {
+    	RequestPattern requestPattern = newRequestPattern(ANY, urlEqualTo(url)).build();
+    	StubMapping mapping = new StubMapping(requestPattern, new ResponseDefinition());
+    	mapping.setPriority(priority);
+    	return mapping;
+    }
+    
+    private Matcher<StubMapping> requestUrlIs(final String expectedUrl) {
+    	return new TypeSafeMatcher<StubMapping>() {
 
-			@Override
-			public void describeTo(Description desc) {
-			}
+    		@Override
+    		public void describeTo(Description desc) {
+    		}
 
-			@Override
-			public boolean matchesSafely(StubMapping actualMapping) {
-				return actualMapping.getRequest().getUrl().equals(expectedUrl);
-			}
-			
-		};
-	}
+    		@Override
+    		public boolean matchesSafely(StubMapping actualMapping) {
+    			return actualMapping.getRequest().getUrl().equals(expectedUrl);
+    		}
+    		
+    	};
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/StubMappingJsonRecorderTest.java
@@ -52,22 +52,22 @@ import static org.skyscreamer.jsonassert.JSONCompareMode.STRICT_ORDER;
 @RunWith(JMock.class)
 public class StubMappingJsonRecorderTest {
 
-	private StubMappingJsonRecorder listener;
-	private FileSource mappingsFileSource;
-	private FileSource filesFileSource;
+    private StubMappingJsonRecorder listener;
+    private FileSource mappingsFileSource;
+    private FileSource filesFileSource;
     private Admin admin;
 
-	private Mockery context;
+    private Mockery context;
 
-	@Before
-	public void init() {
-		context = new Mockery();
-		mappingsFileSource = context.mock(FileSource.class, "mappingsFileSource");
-		filesFileSource = context.mock(FileSource.class, "filesFileSource");
+    @Before
+    public void init() {
+    	context = new Mockery();
+    	mappingsFileSource = context.mock(FileSource.class, "mappingsFileSource");
+    	filesFileSource = context.mock(FileSource.class, "filesFileSource");
         admin = context.mock(Admin.class);
 
         constructRecordingListener(Collections.<String>emptyList());
-	}
+    }
 
     private void constructRecordingListener(List<String> headersToRecord) {
         listener = new StubMappingJsonRecorder(mappingsFileSource, filesFileSource, admin, transform(headersToRecord, TO_CASE_INSENSITIVE_KEYS));
@@ -75,31 +75,31 @@ public class StubMappingJsonRecorderTest {
     }
 
     private static final String SAMPLE_REQUEST_MAPPING =
-		"{ 													             \n" +
-		"	\"request\": {									             \n" +
-		"		\"method\": \"GET\",						             \n" +
-		"		\"url\": \"/recorded/content\"				             \n" +
-		"	},												             \n" +
-		"	\"response\": {									             \n" +
-		"		\"status\": 200,							             \n" +
-		"		\"bodyFileName\": \"body-recorded-content-1$2!3.txt\"    \n" +
-		"	}												             \n" +
-		"}													               ";
+    	"{ 													             \n" +
+    	"	\"request\": {									             \n" +
+    	"		\"method\": \"GET\",						             \n" +
+    	"		\"url\": \"/recorded/content\"				             \n" +
+    	"	},												             \n" +
+    	"	\"response\": {									             \n" +
+    	"		\"status\": 200,							             \n" +
+    	"		\"bodyFileName\": \"body-recorded-content-1$2!3.txt\"    \n" +
+    	"	}												             \n" +
+    	"}													               ";
 
-	@Test
-	public void writesMappingFileAndCorrespondingBodyFileOnRequest() {
-		context.checking(new Expectations() {{
-		    allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
-			one(mappingsFileSource).writeTextFile(with(equal("mapping-recorded-content-1$2!3.json")),
-					with(equalToJson(SAMPLE_REQUEST_MAPPING, STRICT_ORDER)));
-			one(filesFileSource).writeBinaryFile(with(equal("body-recorded-content-1$2!3.txt")),
+    @Test
+    public void writesMappingFileAndCorrespondingBodyFileOnRequest() {
+    	context.checking(new Expectations() {{
+    	    allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
+    		one(mappingsFileSource).writeTextFile(with(equal("mapping-recorded-content-1$2!3.json")),
+    				with(equalToJson(SAMPLE_REQUEST_MAPPING, STRICT_ORDER)));
+    		one(filesFileSource).writeBinaryFile(with(equal("body-recorded-content-1$2!3.txt")),
                     with(equal("Recorded body content".getBytes(UTF_8))));
-		}});
+    	}});
 
-		Request request = new MockRequestBuilder(context)
-			.withMethod(RequestMethod.GET)
-			.withUrl("/recorded/content")
-			.build();
+    	Request request = new MockRequestBuilder(context)
+    		.withMethod(RequestMethod.GET)
+    		.withUrl("/recorded/content")
+    		.build();
 
         Response response = response()
                 .status(200)
@@ -107,10 +107,10 @@ public class StubMappingJsonRecorderTest {
                 .body("Recorded body content")
                 .build();
 
-		listener.requestReceived(request, response);
-	}
+    	listener.requestReceived(request, response);
+    }
 
-	private static final String SAMPLE_REQUEST_MAPPING_WITH_HEADERS =
+    private static final String SAMPLE_REQUEST_MAPPING_WITH_HEADERS =
         "{                                                                  \n" +
         "   \"request\": {                                                  \n" +
         "       \"method\": \"GET\",                                        \n" +
@@ -126,10 +126,10 @@ public class StubMappingJsonRecorderTest {
         "   }                                                               \n" +
         "}                                                                  ";
 
-	@Test
-	public void addsResponseHeaders() {
-	    context.checking(new Expectations() {{
-	        allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
+    @Test
+    public void addsResponseHeaders() {
+        context.checking(new Expectations() {{
+            allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
             one(mappingsFileSource).writeTextFile(with(equal("mapping-headered-content-1$2!3.json")),
                     with(equalToJson(SAMPLE_REQUEST_MAPPING_WITH_HEADERS, STRICT_ORDER)));
             one(filesFileSource).writeBinaryFile("body-headered-content-1$2!3.txt", "Recorded body content".getBytes(UTF_8));
@@ -145,31 +145,31 @@ public class StubMappingJsonRecorderTest {
                 .fromProxy(true)
                 .body("Recorded body content")
                 .headers(new HttpHeaders(
-						httpHeader("Content-Type", "text/plain"),
-						httpHeader("Cache-Control", "no-cache")))
+    					httpHeader("Content-Type", "text/plain"),
+    					httpHeader("Cache-Control", "no-cache")))
                 .build();
 
         listener.requestReceived(request, response);
-	}
+    }
 
-	@Test
-	public void doesNotWriteFileIfRequestAlreadyReceived() {
-	    context.checking(new Expectations() {{
+    @Test
+    public void doesNotWriteFileIfRequestAlreadyReceived() {
+        context.checking(new Expectations() {{
             atLeast(1).of(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(1)));
             never(mappingsFileSource).writeTextFile(with(any(String.class)), with(any(String.class)));
             never(filesFileSource).writeTextFile(with(any(String.class)), with(any(String.class)));
         }});
 
-	    listener.requestReceived(new MockRequestBuilder(context)
+        listener.requestReceived(new MockRequestBuilder(context)
                 .withMethod(RequestMethod.GET)
                 .withUrl("/headered/content")
                 .build(),
             response().fromProxy(true).status(200).build());
-	}
+    }
 
-	@Test
-	public void doesNotWriteFileIfResponseNotFromProxy() {
-	    context.checking(new Expectations() {{
+    @Test
+    public void doesNotWriteFileIfResponseNotFromProxy() {
+        context.checking(new Expectations() {{
             allowing(admin).countRequestsMatching(with(any(RequestPattern.class))); will(returnValue(VerificationResult.withCount(0)));
             never(mappingsFileSource).writeTextFile(with(any(String.class)), with(any(String.class)));
             never(filesFileSource).writeTextFile(with(any(String.class)), with(any(String.class)));
@@ -185,22 +185,22 @@ public class StubMappingJsonRecorderTest {
                 .withUrl("/headered/content")
                 .build(),
             response);
-	}
+    }
 
     private static final String SAMPLE_REQUEST_MAPPING_WITH_BODY =
-            "{ 													             \n" +
-            "	\"request\": {									             \n" +
-            "		\"method\": \"POST\",						             \n" +
-            "		\"url\": \"/body/content\",                              \n" +
+            "{     												             \n" +
+            "    \"request\": {									             \n" +
+            "    	\"method\": \"POST\",						             \n" +
+            "    	\"url\": \"/body/content\",                              \n" +
             "       \"bodyPatterns\": [                                      \n" +
             "            { \"equalTo\": \"somebody\" }                       \n" +
-            "        ]				                                         \n" +
-            "	},												             \n" +
-            "	\"response\": {									             \n" +
-            "		\"status\": 200, 							             \n" +
-            "		\"bodyFileName\": \"body-body-content-1$2!3.txt\"        \n" +
-            "	}												             \n" +
-            "}													               ";
+            "        ]    			                                         \n" +
+            "    },												             \n" +
+            "    \"response\": {									             \n" +
+            "    	\"status\": 200, 							             \n" +
+            "    	\"bodyFileName\": \"body-body-content-1$2!3.txt\"        \n" +
+            "    }												             \n" +
+            "}    												               ";
 
     @Test
     public void includesBodyInRequestPatternIfInRequest() {
@@ -224,36 +224,36 @@ public class StubMappingJsonRecorderTest {
     }
 
     private static final String SAMPLE_REQUEST_MAPPING_WITH_REQUEST_HEADERS_1 =
-            "{ 													             \n" +
-            "	\"request\": {									             \n" +
-            "		\"method\": \"GET\",						             \n" +
-            "		\"url\": \"/same/url\",                             	 \n" +
-            "       \"headers\": {                                       	 \n" +
-            "			 \"Accept\":										 \n" +
-            "            	{ \"equalTo\": \"text/html\" }            		 \n" +
-            "        }				                                         \n" +
-            "	},												             \n" +
-            "	\"response\": {									             \n" +
-            "		\"status\": 200,							             \n" +
-            "		\"bodyFileName\": \"body-same-url-1$2!3.txt\"		 	 \n" +
-            "	}												             \n" +
-            "}													               ";
+            "{     												             \n" +
+            "    \"request\": {									             \n" +
+            "    	\"method\": \"GET\",						             \n" +
+            "    	\"url\": \"/same/url\",                             	 \n" +
+            "       \"headers\": {                                            \n" +
+            "    		 \"Accept\":										 \n" +
+            "                { \"equalTo\": \"text/html\" }            		 \n" +
+            "        }    			                                         \n" +
+            "    },												             \n" +
+            "    \"response\": {									             \n" +
+            "    	\"status\": 200,							             \n" +
+            "    	\"bodyFileName\": \"body-same-url-1$2!3.txt\"		 	 \n" +
+            "    }												             \n" +
+            "}    												               ";
 
     private static final String SAMPLE_REQUEST_MAPPING_WITH_REQUEST_HEADERS_2 =
-            "{ 													             \n" +
-            "	\"request\": {									             \n" +
-            "		\"method\": \"GET\",						             \n" +
-            "		\"url\": \"/same/url\",                             	 \n" +
-            "       \"headers\": {                                       	 \n" +
-            "			 \"Accept\":										 \n" +
-            "            	{ \"equalTo\": \"application/json\" }            \n" +
-            "        }				                                         \n" +
-            "	},												             \n" +
-            "	\"response\": {									             \n" +
-            "		\"status\": 200, 							             \n" +
-            "		\"bodyFileName\": \"body-same-url-1$2!3.txt\"		 	 \n" +
-            "	}												             \n" +
-            "}													               ";
+            "{     												             \n" +
+            "    \"request\": {									             \n" +
+            "    	\"method\": \"GET\",						             \n" +
+            "    	\"url\": \"/same/url\",                             	 \n" +
+            "       \"headers\": {                                            \n" +
+            "    		 \"Accept\":										 \n" +
+            "                { \"equalTo\": \"application/json\" }            \n" +
+            "        }    			                                         \n" +
+            "    },												             \n" +
+            "    \"response\": {									             \n" +
+            "    	\"status\": 200, 							             \n" +
+            "    	\"bodyFileName\": \"body-same-url-1$2!3.txt\"		 	 \n" +
+            "    }												             \n" +
+            "}    												               ";
 
     private static final List<String> MATCHING_REQUEST_HEADERS = new ArrayList<String>(Arrays.asList("Accept"));
 
@@ -279,10 +279,10 @@ public class StubMappingJsonRecorderTest {
                 .build();
 
         Request request2 = new MockRequestBuilder(context, "MockRequestAcceptJson")
-		        .withMethod(GET)
-		        .withUrl("/same/url")
-		        .withHeader("Accept", "application/json")
-		        .build();
+    	        .withMethod(GET)
+    	        .withUrl("/same/url")
+    	        .withHeader("Accept", "application/json")
+    	        .build();
 
         listener.requestReceived(request1,
                 response().status(200).fromProxy(true).build());
@@ -365,18 +365,18 @@ public class StubMappingJsonRecorderTest {
     }
 
     private static final String GZIP_REQUEST_MAPPING =
-                    "{ 													             \n" +
+                    "{     												             \n" +
                     "   \"id\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",            \n" +
                     "   \"uuid\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",          \n" +
-                    "	\"request\": {									             \n" +
-                    "		\"method\": \"GET\",						             \n" +
-                    "		\"url\": \"/gzipped/content\"				             \n" +
-                    "	},												             \n" +
-                    "	\"response\": {									             \n" +
-                    "		\"status\": 200,							             \n" +
-                    "		\"bodyFileName\": \"body-gzipped-content-1$2!3.txt\"     \n" +
-                    "	}												             \n" +
-                    "}													               ";
+                    "    \"request\": {									             \n" +
+                    "    	\"method\": \"GET\",						             \n" +
+                    "    	\"url\": \"/gzipped/content\"				             \n" +
+                    "    },												             \n" +
+                    "    \"response\": {									             \n" +
+                    "    	\"status\": 200,							             \n" +
+                    "    	\"bodyFileName\": \"body-gzipped-content-1$2!3.txt\"     \n" +
+                    "    }												             \n" +
+                    "}    												               ";
 
     @Test
     public void decompressesGzippedResponseBodyAndRemovesContentEncodingHeader() {
@@ -409,52 +409,52 @@ public class StubMappingJsonRecorderTest {
     }
 
     private static final String MULTIPART_REQUEST_MAPPING =
-                    "{																	\n" +
-                    "	\"id\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n" +
-                    "	\"uuid\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n" +
-                    "	\"request\": {													\n" +
-                    "		\"method\": \"POST\",										\n" +
-                    "		\"url\": \"/multipart/content\",							\n" +
-                    "		\"multipartPatterns\" : [ {									\n" +
-                    "			\"name\" : \"binaryFile\",								\n" +
-                    "			\"matchingType\" : \"ALL\",								\n" +
-                    "			\"headers\" : {											\n" +
-                    "				\"Content-Disposition\" : {							\n" +
-                    "					\"contains\" : \"name=\\\"binaryFile\\\"\"		\n" +
-                    "			    }													\n" +
-                    "			},														\n" +
-                    "			\"bodyPatterns\" : [ {									\n" +
-                    "				\"binaryEqualTo\" : \"VGhpcyBhIGZpbGUgY29udGVudA==\"\n" +
-                    "			} ]														\n" +
-                    "		}, {														\n" +
-                    "			\"name\" : \"textFile\",								\n" +
-                    "			\"matchingType\" : \"ALL\",								\n" +
-                    "			\"headers\" : {											\n" +
-                    "				\"Content-Disposition\" : {							\n" +
-                    "					\"contains\" : \"name=\\\"textFile\\\"\"		\n" +
-                    "			    }													\n" +
-                    "			},														\n" +
-                    "			\"bodyPatterns\" : [ {									\n" +
-                    "				\"equalTo\" : \"This a file content\"				\n" +
-                    "			} ]														\n" +
-                    "		}, {														\n" +
-                    "			\"name\" : \"formInput\",								\n" +
-                    "			\"matchingType\" : \"ALL\",								\n" +
-                    "			\"headers\" : {											\n" +
-                    "				\"Content-Disposition\" : {							\n" +
-                    "					\"contains\" : \"name=\\\"formInput\\\"\"		\n" +
-                    "				},													\n" +
-                    "			},														\n" +
-                    "			\"bodyPatterns\" : [ {									\n" +
-                    "				\"equalTo\" : \"I am a field!\"						\n" +
-                    "			} ]														\n" +
-                    "		} ]															\n" +
-                    "	},												            	\n" +
-                    "	\"response\": {									            	\n" +
-                    "		\"status\": 200,							            	\n" +
-                    "		\"bodyFileName\": \"body-multipart-content-1$2!3.txt\"  	\n" +
-                    "	}												            	\n" +
-                    "}																	";
+                    "{    																\n" +
+                    "    \"id\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n" +
+                    "    \"uuid\": \"41544750-0c69-3fd7-93b1-f79499f987c3\",				\n" +
+                    "    \"request\": {													\n" +
+                    "    	\"method\": \"POST\",										\n" +
+                    "    	\"url\": \"/multipart/content\",							\n" +
+                    "    	\"multipartPatterns\" : [ {									\n" +
+                    "    		\"name\" : \"binaryFile\",								\n" +
+                    "    		\"matchingType\" : \"ALL\",								\n" +
+                    "    		\"headers\" : {											\n" +
+                    "    			\"Content-Disposition\" : {							\n" +
+                    "    				\"contains\" : \"name=\\\"binaryFile\\\"\"		\n" +
+                    "    		    }													\n" +
+                    "    		},														\n" +
+                    "    		\"bodyPatterns\" : [ {									\n" +
+                    "    			\"binaryEqualTo\" : \"VGhpcyBhIGZpbGUgY29udGVudA==\"\n" +
+                    "    		} ]														\n" +
+                    "    	}, {														\n" +
+                    "    		\"name\" : \"textFile\",								\n" +
+                    "    		\"matchingType\" : \"ALL\",								\n" +
+                    "    		\"headers\" : {											\n" +
+                    "    			\"Content-Disposition\" : {							\n" +
+                    "    				\"contains\" : \"name=\\\"textFile\\\"\"		\n" +
+                    "    		    }													\n" +
+                    "    		},														\n" +
+                    "    		\"bodyPatterns\" : [ {									\n" +
+                    "    			\"equalTo\" : \"This a file content\"				\n" +
+                    "    		} ]														\n" +
+                    "    	}, {														\n" +
+                    "    		\"name\" : \"formInput\",								\n" +
+                    "    		\"matchingType\" : \"ALL\",								\n" +
+                    "    		\"headers\" : {											\n" +
+                    "    			\"Content-Disposition\" : {							\n" +
+                    "    				\"contains\" : \"name=\\\"formInput\\\"\"		\n" +
+                    "    			},													\n" +
+                    "    		},														\n" +
+                    "    		\"bodyPatterns\" : [ {									\n" +
+                    "    			\"equalTo\" : \"I am a field!\"						\n" +
+                    "    		} ]														\n" +
+                    "    	} ]															\n" +
+                    "    },												            	\n" +
+                    "    \"response\": {									            	\n" +
+                    "    	\"status\": 200,							            	\n" +
+                    "    	\"bodyFileName\": \"body-multipart-content-1$2!3.txt\"  	\n" +
+                    "    }												            	\n" +
+                    "}    																";
     @Test
     public void multipartRequestProcessing() {
         context.checking(new Expectations() {{
@@ -582,15 +582,15 @@ public class StubMappingJsonRecorderTest {
         listener.requestReceived(request, response);
     }
 
-	private IdGenerator fixedIdGenerator(final String id) {
-	    return new IdGenerator() {
+    private IdGenerator fixedIdGenerator(final String id) {
+        return new IdGenerator() {
             public String generate() {
                 return id;
             }
         };
-	}
+    }
 
-	private static Request.Part createPart(final String name, final byte[] data, final String contentType, final String fileName, String... extraHeaderLines) {
+    private static Request.Part createPart(final String name, final byte[] data, final String contentType, final String fileName, String... extraHeaderLines) {
         MockMultipart part = new MockMultipart().name(name).body(data);
 
         for (String headerLine: extraHeaderLines) {

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MappingJsonSamples.java
@@ -21,54 +21,54 @@ import static com.github.tomakehurst.wiremock.common.Encoding.encodeBase64;
 
 public class MappingJsonSamples {
 
-	public static final String BASIC_MAPPING_REQUEST_WITH_RESPONSE_HEADER =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/a/registered/resource\"			\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 401,							\n" +
-		"		\"headers\": {								\n" +
-		"			\"Content-Type\": \"text/plain\"		\n" +
-		"		},											\n" +
-		"		\"body\": \"Not allowed!\"					\n" +
-		"	}												\n" +
-		"}													";
-	
-	public static final String STATUS_ONLY_MAPPING_REQUEST =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"PUT\",						\n" +
-		"		\"url\": \"/status/only\"					\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 204								\n" +
-		"	}												\n" +
-		"}													";
-	
-	public static final String STATUS_ONLY_GET_MAPPING_TEMPLATE =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"urlPattern\": \"%s\"						\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 200								\n" +
-		"	}												\n" +
-		"}													";
-	
-	public static final String WITH_RESPONSE_BODY =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/with/body\"						\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 200,							\n" +
-		"		\"body\": \"Some content\"					\n" +
-		"	}												\n" +
-		"}													";
+    public static final String BASIC_MAPPING_REQUEST_WITH_RESPONSE_HEADER =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/a/registered/resource\"			\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 401,							\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Content-Type\": \"text/plain\"		\n" +
+    	"		},											\n" +
+    	"		\"body\": \"Not allowed!\"					\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    public static final String STATUS_ONLY_MAPPING_REQUEST =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"PUT\",						\n" +
+    	"		\"url\": \"/status/only\"					\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 204								\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    public static final String STATUS_ONLY_GET_MAPPING_TEMPLATE =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"urlPattern\": \"%s\"						\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 200								\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    public static final String WITH_RESPONSE_BODY =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/with/body\"						\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 200,							\n" +
+    	"		\"body\": \"Some content\"					\n" +
+    	"	}												\n" +
+    	"}													";
 
     public static final String SPEC_WITH_RESPONSE_BODY =
         "{                                                  \n" +
@@ -81,160 +81,160 @@ public class MappingJsonSamples {
         "       \"status\": 200                             \n" +
         "   }                                               \n" +
         "}                                                  ";
-	
-	public static final String BASIC_GET =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/basic/mapping/resource\"		\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 304 							\n" +
-		"	}												\n" +
-		"}													";
-	
-	public static final String BASIC_POST = BASIC_GET.replace("GET", "POST");
-	public static final String BASIC_PUT = BASIC_GET.replace("GET", "PUT");
-	public static final String BASIC_DELETE = BASIC_GET.replace("GET", "DELETE");
-	public static final String BASIC_PATCH = BASIC_GET.replace("GET", "PATCH");
-	public static final String BASIC_HEAD = BASIC_GET.replace("GET", "HEAD");
-	public static final String BASIC_OPTIONS = BASIC_GET.replace("GET", "OPTIONS");
-	public static final String BASIC_TRACE = BASIC_GET.replace("GET", "TRACE");
-	public static final String BASIC_ANY_METHOD = BASIC_GET.replace("GET", "ANY");
-	
-	public static final String MAPPING_REQUEST_WITH_EXACT_HEADERS =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/header/dependent\",				\n" +
-		"		\"headers\": {								\n" +
-		"			\"Accept\": {							\n" +
-		"				\"equalTo\": \"text/xml\"			\n" +
-		"			},										\n" +
-		"			\"If-None-Match\": {					\n" +
-		"				\"equalTo\": \"abcd1234\"			\n" +
-		"			}										\n" +
-		"		}											\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 304,							\n" +
-		"		\"headers\": {								\n" +
-		"			\"Content-Type\": \"text/xml\"			\n" +
-		"		}											\n" +
-		"	}												\n" +
-		"}													";
-	
-	public static final String MAPPING_REQUEST_WITH_REGEX_HEADERS =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/header/match/dependent\",		\n" +
-		"		\"headers\": {								\n" +
-		"			\"Accept\": {							\n" +
-		"				\"matches\": \"(.*)xml(.*)\"		\n" +
-		"			},										\n" +
-		"			\"If-None-Match\": {					\n" +
-		"				\"matches\": \"([a-z0-9]*)\"		\n" +
-		"			}										\n" +
-		"		}											\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 304,							\n" +
-		"		\"headers\": {								\n" +
-		"			\"Content-Type\": \"text/xml\"			\n" +
-		"		}											\n" +
-		"	}												\n" +
-		"}													";
-	
-	public static final String MAPPING_REQUEST_WITH_NEGATIVE_REGEX_HEADERS =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"GET\",						\n" +
-		"		\"url\": \"/header/match/dependent\",		\n" +
-		"		\"headers\": {								\n" +
-		"			\"Accept\": {							\n" +
-		"				\"doesNotMatch\": \"(.*)xml(.*)\"	\n" +
-		"			}										\n" +
-		"		}											\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 200,							\n" +
-		"		\"headers\": {								\n" +
-		"			\"Content-Type\": \"text/xml\"			\n" +
-		"		}											\n" +
-		"	}												\n" +
-		"}													";
-	
+    
+    public static final String BASIC_GET =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/basic/mapping/resource\"		\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 304 							\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    public static final String BASIC_POST = BASIC_GET.replace("GET", "POST");
+    public static final String BASIC_PUT = BASIC_GET.replace("GET", "PUT");
+    public static final String BASIC_DELETE = BASIC_GET.replace("GET", "DELETE");
+    public static final String BASIC_PATCH = BASIC_GET.replace("GET", "PATCH");
+    public static final String BASIC_HEAD = BASIC_GET.replace("GET", "HEAD");
+    public static final String BASIC_OPTIONS = BASIC_GET.replace("GET", "OPTIONS");
+    public static final String BASIC_TRACE = BASIC_GET.replace("GET", "TRACE");
+    public static final String BASIC_ANY_METHOD = BASIC_GET.replace("GET", "ANY");
+    
+    public static final String MAPPING_REQUEST_WITH_EXACT_HEADERS =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/header/dependent\",				\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Accept\": {							\n" +
+    	"				\"equalTo\": \"text/xml\"			\n" +
+    	"			},										\n" +
+    	"			\"If-None-Match\": {					\n" +
+    	"				\"equalTo\": \"abcd1234\"			\n" +
+    	"			}										\n" +
+    	"		}											\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 304,							\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Content-Type\": \"text/xml\"			\n" +
+    	"		}											\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    public static final String MAPPING_REQUEST_WITH_REGEX_HEADERS =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/header/match/dependent\",		\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Accept\": {							\n" +
+    	"				\"matches\": \"(.*)xml(.*)\"		\n" +
+    	"			},										\n" +
+    	"			\"If-None-Match\": {					\n" +
+    	"				\"matches\": \"([a-z0-9]*)\"		\n" +
+    	"			}										\n" +
+    	"		}											\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 304,							\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Content-Type\": \"text/xml\"			\n" +
+    	"		}											\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    public static final String MAPPING_REQUEST_WITH_NEGATIVE_REGEX_HEADERS =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"GET\",						\n" +
+    	"		\"url\": \"/header/match/dependent\",		\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Accept\": {							\n" +
+    	"				\"doesNotMatch\": \"(.*)xml(.*)\"	\n" +
+    	"			}										\n" +
+    	"		}											\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 200,							\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Content-Type\": \"text/xml\"			\n" +
+    	"		}											\n" +
+    	"	}												\n" +
+    	"}													";
+    
 
-	public static final String WITH_REQUEST_HEADERS =
-		"{ 													\n" +
-		"	\"request\": {									\n" +
-		"		\"method\": \"PUT\",						\n" +
-		"		\"url\": \"/header/matches/dependent\",		\n" +
-		"		\"headers\": {								\n" +
-		"			\"Content-Type\": {						\n" +
-		"				\"equalTo\": \"text/xml\"			\n" +
-		"			},										\n" +
-		"			\"Cache-Control\": {					\n" +
-		"				\"contains\": \"private\"			\n" +
-		"			},										\n" +
-		"			\"If-None-Match\": {					\n" +
-		"				\"matches\": \"([a-z0-9]*)\"		\n" +
-		"			},										\n" +
-		"			\"Accept\": {							\n" +
-		"				\"doesNotMatch\": \"(.*)xml(.*)\"	\n" +
-		"			}										\n" +
-		"		}											\n" +
-		"	},												\n" +
-		"	\"response\": {									\n" +
-		"		\"status\": 201								\n" +
-		"	}												\n" +
-		"}													";
-	
-	public static final String WITH_BODY_PATTERNS =
-		"{ 														\n" +
-		"	\"request\": {										\n" +
-		"		\"method\": \"PUT\",							\n" +
-		"		\"url\": \"/body/patterns/dependent\",			\n" +
-		"		\"bodyPatterns\": [								\n" +
-		"			{ \"equalTo\": \"the number is 1234\" },	\n" +
-		"			{ \"contains\": \"number\" },				\n" +
-		"			{ \"matches\": \".*[0-9]{4}\" },			\n" +
-		"			{ \"doesNotMatch\": \".*5678.*\"}			\n" +
-		"		]												\n" +
-		"	},													\n" +
-		"	\"response\": {										\n" +
-		"		\"status\": 201									\n" +
-		"	}													\n" +
-		"}														";
+    public static final String WITH_REQUEST_HEADERS =
+    	"{ 													\n" +
+    	"	\"request\": {									\n" +
+    	"		\"method\": \"PUT\",						\n" +
+    	"		\"url\": \"/header/matches/dependent\",		\n" +
+    	"		\"headers\": {								\n" +
+    	"			\"Content-Type\": {						\n" +
+    	"				\"equalTo\": \"text/xml\"			\n" +
+    	"			},										\n" +
+    	"			\"Cache-Control\": {					\n" +
+    	"				\"contains\": \"private\"			\n" +
+    	"			},										\n" +
+    	"			\"If-None-Match\": {					\n" +
+    	"				\"matches\": \"([a-z0-9]*)\"		\n" +
+    	"			},										\n" +
+    	"			\"Accept\": {							\n" +
+    	"				\"doesNotMatch\": \"(.*)xml(.*)\"	\n" +
+    	"			}										\n" +
+    	"		}											\n" +
+    	"	},												\n" +
+    	"	\"response\": {									\n" +
+    	"		\"status\": 201								\n" +
+    	"	}												\n" +
+    	"}													";
+    
+    public static final String WITH_BODY_PATTERNS =
+    	"{ 														\n" +
+    	"	\"request\": {										\n" +
+    	"		\"method\": \"PUT\",							\n" +
+    	"		\"url\": \"/body/patterns/dependent\",			\n" +
+    	"		\"bodyPatterns\": [								\n" +
+    	"			{ \"equalTo\": \"the number is 1234\" },	\n" +
+    	"			{ \"contains\": \"number\" },				\n" +
+    	"			{ \"matches\": \".*[0-9]{4}\" },			\n" +
+    	"			{ \"doesNotMatch\": \".*5678.*\"}			\n" +
+    	"		]												\n" +
+    	"	},													\n" +
+    	"	\"response\": {										\n" +
+    	"		\"status\": 201									\n" +
+    	"	}													\n" +
+    	"}														";
 
     public static final byte[] BINARY_COMPRESSED_CONTENT = new byte []{31, -117, 8, 8, 72, -53, -8, 79, 0, 3, 103, 122, 105, 112, 100, 97, 116, 97, 45, 111, 117, 116, 0, -77, 41, 74, 45, 46, -56, -49, 43, 78, -75, -53, 72, -51, -55, -55, -73, -47, -121, -13, 1, 9, 69, -3, 52, 26, 0, 0, 0};
     public static final String BINARY_COMPRESSED_JSON_STRING = encodeBase64(BINARY_COMPRESSED_CONTENT);
     public static final String BINARY_COMPRESSED_CONTENT_AS_STRING = "<response>hello</response>";
 
     public static final String MAPPING_REQUEST_FOR_BYTE_BODY =
-            "{ 													                            \n" +
-            "	\"request\": {									                            \n" +
-            "		\"method\": \"GET\",						                            \n" +
-            "		\"url\": \"/byte/resource/from/file\"			                        \n" +
-            "	},												                            \n" +
-            "	\"response\": {									                            \n" +
-            "		\"status\": 200,							                            \n" +
-            "		\"base64Body\": \"" + encodeBase64(new byte[]{65,66,67}) + "\"		\n" +
-            "	}												                            \n" +
-            "}													                            ";
+            "{     												                            \n" +
+            "    \"request\": {									                            \n" +
+            "    	\"method\": \"GET\",						                            \n" +
+            "    	\"url\": \"/byte/resource/from/file\"			                        \n" +
+            "    },												                            \n" +
+            "    \"response\": {									                            \n" +
+            "    	\"status\": 200,							                            \n" +
+            "    	\"base64Body\": \"" + encodeBase64(new byte[]{65,66,67}) + "\"		\n" +
+            "    }												                            \n" +
+            "}    												                            ";
 
     public static final String MAPPING_REQUEST_FOR_BINARY_BYTE_BODY =
-            "{ 													                    \n" +
-            "	\"request\": {									                    \n" +
-            "		\"method\": \"GET\",						                    \n" +
-            "		\"url\": \"/bytecompressed/resource/from/file\"			        \n" +
-            "	},												                    \n" +
-            "	\"response\": {									                    \n" +
-            "		\"status\": 200,							                    \n" +
-            "		\"base64Body\": \""+ BINARY_COMPRESSED_JSON_STRING + "\"	    \n" +
-            "	}												                    \n" +
-            "}													                    ";
+            "{     												                    \n" +
+            "    \"request\": {									                    \n" +
+            "    	\"method\": \"GET\",						                    \n" +
+            "    	\"url\": \"/bytecompressed/resource/from/file\"			        \n" +
+            "    },												                    \n" +
+            "    \"response\": {									                    \n" +
+            "    	\"status\": 200,							                    \n" +
+            "    	\"base64Body\": \""+ BINARY_COMPRESSED_JSON_STRING + "\"	    \n" +
+            "    }												                    \n" +
+            "}    												                    ";
 
     public static final String MAPPING_REQUEST_FOR_NON_UTF8 =
             "{                                                                                                                      \n" +

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockHttpServletRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockHttpServletRequest.java
@@ -41,37 +41,37 @@ import java.util.Map;
 
 public class MockHttpServletRequest implements HttpServletRequest {
 
-	@Override
-	public Object getAttribute(String name) {
-		
-		return null;
-	}
+    @Override
+    public Object getAttribute(String name) {
+    	
+    	return null;
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Enumeration getAttributeNames() {
-		
-		return null;
-	}
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Enumeration getAttributeNames() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getCharacterEncoding() {
-		
-		return null;
-	}
+    @Override
+    public String getCharacterEncoding() {
+    	
+    	return null;
+    }
 
-	@Override
-	public void setCharacterEncoding(String env)
-			throws UnsupportedEncodingException {
-		
-		
-	}
+    @Override
+    public void setCharacterEncoding(String env)
+    		throws UnsupportedEncodingException {
+    	
+    	
+    }
 
-	@Override
-	public int getContentLength() {
-		
-		return 0;
-	}
+    @Override
+    public int getContentLength() {
+    	
+    	return 0;
+    }
 
     @Override
     public long getContentLengthLong() {
@@ -79,151 +79,151 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-	public String getContentType() {
-		
-		return null;
-	}
+    public String getContentType() {
+    	
+    	return null;
+    }
 
-	@Override
-	public ServletInputStream getInputStream() throws IOException {
-		
-		return null;
-	}
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getParameter(String name) {
-		
-		return null;
-	}
+    @Override
+    public String getParameter(String name) {
+    	
+    	return null;
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Enumeration getParameterNames() {
-		
-		return null;
-	}
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Enumeration getParameterNames() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String[] getParameterValues(String name) {
-		
-		return null;
-	}
+    @Override
+    public String[] getParameterValues(String name) {
+    	
+    	return null;
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Map getParameterMap() {
-		
-		return null;
-	}
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Map getParameterMap() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getProtocol() {
-		
-		return null;
-	}
+    @Override
+    public String getProtocol() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getScheme() {
-		
-		return null;
-	}
+    @Override
+    public String getScheme() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getServerName() {
-		
-		return null;
-	}
+    @Override
+    public String getServerName() {
+    	
+    	return null;
+    }
 
-	@Override
-	public int getServerPort() {
-		
-		return 0;
-	}
+    @Override
+    public int getServerPort() {
+    	
+    	return 0;
+    }
 
-	@Override
-	public BufferedReader getReader() throws IOException {
-		
-		return null;
-	}
+    @Override
+    public BufferedReader getReader() throws IOException {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getRemoteAddr() {
-		
-		return null;
-	}
+    @Override
+    public String getRemoteAddr() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getRemoteHost() {
-		
-		return null;
-	}
+    @Override
+    public String getRemoteHost() {
+    	
+    	return null;
+    }
 
-	@Override
-	public void setAttribute(String name, Object o) {
-		
-		
-	}
+    @Override
+    public void setAttribute(String name, Object o) {
+    	
+    	
+    }
 
-	@Override
-	public void removeAttribute(String name) {
-		
-		
-	}
+    @Override
+    public void removeAttribute(String name) {
+    	
+    	
+    }
 
-	@Override
-	public Locale getLocale() {
-		
-		return null;
-	}
+    @Override
+    public Locale getLocale() {
+    	
+    	return null;
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Enumeration getLocales() {
-		
-		return null;
-	}
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Enumeration getLocales() {
+    	
+    	return null;
+    }
 
-	@Override
-	public boolean isSecure() {
-		
-		return false;
-	}
+    @Override
+    public boolean isSecure() {
+    	
+    	return false;
+    }
 
-	@Override
-	public RequestDispatcher getRequestDispatcher(String path) {
-		
-		return null;
-	}
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getRealPath(String path) {
-		
-		return null;
-	}
+    @Override
+    public String getRealPath(String path) {
+    	
+    	return null;
+    }
 
-	@Override
-	public int getRemotePort() {
-		
-		return 0;
-	}
+    @Override
+    public int getRemotePort() {
+    	
+    	return 0;
+    }
 
-	@Override
-	public String getLocalName() {
-		
-		return null;
-	}
+    @Override
+    public String getLocalName() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getLocalAddr() {
-		
-		return null;
-	}
+    @Override
+    public String getLocalAddr() {
+    	
+    	return null;
+    }
 
-	@Override
-	public int getLocalPort() {
-		
-		return 0;
-	}
+    @Override
+    public int getLocalPort() {
+    	
+    	return 0;
+    }
 
     @Override
     public ServletContext getServletContext() {
@@ -261,132 +261,132 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-	public String getAuthType() {
-		
-		return null;
-	}
+    public String getAuthType() {
+    	
+    	return null;
+    }
 
-	@Override
-	public Cookie[] getCookies() {
-		
-		return null;
-	}
+    @Override
+    public Cookie[] getCookies() {
+    	
+    	return null;
+    }
 
-	@Override
-	public long getDateHeader(String name) {
-		
-		return 0;
-	}
+    @Override
+    public long getDateHeader(String name) {
+    	
+    	return 0;
+    }
 
-	@Override
-	public String getHeader(String name) {
-		
-		return null;
-	}
+    @Override
+    public String getHeader(String name) {
+    	
+    	return null;
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Enumeration getHeaders(String name) {
-		
-		return null;
-	}
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Enumeration getHeaders(String name) {
+    	
+    	return null;
+    }
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public Enumeration getHeaderNames() {
-		
-		return null;
-	}
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Enumeration getHeaderNames() {
+    	
+    	return null;
+    }
 
-	@Override
-	public int getIntHeader(String name) {
-		
-		return 0;
-	}
+    @Override
+    public int getIntHeader(String name) {
+    	
+    	return 0;
+    }
 
-	@Override
-	public String getMethod() {
-		
-		return null;
-	}
+    @Override
+    public String getMethod() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getPathInfo() {
-		
-		return null;
-	}
+    @Override
+    public String getPathInfo() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getPathTranslated() {
-		
-		return null;
-	}
+    @Override
+    public String getPathTranslated() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getContextPath() {
-		
-		return null;
-	}
+    @Override
+    public String getContextPath() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getQueryString() {
-		
-		return null;
-	}
+    @Override
+    public String getQueryString() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getRemoteUser() {
-		
-		return null;
-	}
+    @Override
+    public String getRemoteUser() {
+    	
+    	return null;
+    }
 
-	@Override
-	public boolean isUserInRole(String role) {
-		
-		return false;
-	}
+    @Override
+    public boolean isUserInRole(String role) {
+    	
+    	return false;
+    }
 
-	@Override
-	public Principal getUserPrincipal() {
-		
-		return null;
-	}
+    @Override
+    public Principal getUserPrincipal() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getRequestedSessionId() {
-		
-		return null;
-	}
+    @Override
+    public String getRequestedSessionId() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getRequestURI() {
-		
-		return null;
-	}
+    @Override
+    public String getRequestURI() {
+    	
+    	return null;
+    }
 
-	@Override
-	public StringBuffer getRequestURL() {
-		
-		return null;
-	}
+    @Override
+    public StringBuffer getRequestURL() {
+    	
+    	return null;
+    }
 
-	@Override
-	public String getServletPath() {
-		
-		return null;
-	}
+    @Override
+    public String getServletPath() {
+    	
+    	return null;
+    }
 
-	@Override
-	public HttpSession getSession(boolean create) {
-		
-		return null;
-	}
+    @Override
+    public HttpSession getSession(boolean create) {
+    	
+    	return null;
+    }
 
-	@Override
-	public HttpSession getSession() {
-		
-		return null;
-	}
+    @Override
+    public HttpSession getSession() {
+    	
+    	return null;
+    }
 
     @Override
     public String changeSessionId() {
@@ -394,28 +394,28 @@ public class MockHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-	public boolean isRequestedSessionIdValid() {
-		
-		return false;
-	}
+    public boolean isRequestedSessionIdValid() {
+    	
+    	return false;
+    }
 
-	@Override
-	public boolean isRequestedSessionIdFromCookie() {
-		
-		return false;
-	}
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+    	
+    	return false;
+    }
 
-	@Override
-	public boolean isRequestedSessionIdFromURL() {
-		
-		return false;
-	}
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+    	
+    	return false;
+    }
 
-	@Override
-	public boolean isRequestedSessionIdFromUrl() {
-		
-		return false;
-	}
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+    	
+    	return false;
+    }
 
     @Override
     public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/MockRequestBuilder.java
@@ -32,126 +32,126 @@ import static com.google.common.collect.Sets.newLinkedHashSet;
 
 public class MockRequestBuilder {
 
-	private final Mockery context;
-	private String url = "/";
-	private RequestMethod method = GET;
-	private String clientIp = "x.x.x.x";
-	private List<HttpHeader> individualHeaders = newArrayList();
-	private Map<String, Cookie> cookies = newHashMap();
-	private List<QueryParameter> queryParameters = newArrayList();
-	private String body = "";
-	private String bodyAsBase64 = "";
-	private Collection<Request.Part> multiparts = newArrayList();
+    private final Mockery context;
+    private String url = "/";
+    private RequestMethod method = GET;
+    private String clientIp = "x.x.x.x";
+    private List<HttpHeader> individualHeaders = newArrayList();
+    private Map<String, Cookie> cookies = newHashMap();
+    private List<QueryParameter> queryParameters = newArrayList();
+    private String body = "";
+    private String bodyAsBase64 = "";
+    private Collection<Request.Part> multiparts = newArrayList();
 
-	private boolean browserProxyRequest = false;
-	private String mockName;
+    private boolean browserProxyRequest = false;
+    private String mockName;
 
-	public MockRequestBuilder(Mockery context) {
-		this.context = context;
-	}
+    public MockRequestBuilder(Mockery context) {
+    	this.context = context;
+    }
 
-	public MockRequestBuilder(Mockery context, String mockName) {
-		this.mockName = mockName;
-		this.context = context;
-	}
+    public MockRequestBuilder(Mockery context, String mockName) {
+    	this.mockName = mockName;
+    	this.context = context;
+    }
 
-	public static MockRequestBuilder aRequest(Mockery context) {
-		return new MockRequestBuilder(context);
-	}
+    public static MockRequestBuilder aRequest(Mockery context) {
+    	return new MockRequestBuilder(context);
+    }
 
-	public static MockRequestBuilder aRequest(Mockery context, String mockName) {
-		return new MockRequestBuilder(context, mockName);
-	}
+    public static MockRequestBuilder aRequest(Mockery context, String mockName) {
+    	return new MockRequestBuilder(context, mockName);
+    }
 
-	public MockRequestBuilder withUrl(String url) {
-		this.url = url;
-		return this;
-	}
+    public MockRequestBuilder withUrl(String url) {
+    	this.url = url;
+    	return this;
+    }
 
-	public MockRequestBuilder withQueryParameter(String key, String... values) {
-		queryParameters.add(new QueryParameter(key, Arrays.asList(values)));
-		return this;
-	}
+    public MockRequestBuilder withQueryParameter(String key, String... values) {
+    	queryParameters.add(new QueryParameter(key, Arrays.asList(values)));
+    	return this;
+    }
 
-	public MockRequestBuilder withMethod(RequestMethod method) {
-		this.method = method;
-		return this;
-	}
+    public MockRequestBuilder withMethod(RequestMethod method) {
+    	this.method = method;
+    	return this;
+    }
 
-	public MockRequestBuilder withClientIp(String clientIp) {
-		this.clientIp = clientIp;
-		return this;
-	}
+    public MockRequestBuilder withClientIp(String clientIp) {
+    	this.clientIp = clientIp;
+    	return this;
+    }
 
-	public MockRequestBuilder withHeader(String key, String value) {
-		individualHeaders.add(new HttpHeader(key, value));
-		return this;
-	}
+    public MockRequestBuilder withHeader(String key, String value) {
+    	individualHeaders.add(new HttpHeader(key, value));
+    	return this;
+    }
 
-	public MockRequestBuilder withCookie(String key, String value) {
-		cookies.put(key, new Cookie(value));
-		return this;
-	}
+    public MockRequestBuilder withCookie(String key, String value) {
+    	cookies.put(key, new Cookie(value));
+    	return this;
+    }
 
-	public MockRequestBuilder withBody(String body) {
-		this.body = body;
-		return this;
-	}
+    public MockRequestBuilder withBody(String body) {
+    	this.body = body;
+    	return this;
+    }
 
-	public MockRequestBuilder withBodyAsBase64(String bodyAsBase64) {
-		this.bodyAsBase64 = bodyAsBase64;
-		return this;
-	}
+    public MockRequestBuilder withBodyAsBase64(String bodyAsBase64) {
+    	this.bodyAsBase64 = bodyAsBase64;
+    	return this;
+    }
 
-	public MockRequestBuilder asBrowserProxyRequest() {
-		this.browserProxyRequest = true;
-		return this;
-	}
+    public MockRequestBuilder asBrowserProxyRequest() {
+    	this.browserProxyRequest = true;
+    	return this;
+    }
 
-	public MockRequestBuilder withMultiparts(Collection<Request.Part> parts) {
-		this.multiparts = parts;
-		return this;
-	}
+    public MockRequestBuilder withMultiparts(Collection<Request.Part> parts) {
+    	this.multiparts = parts;
+    	return this;
+    }
 
-	public Request build() {
-		final HttpHeaders headers = new HttpHeaders(individualHeaders);
+    public Request build() {
+    	final HttpHeaders headers = new HttpHeaders(individualHeaders);
 
-		final Request request = mockName == null ? context.mock(Request.class) : context.mock(Request.class, mockName);
-		context.checking(new Expectations() {{
-			allowing(request).getUrl(); will(returnValue(url));
-			allowing(request).getMethod(); will(returnValue(method));
-			allowing(request).getClientIp(); will(returnValue(clientIp));
-			for (HttpHeader header: headers.all()) {
-				allowing(request).containsHeader(header.key()); will(returnValue(true));
-				allowing(request).getHeader(header.key()); will(returnValue(header.firstValue()));
-			}
+    	final Request request = mockName == null ? context.mock(Request.class) : context.mock(Request.class, mockName);
+    	context.checking(new Expectations() {{
+    		allowing(request).getUrl(); will(returnValue(url));
+    		allowing(request).getMethod(); will(returnValue(method));
+    		allowing(request).getClientIp(); will(returnValue(clientIp));
+    		for (HttpHeader header: headers.all()) {
+    			allowing(request).containsHeader(header.key()); will(returnValue(true));
+    			allowing(request).getHeader(header.key()); will(returnValue(header.firstValue()));
+    		}
 
-			for (HttpHeader header: headers.all()) {
-				allowing(request).header(header.key()); will(returnValue(header));
-				if (header.key().equals(ContentTypeHeader.KEY) && header.isPresent()) {
-					allowing(request).contentTypeHeader(); will(returnValue(new ContentTypeHeader(header.firstValue())));
-				}
-			}
+    		for (HttpHeader header: headers.all()) {
+    			allowing(request).header(header.key()); will(returnValue(header));
+    			if (header.key().equals(ContentTypeHeader.KEY) && header.isPresent()) {
+    				allowing(request).contentTypeHeader(); will(returnValue(new ContentTypeHeader(header.firstValue())));
+    			}
+    		}
 
-			for (QueryParameter queryParameter: queryParameters) {
-				allowing(request).queryParameter(queryParameter.key()); will(returnValue(queryParameter));
-			}
+    		for (QueryParameter queryParameter: queryParameters) {
+    			allowing(request).queryParameter(queryParameter.key()); will(returnValue(queryParameter));
+    		}
 
-			allowing(request).header(with(any(String.class))); will(returnValue(httpHeader("key", "value")));
+    		allowing(request).header(with(any(String.class))); will(returnValue(httpHeader("key", "value")));
 
-			allowing(request).getHeaders(); will(returnValue(headers));
-			allowing(request).getAllHeaderKeys(); will(returnValue(newLinkedHashSet(headers.keys())));
-			allowing(request).containsHeader(with(any(String.class))); will(returnValue(false));
-			allowing(request).getCookies(); will(returnValue(cookies));
-			allowing(request).getBody(); will(returnValue(body.getBytes()));
-			allowing(request).getBodyAsString(); will(returnValue(body));
-			allowing(request).getBodyAsBase64(); will(returnValue(bodyAsBase64));
-			allowing(request).getAbsoluteUrl(); will(returnValue("http://localhost:8080" + url));
-			allowing(request).isBrowserProxyRequest(); will(returnValue(browserProxyRequest));
-			allowing(request).isMultipart(); will(returnValue(multiparts != null && !multiparts.isEmpty()));
-			allowing(request).getParts(); will(returnValue(multiparts));
-		}});
+    		allowing(request).getHeaders(); will(returnValue(headers));
+    		allowing(request).getAllHeaderKeys(); will(returnValue(newLinkedHashSet(headers.keys())));
+    		allowing(request).containsHeader(with(any(String.class))); will(returnValue(false));
+    		allowing(request).getCookies(); will(returnValue(cookies));
+    		allowing(request).getBody(); will(returnValue(body.getBytes()));
+    		allowing(request).getBodyAsString(); will(returnValue(body));
+    		allowing(request).getBodyAsBase64(); will(returnValue(bodyAsBase64));
+    		allowing(request).getAbsoluteUrl(); will(returnValue("http://localhost:8080" + url));
+    		allowing(request).isBrowserProxyRequest(); will(returnValue(browserProxyRequest));
+    		allowing(request).isMultipart(); will(returnValue(multiparts != null && !multiparts.isEmpty()));
+    		allowing(request).getParts(); will(returnValue(multiparts));
+    	}});
 
-		return request;
-	}
+    	return request;
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/TestHttpHeader.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/TestHttpHeader.java
@@ -17,25 +17,25 @@ package com.github.tomakehurst.wiremock.testsupport;
 
 public class TestHttpHeader {
 
-	private String name;
-	private String value;
-	
-	public static TestHttpHeader withHeader(String name, String value) {
-		return new TestHttpHeader(name, value);
-	}
-	
-	public TestHttpHeader(String name, String value) {
-		this.name = name;
-		this.value = value;
-	}
+    private String name;
+    private String value;
+    
+    public static TestHttpHeader withHeader(String name, String value) {
+    	return new TestHttpHeader(name, value);
+    }
+    
+    public TestHttpHeader(String name, String value) {
+    	this.name = name;
+    	this.value = value;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+    	return name;
+    }
 
-	public String getValue() {
-		return value;
-	}
-	
-	
+    public String getValue() {
+    	return value;
+    }
+    
+    
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMatchers.java
@@ -54,50 +54,50 @@ import static java.util.Arrays.asList;
 
 public class WireMatchers {
 
-	public static Matcher<String> equalToJson(final String expectedJson) {
-		return new TypeSafeMatcher<String>() {
+    public static Matcher<String> equalToJson(final String expectedJson) {
+    	return new TypeSafeMatcher<String>() {
 
-			@Override
-			public void describeTo(Description desc) {
+    		@Override
+    		public void describeTo(Description desc) {
                 desc.appendText("Expected:\n" + expectedJson);
-			}
+    		}
 
-			@Override
-			public boolean matchesSafely(String actualJson) {
-				try {
-					JSONAssert.assertEquals(expectedJson, actualJson, JSONCompareMode.STRICT);
-					return true;
-				} catch (Throwable e) {
-					return false;
-				}
-			}
+    		@Override
+    		public boolean matchesSafely(String actualJson) {
+    			try {
+    				JSONAssert.assertEquals(expectedJson, actualJson, JSONCompareMode.STRICT);
+    				return true;
+    			} catch (Throwable e) {
+    				return false;
+    			}
+    		}
 
-		};
-	}
+    	};
+    }
 
-	public static Matcher<String> equalToJson(final String expectedJson, final JSONCompareMode jsonCompareMode) {
-		return new TypeSafeMatcher<String>() {
+    public static Matcher<String> equalToJson(final String expectedJson, final JSONCompareMode jsonCompareMode) {
+    	return new TypeSafeMatcher<String>() {
 
-			@Override
-			public void describeTo(Description desc) {
-				desc.appendText("Expected:\n" + expectedJson);
-			}
+    		@Override
+    		public void describeTo(Description desc) {
+    			desc.appendText("Expected:\n" + expectedJson);
+    		}
 
-			@Override
-			public boolean matchesSafely(String actualJson) {
-				try {
-					JSONAssert.assertEquals(expectedJson, actualJson, jsonCompareMode);
-					return true;
-				} catch (Throwable e) {
-					return false;
-				}
-			}
-			
-		};
-	}
+    		@Override
+    		public boolean matchesSafely(String actualJson) {
+    			try {
+    				JSONAssert.assertEquals(expectedJson, actualJson, jsonCompareMode);
+    				return true;
+    			} catch (Throwable e) {
+    				return false;
+    			}
+    		}
+    		
+    	};
+    }
 
-	public static Matcher<String> equalToXml(final String expected) {
-	    return new TypeSafeMatcher<String>() {
+    public static Matcher<String> equalToXml(final String expected) {
+        return new TypeSafeMatcher<String>() {
             @Override
             protected boolean matchesSafely(String value) {
                 Diff diff = DiffBuilder.compare(Input.from(expected))
@@ -135,59 +135,59 @@ public class WireMatchers {
     }
 
     public static <T> Matcher<Iterable<T>> hasExactly(final Matcher<T>... items) {
-    	return new TypeSafeMatcher<Iterable<T>>() {
+        return new TypeSafeMatcher<Iterable<T>>() {
 
-			@Override
-			public void describeTo(Description desc) {
-				desc.appendText("Collection must match exactly");
-			}
+    		@Override
+    		public void describeTo(Description desc) {
+    			desc.appendText("Collection must match exactly");
+    		}
 
-			@Override
-			public boolean matchesSafely(Iterable<T> actual) {
-				Iterator<T> actualIter = actual.iterator();
-				for (Matcher<T> matcher: items) {
-					if (!matcher.matches(actualIter.next())) {
-						return false;
-					}
-				}
-				
-				return !actualIter.hasNext();
-			}
-    		
-    	};
+    		@Override
+    		public boolean matchesSafely(Iterable<T> actual) {
+    			Iterator<T> actualIter = actual.iterator();
+    			for (Matcher<T> matcher: items) {
+    				if (!matcher.matches(actualIter.next())) {
+    					return false;
+    				}
+    			}
+    			
+    			return !actualIter.hasNext();
+    		}
+        	
+        };
     }
     
     public static <T> Matcher<Iterable<T>> hasExactlyIgnoringOrder(final Matcher<T>... items) {
-    	return new TypeSafeMatcher<Iterable<T>>() {
+        return new TypeSafeMatcher<Iterable<T>>() {
 
-			@Override
-			public void describeTo(Description desc) {
-				desc.appendText("Collection elements must match, but don't have to be in the same order.");
-			}
+    		@Override
+    		public void describeTo(Description desc) {
+    			desc.appendText("Collection elements must match, but don't have to be in the same order.");
+    		}
 
-			@Override
-			public boolean matchesSafely(Iterable<T> actual) {
-				if (size(actual) != items.length) {
-					return false;
-				}
-				
-				for (final Matcher<T> matcher: items) {
-					if (find(actual, isMatchFor(matcher), null) == null) {
-						return false;
-					}
-				}
-				
-				return true;
-			}
-    	};
+    		@Override
+    		public boolean matchesSafely(Iterable<T> actual) {
+    			if (size(actual) != items.length) {
+    				return false;
+    			}
+    			
+    			for (final Matcher<T> matcher: items) {
+    				if (find(actual, isMatchFor(matcher), null) == null) {
+    					return false;
+    				}
+    			}
+    			
+    			return true;
+    		}
+        };
     }
     
     private static <T> Predicate<T> isMatchFor(final Matcher<T> matcher) {
-    	return new Predicate<T>() {
-			public boolean apply(T input) {
-				return matcher.matches(input);
-			}
-		};
+        return new Predicate<T>() {
+    		public boolean apply(T input) {
+    			return matcher.matches(input);
+    		}
+    	};
     }
     
     public static Matcher<TextFile> fileNamed(final String name) {
@@ -312,7 +312,7 @@ public class WireMatchers {
     }
 
     private static String normaliseLineBreaks(String s) {
-	    return s.replace("\n", lineSeparator());
+        return s.replace("\n", lineSeparator());
     }
 
     private static String fileContents(File input) {

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockResponse.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockResponse.java
@@ -27,45 +27,45 @@ import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.collect.Iterables.getFirst;
 
 public class WireMockResponse {
-	
-	private final HttpResponse httpResponse;
-	private final byte[] content;
-	
-	public WireMockResponse(HttpResponse httpResponse) {
-		this.httpResponse = httpResponse;
-		content = getEntityAsByteArrayAndCloseStream(httpResponse);
-	}
+    
+    private final HttpResponse httpResponse;
+    private final byte[] content;
+    
+    public WireMockResponse(HttpResponse httpResponse) {
+    	this.httpResponse = httpResponse;
+    	content = getEntityAsByteArrayAndCloseStream(httpResponse);
+    }
 
-	public int statusCode() {
-		return httpResponse.getStatusLine().getStatusCode();
-	}
-	
-	public String content() {
+    public int statusCode() {
+    	return httpResponse.getStatusLine().getStatusCode();
+    }
+    
+    public String content() {
         if(content==null) {
             return null;
         }
-		return new String(content, Charset.forName(UTF_8.name()));
-	}
+    	return new String(content, Charset.forName(UTF_8.name()));
+    }
 
     public byte[] binaryContent() {
         return content;
     }
-	
-	public String firstHeader(String key) {
-		return getFirst(headers().get(key), null);
-	}
-	
-	public Multimap<String, String> headers() {
+    
+    public String firstHeader(String key) {
+    	return getFirst(headers().get(key), null);
+    }
+    
+    public Multimap<String, String> headers() {
         ImmutableListMultimap.Builder<String, String> builder = ImmutableListMultimap.builder();
 
-		for (Header header: httpResponse.getAllHeaders()) {
-			builder.put(header.getName(), header.getValue());
-		}
-		
-		return builder.build();
-	}
+    	for (Header header: httpResponse.getAllHeaders()) {
+    		builder.put(header.getName(), header.getValue());
+    	}
+    	
+    	return builder.build();
+    }
 
-	public String statusMessage() {
-		return httpResponse.getStatusLine().getReasonPhrase();
-	}
+    public String statusMessage() {
+    	return httpResponse.getStatusLine().getReasonPhrase();
+    }
 }


### PR DESCRIPTION
Indentation is inconsistent across the code base, which makes viewing code in github difficult.

I'm inferring that spaces are the preferred way given:
```bash
❯ git grep --files-with-matches "       " | grep java | wc -l # tabs
      76
❯ git grep --files-with-matches "    " | grep java | wc -l # spaces
     578
```

The transformation I ran was:
```
git ls-files | grep "\.java" | xargs perl -pi -e "s/\t/    /"
```

But I'm happy to do the opposite transformation!