### PR TITLE
Upgrade to Jackson 2.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,16 +40,16 @@ allprojects {
             handlebars     : '4.0.7',
             jetty          : '9.2.28.v20190418', // Please don't raise PRs upgrading this to the latest version as it drops Java 7 support. See https://github.com/tomakehurst/wiremock/issues/407 and https://github.com/tomakehurst/wiremock/pull/887 for details
             guava          : '20.0',
-            jackson        : '2.9.10',
-            jacksonDatabind: '2.9.10',
+            jackson        : '2.10.0',
+            jacksonDatabind: '2.10.0',
             xmlUnit        : '2.6.2'
         ],
         java8: [
             handlebars     : '4.1.2',
             jetty          : '9.4.20.v20190813',
             guava          : '27.0.1-jre',
-            jackson        : '2.9.10',
-            jacksonDatabind: '2.9.10',
+            jackson        : '2.10.0',
+            jacksonDatabind: '2.10.0',
             xmlUnit        : '2.6.2'
         ]
     ]

--- a/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/Json.java
@@ -53,10 +53,8 @@ public final class Json {
 			return mapper.readValue(json, clazz);
 		} catch (JsonProcessingException processingException) {
             throw JsonException.fromJackson(processingException);
-        } catch (IOException ioe) {
-			return throwUnchecked(ioe, clazz);
-		}
-	}
+        }
+    }
 
 	public static <T> T read(String json, TypeReference<T> typeRef) {
         try {
@@ -64,10 +62,8 @@ public final class Json {
             return mapper.readValue(json, typeRef);
         } catch (JsonProcessingException processingException) {
             throw JsonException.fromJackson(processingException);
-        } catch (IOException ioe) {
-            return throwUnchecked(ioe, (Class<T>) typeRef.getType());
         }
-    }
+  }
 
     public static <T> String write(T object) {
 	    return write(object, PublicView.class);

--- a/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/AdminApiTest.java
@@ -546,7 +546,7 @@ public class AdminApiTest extends AcceptanceTestBase {
         Errors errors = Json.read(response.content(), Errors.class);
         assertThat(errors.first().getSource().getPointer(), is("/request/bodyPatterns/0"));
         assertThat(errors.first().getDetail(), allOf(
-                containsString("Unexpected character ('(' (code 40)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')"),
+                containsString("Unexpected character ('(' (code 40)): expected a valid value (JSON String, Number, Array, Object or token 'null', 'true' or 'false')"),
                 containsString("line: 1, column: 2"))
         );
     }


### PR DESCRIPTION
Changes in _Json.java_ are due to: https://github.com/FasterXML/jackson-databind/issues/1675
Changes in _AdminApiTest.java_ are due to: https://github.com/FasterXML/jackson-core/blob/master/src/main/java/com/fasterxml/jackson/core/json/JsonParserBase.java#L110