### PR TITLE
Use daemon threads for async response handlers (fixes #1206)

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHandlerDispatchingServlet.java
@@ -40,7 +40,6 @@ import static com.github.tomakehurst.wiremock.servlet.WireMockHttpServletRequest
 import static com.google.common.base.Charsets.UTF_8;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.URLDecoder.decode;
-import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class WireMockHandlerDispatchingServlet extends HttpServlet {


### PR DESCRIPTION
See #1206 for how to reproduce.

NOTE: This only seems to help for JDK7 build, the JDK8 build has problems even without `--async-response-enabled=true`, leaving alot of `qtp1234NNN` threads behind. Looks like some general Jetty issue (https://stackoverflow.com/questions/18521183/jetty-9-hangs-queuedthreadpool-growing-large)