### PR TITLE
Docs: Fix handlebar syntax in formData example

### DIFF
--- a/docs-v2/_docs/response-templating.md
+++ b/docs-v2/_docs/response-templating.md
@@ -425,7 +425,7 @@ indicating that values should be URL decoded. The folowing example will parse th
 
 {% raw %}
 ```
-{{formData request.body 'form' urlDecode=true}}}{{{form.formField3}}
+{{formData request.body 'form' urlDecode=true}}{{form.formField3}}
 ```
 {% endraw %}
 
@@ -433,8 +433,8 @@ If the form submitted has multiple values for a given field, these can be access
 
 {% raw %}
 ```
-{{formData request.body 'form' urlDecode=true}}}{{{form.multiValueField.1}}, {{{form.multiValueField.2}}
-{{formData request.body 'form' urlDecode=true}}}{{{form.multiValueField.first}}, {{{form.multiValueField.last}}
+{{formData request.body 'form' urlDecode=true}}{{form.multiValueField.1}}, {{form.multiValueField.2}}
+{{formData request.body 'form' urlDecode=true}}{{form.multiValueField.first}}, {{form.multiValueField.last}}
 ```
 {% endraw %}
 


### PR DESCRIPTION
The handlebars in the example does not line up - I guess you could use two or three curly brackets as long as they match. I got it working with the changes I made.
