### PR TITLE
Exclude transitive jackson dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,10 @@ allprojects {
             exclude group: "org.hamcrest", module: "hamcrest-core"
         }
         compile 'org.apache.commons:commons-lang3:3.7'
-        compile 'com.flipkart.zjsonpatch:zjsonpatch:0.4.4'
+        compile 'com.flipkart.zjsonpatch:zjsonpatch:0.4.4', {
+            exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+            exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        }
         compile "com.github.jknack:handlebars:$versions.handlebars", {
             exclude group: 'org.mozilla', module: 'rhino'
         }


### PR DESCRIPTION
`zjsonpatch` adds older `jackson` dependencies than the ones that are already being added by wiremock itself.