### PR TITLE
Added unauthorizedJson method to support json body

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/WireMock.java
@@ -493,6 +493,10 @@ public class WireMock {
         return aResponse().withStatus(401);
     }
 
+    public static ResponseDefinitionBuilder unauthorizedJson(String body) {
+	    return aResponse().withStatus(401).withHeader(CONTENT_TYPE, "application/json").withBody(body);
+    }
+
     public static ResponseDefinitionBuilder forbidden() {
         return aResponse().withStatus(403);
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/recording/SnapshotStubMappingBodyExtractorTest.java
@@ -25,8 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -103,4 +102,15 @@ public class SnapshotStubMappingBodyExtractorTest {
             );
         }});
     }
+
+    @Test
+    public void determinesFileNamePropertyWithNamedStubMappingForUnauthorized() {
+        StubMapping stubMapping = WireMock.get("/foo")
+                .willReturn(unauthorizedJson("{}"))
+                .build();
+        stubMapping.setName("TEST NAME!");
+        setFileExpectations("test-name-" + stubMapping.getId() + ".json", "{}");
+        bodyExtractor.extractInPlace(stubMapping);
+    }
+
 }


### PR DESCRIPTION
In some cases we get JSON content in return for unauthorized status code which clients might want to parse, so added unauthorizedJson method which returns 401 status code with specified body in response with application/json content type.