### PR TITLE
Update correctly tostring http and https port values

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -102,7 +102,6 @@ public class CommandLineOptions implements Options {
     private final MappingsSource mappingsSource;
 
     private String helpText;
-    private Optional<Integer> resultingPort;
 
     public CommandLineOptions(String... args) {
         OptionParser optionParser = new OptionParser();
@@ -153,8 +152,6 @@ public class CommandLineOptions implements Options {
 
         fileSource = new SingleRootFileSource((String) optionSet.valueOf(ROOT_DIR));
         mappingsSource = new JsonFileMappingsSource(fileSource.child(MAPPINGS_ROOT));
-
-        resultingPort = Optional.absent();
 	}
 
     private void validate() {
@@ -241,15 +238,11 @@ public class CommandLineOptions implements Options {
         return optionSet.has(DISABLE_HTTP);
     }
 
-	public void setResultingPort(int port) {
-		resultingPort = Optional.of(port);
-	}
-
     @Override
     public String bindAddress(){
-	if (optionSet.has(BIND_ADDRESS)) {
-            return (String) optionSet.valueOf(BIND_ADDRESS);
-        }
+      if (optionSet.has(BIND_ADDRESS)) {
+        return (String) optionSet.valueOf(BIND_ADDRESS);
+      }
 
         return DEFAULT_BIND_ADDRESS;
     }
@@ -452,8 +445,9 @@ public class CommandLineOptions implements Options {
     @Override
     public String toString() {
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
-        int port = resultingPort.isPresent() ? resultingPort.get() : portNumber();
-        builder.put(PORT, port);
+        if (!getHttpDisabled()) {
+          builder.put(PORT, portNumber());
+        }
 
         if (httpsSettings().enabled()) {
             builder.put(HTTPS_PORT, nullToString(httpsSettings().port()))

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -74,8 +74,6 @@ public class WireMockServerRunner {
 
         try {
             wireMockServer.start();
-            boolean https = options.httpsSettings().enabled();
-            options.setResultingPort(https ? wireMockServer.httpsPort() : wireMockServer.port());
             if (!options.bannerDisabled()){
                 out.println(BANNER);
                 out.println();

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -402,15 +402,6 @@ public class CommandLineOptionsTest {
     }
 
     @Test
-    public void usesPortInToString() {
-        CommandLineOptions options = new CommandLineOptions("--port", "1337");
-        assertThat(options.toString(), allOf(containsString("1337")));
-
-        options.setResultingPort(1338);
-        assertThat(options.toString(), allOf(containsString("1338")));
-    }
-
-    @Test
     public void configuresMaxTemplateCacheEntriesIfSpecified() {
         CommandLineOptions options = new CommandLineOptions("--global-response-templating", "--max-template-cache-entries", "5");
         Map<String, ResponseTemplateTransformer> extensions = options.extensionsOfType(ResponseTemplateTransformer.class);


### PR DESCRIPTION
I would need your opinion on this one @tomakehurst - it looks this `resultingPort` was only used to set and update the `http-port` value in the `toString` method and test it.

`resultingPort` has now to return the HTTP or HTTPS port based on command line arguments passed and can't be used directly in the `toString`