### PR TITLE
Use HTTPS for Maven central links in documentation

### DIFF
--- a/docs-v2/_docs/download-and-installation.md
+++ b/docs-v2/_docs/download-and-installation.md
@@ -93,4 +93,4 @@ testCompile "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wiremock_ve
 ## Direct download
 
 If you want to run WireMock as a standalone process you can [download the standalone JAR from
-here](http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/{{ site.wiremock_version }}/wiremock-standalone-{{ site.wiremock_version }}.jar).
+here](https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/{{ site.wiremock_version }}/wiremock-standalone-{{ site.wiremock_version }}.jar).

--- a/docs-v2/_docs/getting-started.md
+++ b/docs-v2/_docs/getting-started.md
@@ -152,7 +152,7 @@ the Java API, JSON over HTTP or JSON files.
 This will start the server on port 8080:
 
 You can [download the standalone JAR from
-here](http://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/{{ site.wiremock_version }}/wiremock-standalone-{{ site.wiremock_version }}.jar).
+here](https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/{{ site.wiremock_version }}/wiremock-standalone-{{ site.wiremock_version }}.jar).
 
 See [Running as a Standalone Process](/docs/running-standalone/) running-standalone for more details and commandline options.
 


### PR DESCRIPTION
Maven central recently moved to HTTPS only, the links were returning a 501 error.