### PR TITLE
Response Templating: Case-Insensitive Headers

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/RequestTemplateModel.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.http.Request;
 import com.google.common.base.Function;
 import com.google.common.collect.Maps;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class RequestTemplateModel {
 
@@ -40,12 +41,13 @@ public class RequestTemplateModel {
 
     public static RequestTemplateModel from(final Request request) {
         RequestLine requestLine = RequestLine.fromRequest(request);
-        Map<String, ListOrSingle<String>> adaptedHeaders = Maps.toMap(request.getAllHeaderKeys(), new Function<String, ListOrSingle<String>>() {
+        Map<String, ListOrSingle<String>> adaptedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        adaptedHeaders.putAll(Maps.toMap(request.getAllHeaderKeys(), new Function<String, ListOrSingle<String>>() {
             @Override
             public ListOrSingle<String> apply(String input) {
                 return ListOrSingle.of(request.header(input).values());
             }
-        });
+        }));
         Map<String, ListOrSingle<String>> adaptedCookies = Maps.transformValues(request.getCookies(), new Function<Cookie, ListOrSingle<String>>() {
             @Override
             public ListOrSingle<String> apply(Cookie cookie) {

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,6 +87,21 @@ public class ResponseTemplateTransformerTest {
 
         assertThat(transformedResponseDef.getBody(), is(
             "Request ID: req-id-1234, Awkward named header: foundit"
+        ));
+    }
+
+    @Test
+    public void requestHeadersCaseInsensitive() {
+        ResponseDefinition transformedResponseDef = transform(mockRequest()
+                .url("/things")
+                .header("Case-KEY-123", "foundit"),
+            aResponse().withBody(
+                "Case key header: {{request.headers.case-key-123}}, With brackets: {{request.headers.[case-key-123]}}"
+            )
+        );
+
+        assertThat(transformedResponseDef.getBody(), CoreMatchers.is(
+            "Case key header: foundit, With brackets: foundit"
         ));
     }
 


### PR DESCRIPTION
This changes adaptedHeaders in `RequestTemplateModel.from(..)` to TreeMap with CASE_INSENSITIVE_ORDER to ignore case for headers in response templating.

E.g. allows that `{{request.headers.X-CorrelationID}}` also matches `x-correlationid`.

Resolves issue https://github.com/tomakehurst/wiremock/issues/1313
