### PR TITLE
Make response template caching works

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/HttpHeaders.java
@@ -124,9 +124,7 @@ public class HttpHeaders {
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (headers != null ? headers.hashCode() : 0);
-        return result;
+        return headers != null ? headers.hashCode() : 0;
     }
 
     @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/HttpHeadersTest.java
@@ -146,4 +146,17 @@ public class HttpHeadersTest {
         HttpHeaders httpHeaders = new HttpHeaders();
         assertThat(httpHeaders.toString().equals("(no headers)\n"), is(true));
     }
+    
+    @Test
+    public void shouldEqualWhenIdentical() throws Exception {
+        HttpHeaders httpHeaders = new HttpHeaders(
+                httpHeader("Header-1", "h1v1", "h1v2"),
+                httpHeader("Header-2", "h2v1", "h2v2"));
+
+        HttpHeaders copyOfHeaders = HttpHeaders.copyOf(httpHeaders);
+
+        assertThat(httpHeaders.equals(copyOfHeaders), is(true));
+        assertThat(httpHeaders.hashCode(), equalTo(copyOfHeaders.hashCode()));
+    }
+
 }


### PR DESCRIPTION
Actually, cache doesn't work because of incorrect HttpHeaders.hashCode() implementation.
This pull request fix this bug 😃