### PR TITLE
Feature: Add --http-disabled flag

### DIFF
--- a/docs-v2/_docs/https.md
+++ b/docs-v2/_docs/https.md
@@ -43,6 +43,12 @@ The keystore type defaults to JKS, but this can be changed if you're using anoth
 .keystoreType("BKS")
 ```
 
+To allow only HTTPS requests, disable HTTP by adding:
+```java
+@Rule
+public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().httpsPort(8443).httpDisabled(true));
+```
+
 ## Requiring client certificates
 
 To make WireMock require clients to authenticate via a certificate you
@@ -66,7 +72,6 @@ specify a trust store containing the certificate(s).
 > Version 9.4.15.v20190215 of Jetty (used in the jre8 WireMock build) requires client certificates to contain Subject Alternative Names.
 > See [this script](https://github.com/tomakehurst/wiremock/blob/master/scripts/create-client-cert.sh) for an example of how to build
 > a truststore containing a valid certificate (you'll probably want to edit the client-cert.conf file before running this).
-
 
 ## Common HTTPS issues
 

--- a/docs-v2/_docs/running-standalone.md
+++ b/docs-v2/_docs/running-standalone.md
@@ -28,6 +28,8 @@ The following can optionally be specified on the command line:
 
 `--port`: Set the HTTP port number e.g. `--port 9999`. Use `--port 0` to dynamically determine a port.
 
+`--disable-http`: Disable the HTTP listener, option available only if HTTPS is enabled.
+
 `--https-port`: If specified, enables HTTPS on the supplied port.
 Note: When you specify this parameter, WireMock will still, additionally, bind to an HTTP port (8080 by default). So when running multiple WireMock servers you will also need to specify the `--port` parameter in order to avoid conflicts.
 

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -175,9 +175,16 @@ public class WireMockServer implements Container, Stubbing, Admin {
     }
 
     public int port() {
+        if (options.getHttpDisabled()) {
+            return httpsPort();
+        }
+        return httpPort();
+    }
+
+    private int httpPort() {
         checkState(
-                isRunning(),
-                "Not listening on HTTP port. The WireMock server is most likely stopped"
+                isRunning() && !options.getHttpDisabled(),
+                "Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is stopped."
         );
         return httpServer.port();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/WireMockServer.java
@@ -175,16 +175,9 @@ public class WireMockServer implements Container, Stubbing, Admin {
     }
 
     public int port() {
-        if (options.getHttpDisabled()) {
-            return httpsPort();
-        }
-        return httpPort();
-    }
-
-    private int httpPort() {
         checkState(
-                isRunning() && !options.getHttpDisabled(),
-                "Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is stopped."
+            isRunning() && !options.getHttpDisabled(),
+            "Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is stopped."
         );
         return httpServer.port();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -45,6 +45,7 @@ public interface Options {
     String DEFAULT_BIND_ADDRESS = "0.0.0.0";
 
     int portNumber();
+    boolean getHttpDisabled();
     HttpsSettings httpsSettings();
     JettySettings jettySettings();
     int containerThreads();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -50,6 +50,7 @@ import static java.util.Collections.emptyList;
 public class WireMockConfiguration implements Options {
 
     private int portNumber = DEFAULT_PORT;
+    private boolean httpDisabled = false;
     private String bindAddress = DEFAULT_BIND_ADDRESS;
 
     private int containerThreads = DEFAULT_CONTAINER_THREADS;
@@ -118,6 +119,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration dynamicPort() {
         this.portNumber = DYNAMIC_PORT;
+        return this;
+    }
+
+    public WireMockConfiguration httpDisabled(boolean httpDisabled) {
+        this.httpDisabled = httpDisabled;
         return this;
     }
 
@@ -346,6 +352,11 @@ public class WireMockConfiguration implements Options {
     @Override
     public int portNumber() {
         return portNumber;
+    }
+
+    @Override
+    public boolean getHttpDisabled() {
+        return httpDisabled;
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -71,13 +71,18 @@ public class JettyHttpServer implements HttpServer {
         jettyServer = createServer(options);
 
         NetworkTrafficListenerAdapter networkTrafficListenerAdapter = new NetworkTrafficListenerAdapter(options.networkTrafficListener());
-        httpConnector = createHttpConnector(
-                options.bindAddress(),
-                options.portNumber(),
-                options.jettySettings(),
-                networkTrafficListenerAdapter
-        );
-        jettyServer.addConnector(httpConnector);
+
+        if (options.getHttpDisabled()) {
+            httpConnector = null;
+        } else {
+            httpConnector = createHttpConnector(
+                    options.bindAddress(),
+                    options.portNumber(),
+                    options.jettySettings(),
+                    networkTrafficListenerAdapter
+            );
+            jettyServer.addConnector(httpConnector);
+        }
 
         if (options.httpsSettings().enabled()) {
             httpsConnector = createHttpsConnector(

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -53,6 +53,11 @@ public class WarConfiguration implements Options {
     }
 
     @Override
+    public boolean getHttpDisabled() {
+        return false;
+    }
+
+    @Override
     public HttpsSettings httpsSettings() {
         return new HttpsSettings.Builder().build();
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -62,7 +62,8 @@ public class CommandLineOptions implements Options {
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PRESERVE_HOST_HEADER = "preserve-host-header";
     private static final String PROXY_VIA = "proxy-via";
-	private static final String PORT = "port";
+    private static final String PORT = "port";
+    private static final String DISABLE_HTTP = "disable-http";
     private static final String BIND_ADDRESS = "bind-address";
     private static final String HTTPS_PORT = "https-port";
     private static final String HTTPS_KEYSTORE = "https-keystore";
@@ -104,8 +105,9 @@ public class CommandLineOptions implements Options {
     private Optional<Integer> resultingPort;
 
     public CommandLineOptions(String... args) {
-		OptionParser optionParser = new OptionParser();
-		optionParser.accepts(PORT, "The port number for the server to listen on (default: 8080). 0 for dynamic port selection.").withRequiredArg();
+        OptionParser optionParser = new OptionParser();
+        optionParser.accepts(PORT, "The port number for the server to listen on (default: 8080). 0 for dynamic port selection.").withRequiredArg();
+        optionParser.accepts(DISABLE_HTTP, "Disable the default HTTP listener.");
         optionParser.accepts(HTTPS_PORT, "If this option is present WireMock will enable HTTPS on the specified port").withRequiredArg();
         optionParser.accepts(BIND_ADDRESS, "The IP to listen connections").withRequiredArg();
         optionParser.accepts(CONTAINER_THREADS, "The number of container threads").withRequiredArg();
@@ -156,6 +158,12 @@ public class CommandLineOptions implements Options {
 	}
 
     private void validate() {
+        if (optionSet.has(PORT) && optionSet.has(DISABLE_HTTP)) {
+            throw new IllegalArgumentException("The HTTP listener can't have a port set and disable at the same time");
+        }
+        if (!optionSet.has(HTTPS_PORT) && optionSet.has(DISABLE_HTTP)) {
+            throw new IllegalArgumentException("HTTPS must be enabled if HTTP is not.");
+        }
         if (optionSet.has(HTTPS_KEYSTORE) && !optionSet.has(HTTPS_PORT)) {
             throw new IllegalArgumentException("HTTPS port number must be specified if specifying the keystore path");
         }
@@ -227,6 +235,11 @@ public class CommandLineOptions implements Options {
 
         return DEFAULT_PORT;
 	}
+
+    @Override
+    public boolean getHttpDisabled() {
+        return optionSet.has(DISABLE_HTTP);
+    }
 
 	public void setResultingPort(int port) {
 		resultingPort = Optional.of(port);
@@ -410,7 +423,7 @@ public class CommandLineOptions implements Options {
     public boolean requestJournalDisabled() {
         return optionSet.has(DISABLE_REQUEST_JOURNAL);
     }
-    
+
     public boolean bannerDisabled() {
         return optionSet.has(DISABLE_BANNER);
     }
@@ -456,7 +469,7 @@ public class CommandLineOptions implements Options {
         }
 
         builder.put(ENABLE_BROWSER_PROXYING, browserProxyingEnabled());
-        
+
         builder.put(DISABLE_BANNER, bannerDisabled());
 
         if (recordMappingsEnabled()) {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -159,7 +159,7 @@ public class CommandLineOptions implements Options {
 
     private void validate() {
         if (optionSet.has(PORT) && optionSet.has(DISABLE_HTTP)) {
-            throw new IllegalArgumentException("The HTTP listener can't have a port set and disable at the same time");
+            throw new IllegalArgumentException("The HTTP listener can't have a port set and be disabled at the same time");
         }
         if (!optionSet.has(HTTPS_PORT) && optionSet.has(DISABLE_HTTP)) {
             throw new IllegalArgumentException("HTTPS must be enabled if HTTP is not.");

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
@@ -92,7 +92,7 @@ public class HttpsAcceptanceTest {
     }
 
     @Test
-    public void connectionFailsOnHttpWhenHttpDisabled() throws Exception {
+    public void shouldReturnOnlyOnHttpsWhenHttpDisabled() throws Exception {
         // HTTP
         exceptionRule.expect(IllegalStateException.class);
         exceptionRule.expectMessage("Not listening on HTTP port. Either HTTP is not enabled or the WireMock server is stopped.");

--- a/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/HttpsAcceptanceTest.java
@@ -20,7 +20,6 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.http.HttpClientFactory;
-import com.github.tomakehurst.wiremock.testsupport.TestFiles;
 import com.google.common.io.Resources;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.http.HttpResponse;
@@ -59,11 +58,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static com.github.tomakehurst.wiremock.testsupport.TestFiles.*;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeTrue;
 
 public class HttpsAcceptanceTest {
 
@@ -85,6 +81,19 @@ public class HttpsAcceptanceTest {
     @Test
     public void shouldReturnStubOnSpecifiedPort() throws Exception {
         startServerWithDefaultKeystore();
+        stubFor(get(urlEqualTo("/https-test")).willReturn(aResponse().withStatus(200).withBody("HTTPS content")));
+
+        assertThat(contentFor(url("/https-test")), is("HTTPS content"));
+    }
+
+    @Test
+    public void shouldReturnStubOnHttpsWhenHttpDisabled() throws Exception {
+        WireMockConfiguration config = wireMockConfig().httpDisabled(true).dynamicHttpsPort();
+        wireMockServer = new WireMockServer(config);
+        wireMockServer.start();
+        WireMock.configureFor("https", "localhost", wireMockServer.port());
+        httpClient = HttpClientFactory.createClient();
+
         stubFor(get(urlEqualTo("/https-test")).willReturn(aResponse().withStatus(200).withBody("HTTPS content")));
 
         assertThat(contentFor(url("/https-test")), is("HTTPS content"));

--- a/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServerTest.java
@@ -27,15 +27,18 @@ import com.github.tomakehurst.wiremock.http.ResponseRenderer;
 import com.github.tomakehurst.wiremock.http.StubRequestHandler;
 import com.github.tomakehurst.wiremock.security.NoAuthenticator;
 import com.github.tomakehurst.wiremock.verification.RequestJournal;
+import org.eclipse.jetty.server.ServerConnector;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JMock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Field;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 @RunWith(JMock.class)
@@ -82,5 +85,18 @@ public class JettyHttpServerTest {
         JettyHttpServer jettyHttpServer = (JettyHttpServer) serverFactory.buildHttpServer(config, adminRequestHandler, stubRequestHandler);
 
         assertThat(jettyHttpServer.stopTimeout(), is(expectedStopTimeout));
+    }
+
+    @Test
+    public void testHttpConnectorIsNullWhenHttpDisabled() throws NoSuchFieldException, IllegalAccessException {
+        WireMockConfiguration config = WireMockConfiguration.wireMockConfig().httpDisabled(true);
+
+        JettyHttpServer jettyHttpServer = (JettyHttpServer) serverFactory.buildHttpServer(config, adminRequestHandler, stubRequestHandler);
+
+        Field httpConnectorField = JettyHttpServer.class.getDeclaredField("httpConnector");
+        httpConnectorField.setAccessible(true);
+        ServerConnector httpConnector = (ServerConnector) httpConnectorField.get(jettyHttpServer);
+
+       assertNull(httpConnector);
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -80,6 +80,13 @@ public class CommandLineOptionsTest {
     }
 
     @Test
+    public void disablesHttpWhenOptionPresentAndHttpsEnabled() {
+        CommandLineOptions options = new CommandLineOptions("--disable-http",
+                "--https-port", "8443");
+        assertThat(options.getHttpDisabled(), is(true));
+    }
+
+    @Test
     public void enablesHttpsAndSetsPortNumberWhenOptionPresent() {
         CommandLineOptions options = new CommandLineOptions("--https-port", "8443");
         assertThat(options.httpsSettings().enabled(), is(true));

--- a/src/test/java/ignored/Examples.java
+++ b/src/test/java/ignored/Examples.java
@@ -374,6 +374,9 @@ public class Examples extends AcceptanceTestBase {
             // Statically set the HTTP port number. Defaults to 8080.
             .port(8000)
 
+            // Disable HTTP listener.
+            .httpDisabled(true)
+
             // Statically set the HTTPS port number. Defaults to 8443.
             .httpsPort(8001)
 


### PR DESCRIPTION
**Context:**
By default, Wiremock has always an HTTP listener started on 8080 if the flag `port` is not set even if you are setting an HTTPS listener.

**Goal:**
Adding a flag `--http-disabled` allowing the Wiremock server to be reached only from HTTPS.