### PR TITLE
Allow keystore url to be null

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -56,7 +56,7 @@ public class WireMockConfiguration implements Options {
     private int containerThreads = DEFAULT_CONTAINER_THREADS;
 
     private int httpsPort = -1;
-    private String keyStorePath = Resources.getResource("keystore").toString();
+    private String keyStorePath = getResource("keystore");
     private String keyStorePassword = "password";
     private String keyStoreType = "JKS";
     private String trustStorePath;
@@ -103,6 +103,17 @@ public class WireMockConfiguration implements Options {
         }
 
         return mappingsSource;
+    }
+    
+    private static String getResource(final String resource)
+    {
+    	try
+    	{
+    		return Resources.getResource(resource).toString();
+    	}
+    	catch (IllegalArgumentException e) {
+			return null;
+		}
     }
 
     public static WireMockConfiguration wireMockConfig() {


### PR DESCRIPTION
We don't really care about the keystore path so it can be null. I assume this is what happens in most runtimes but we are running wiremock in an OSGi environment and this will throw an IllegalArgumentException because the guava bundle does not contain a resource keystore.
Because the getResource call is done inline it also becomes very hard to work around this.
The only work around atm is to copy the class and tweak in in our codebase but we rather not do that.