### PR TITLE
Allow pass through forward proxying of HTTPS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ allprojects {
         compile "org.eclipse.jetty:jetty-servlet:$versions.jetty"
         compile "org.eclipse.jetty:jetty-servlets:$versions.jetty"
         compile "org.eclipse.jetty:jetty-webapp:$versions.jetty"
+        compile "org.eclipse.jetty:jetty-proxy:$versions.jetty"
         compile "com.google.guava:guava:$versions.guava"
         compile "com.fasterxml.jackson.core:jackson-core:$versions.jackson",
             "com.fasterxml.jackson.core:jackson-annotations:$versions.jackson",

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -30,6 +30,7 @@ import com.google.common.io.Resources;
 import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.NetworkTrafficListener;
+import org.eclipse.jetty.proxy.ConnectHandler;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
@@ -127,6 +128,8 @@ public class JettyHttpServer implements HttpServer {
         } else {
             addGZipHandler(mockServiceContext, handlers);
         }
+
+        handlers.addHandler(new ConnectHandler());
 
         return handlers;
     }

--- a/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
@@ -62,7 +62,7 @@ public class BrowserProxyAcceptanceTest {
         assertThat(testClient.getViaProxy(url("/whatever"), proxy.port()).content(), is("Got it"));
     }
 
-    @Test @Ignore
+    @Test
     public void canProxyHttps() throws Exception {
         target.stubFor(get(urlEqualTo("/whatever")).willReturn(aResponse().withBody("Got it")));
 

--- a/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/BrowserProxyAcceptanceTest.java
@@ -27,7 +27,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class BrowserProxyAcceptanceTest {
 
     @ClassRule
-    public static WireMockClassRule target = new WireMockClassRule(wireMockConfig().dynamicPort());
+    public static WireMockClassRule target = new WireMockClassRule(wireMockConfig()
+            .dynamicPort()
+            .dynamicHttpsPort()
+    );
 
     @Rule
     public WireMockClassRule instanceRule = target;
@@ -59,6 +62,13 @@ public class BrowserProxyAcceptanceTest {
         assertThat(testClient.getViaProxy(url("/whatever"), proxy.port()).content(), is("Got it"));
     }
 
+    @Test @Ignore
+    public void canProxyHttps() throws Exception {
+        target.stubFor(get(urlEqualTo("/whatever")).willReturn(aResponse().withBody("Got it")));
+
+        assertThat(testClient.getViaProxy(httpsUrl("/whatever"), proxy.port()).content(), is("Got it"));
+    }
+
     @Test
     public void passesQueryParameters() {
         target.stubFor(get(urlEqualTo("/search?q=things&limit=10")).willReturn(aResponse().withStatus(200)));
@@ -68,6 +78,10 @@ public class BrowserProxyAcceptanceTest {
 
     private String url(String pathAndQuery) {
         return "http://localhost:" + target.port() + pathAndQuery;
+    }
+
+    private String httpsUrl(String pathAndQuery) {
+        return "https://localhost:" + target.httpsPort() + pathAndQuery;
     }
 
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/testsupport/WireMockTestClient.java
@@ -102,7 +102,7 @@ public class WireMockTestClient {
 
     public WireMockResponse getViaProxy(String url, int proxyPort) {
         URI targetUri = URI.create(url);
-        HttpHost proxy = new HttpHost(address, proxyPort, targetUri.getScheme());
+        HttpHost proxy = new HttpHost(address, proxyPort);
         HttpClient httpClientUsingProxy = HttpClientBuilder.create()
             .disableAuthCaching()
             .disableAutomaticRetries()


### PR DESCRIPTION
This allows WireMock to act as a forward (browser) proxy for HTTPS as well as
HTTP origins.

At present it is a pure HTTP tunnel, so stubbing & recording are not supported
and the client will get the precise byte stream (including TLS certificate)
from the endpoint.

First step towards implementing #401.