### PR TITLE
Add request details to VerificationException

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/VerificationException.java
@@ -89,7 +89,8 @@ public class VerificationException extends AssertionError {
 
     public static VerificationException forUnmatchedRequests(List<LoggedRequest> unmatchedRequests) {
         if (unmatchedRequests.size() == 1) {
-            return new VerificationException(String.format("A request was unmatched by any stub mapping. Request was: ",
+            return new VerificationException(String.format("A request was unmatched by any stub "
+                    + "mapping. Request was: %s",
                     unmatchedRequests.get(0)));
         }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/junit/WireMockRuleFailOnUnmatchedRequestsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/junit/WireMockRuleFailOnUnmatchedRequestsTest.java
@@ -64,7 +64,6 @@ public class WireMockRuleFailOnUnmatchedRequestsTest {
         client = new WireMockTestClient(wm.port());
     }
 
-
     @Test
     public void singleUnmatchedRequestShouldThrowVerificationException() {
         expectedException.expect(VerificationException.class);
@@ -104,6 +103,10 @@ public class WireMockRuleFailOnUnmatchedRequestsTest {
     public void unmatchedRequestWithoutStubShouldThrowVerificationException() {
         expectedException.expect(VerificationException.class);
         expectedException.expectMessage(containsString("A request was unmatched by any stub mapping."));
+
+        // Check that url details are part of the output error
+        expectedException.expectMessage(containsString("\"url\" : \"/miss\""));
+
         client.get("/miss");
     }
 


### PR DESCRIPTION
The intent behind the exception message is that request must be printed but it was not being done due to the lack of formatter in `String.format`, this PR fixes that issue and modifies the tests to assert the same.