### PR TITLE
Validate certs by default on forward proxy

### DIFF
--- a/docs-v2/_docs/proxying.md
+++ b/docs-v2/_docs/proxying.md
@@ -132,6 +132,11 @@ stubFor(get(urlEqualTo("/users/12345.json"))
   .withStatus(503)));
 ```
 
+wiremock-jre8 allows forward proxying, stubbing & recording of HTTPS traffic. By default, this will verify the origin certificates; this behaviour can be turned to trusting all as follows:
+```bash
+$ java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar --enable-browser-proxying --trust-all
+```
+
 ## Proxying via another proxy server
 
 If you're inside a network that only permits HTTP traffic out to the

--- a/docs-v2/_docs/proxying.md
+++ b/docs-v2/_docs/proxying.md
@@ -134,7 +134,7 @@ stubFor(get(urlEqualTo("/users/12345.json"))
 
 wiremock-jre8 allows forward proxying, stubbing & recording of HTTPS traffic. By default, this will verify the origin certificates; this behaviour can be turned to trusting all as follows:
 ```bash
-$ java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar --enable-browser-proxying --trust-all
+$ java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar --enable-browser-proxying --trust-all-proxy-targets
 ```
 
 ## Proxying via another proxy server

--- a/docs-v2/_docs/running-standalone.md
+++ b/docs-v2/_docs/running-standalone.md
@@ -86,6 +86,9 @@ e.g. `--proxy-via http://username:password@webproxy.mycorp.com:8080/`.
 `--enable-browser-proxying`: Run as a browser proxy. See
 browser-proxying.
 
+`--trust-all`: Trust all remote certificates when running as a browser proxy and
+proxying HTTPS traffic.
+
 `--no-request-journal`: Disable the request journal, which records
 incoming requests for later verification. This allows WireMock to be run
 (and serve stubs) for long periods (without resetting) without

--- a/docs-v2/_docs/running-standalone.md
+++ b/docs-v2/_docs/running-standalone.md
@@ -86,7 +86,7 @@ e.g. `--proxy-via http://username:password@webproxy.mycorp.com:8080/`.
 `--enable-browser-proxying`: Run as a browser proxy. See
 browser-proxying.
 
-`--trust-all`: Trust all remote certificates when running as a browser proxy and
+`--trust-all-proxy-targets`: Trust all remote certificates when running as a browser proxy and
 proxying HTTPS traffic.
 
 `--no-request-journal`: Disable the request journal, which records

--- a/java8/build.gradle
+++ b/java8/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile "org.eclipse.jetty:jetty-alpn-server:$jettyVersion"
     compile "org.eclipse.jetty:jetty-alpn-conscrypt-server:$jettyVersion"
     compile "org.eclipse.jetty:jetty-alpn-conscrypt-client:$jettyVersion"
+    compile 'org.conscrypt:conscrypt-openjdk-uber:2.4.0'
     compile 'net.javacrumbs.json-unit:json-unit-core:2.12.0'
 
     testCompile "org.eclipse.jetty:jetty-client:$jettyVersion"

--- a/java8/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
+++ b/java8/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
@@ -69,7 +69,7 @@ public class HttpsBrowserProxyAcceptanceTest {
                 .dynamicHttpsPort()
                 .fileSource(new SingleRootFileSource(setupTempFileRoot()))
                 .enableBrowserProxying(true)
-                .trustAll(true)
+                .trustAllProxyTargets(true)
         );
         proxy.start();
     }

--- a/java8/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
+++ b/java8/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
@@ -68,7 +68,9 @@ public class HttpsBrowserProxyAcceptanceTest {
                 .dynamicPort()
                 .dynamicHttpsPort()
                 .fileSource(new SingleRootFileSource(setupTempFileRoot()))
-                .enableBrowserProxying(true));
+                .enableBrowserProxying(true)
+                .trustAll(true)
+        );
         proxy.start();
     }
 

--- a/java8/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
+++ b/java8/src/test/java/com/github/tomakehurst/wiremock/HttpsBrowserProxyAcceptanceTest.java
@@ -43,7 +43,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class Http2BrowserProxyAcceptanceTest {
+public class HttpsBrowserProxyAcceptanceTest {
 
     private static final String CERTIFICATE_NOT_TRUSTED_BY_TEST_CLIENT = TestFiles.KEY_STORE_PATH;
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -73,5 +73,5 @@ public interface Options {
     boolean getGzipDisabled();
     boolean getStubRequestLoggingDisabled();
     boolean getStubCorsEnabled();
-    boolean trustAll();
+    boolean trustAllProxyTargets();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -73,4 +73,5 @@ public interface Options {
     boolean getGzipDisabled();
     boolean getStubRequestLoggingDisabled();
     boolean getStubCorsEnabled();
+    boolean trustAll();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -150,7 +150,9 @@ public class WireMockApp implements StubServer, Admin {
                     options.httpsSettings().trustStore(),
                     options.shouldPreserveHostHeader(),
                     options.proxyHostHeader(),
-                    globalSettingsHolder),
+                    globalSettingsHolder,
+                    options.trustAll()
+                ),
                 ImmutableList.copyOf(options.extensionsOfType(ResponseTransformer.class).values())
             ),
             this,

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -151,7 +151,7 @@ public class WireMockApp implements StubServer, Admin {
                     options.shouldPreserveHostHeader(),
                     options.proxyHostHeader(),
                     globalSettingsHolder,
-                    options.trustAll()
+                    options.trustAllProxyTargets()
                 ),
                 ImmutableList.copyOf(options.extensionsOfType(ResponseTransformer.class).values())
             ),

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -98,6 +98,7 @@ public class WireMockConfiguration implements Options {
     private String permittedSystemKeys = null;
 
     private boolean stubCorsEnabled = false;
+    private boolean trustAll = false;
 
     private MappingsSource getMappingsSource() {
         if (mappingsSource == null) {
@@ -362,6 +363,11 @@ public class WireMockConfiguration implements Options {
         return this;
     }
 
+    public WireMockConfiguration trustAll(boolean enabled) {
+        this.trustAll = enabled;
+        return this;
+    }
+
     @Override
     public int portNumber() {
         return portNumber;
@@ -520,5 +526,10 @@ public class WireMockConfiguration implements Options {
     @Override
     public boolean getStubCorsEnabled() {
         return stubCorsEnabled;
+    }
+
+    @Override
+    public boolean trustAll() {
+        return trustAll;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -98,7 +98,7 @@ public class WireMockConfiguration implements Options {
     private String permittedSystemKeys = null;
 
     private boolean stubCorsEnabled = false;
-    private boolean trustAll = false;
+    private boolean trustAllProxyTargets = false;
 
     private MappingsSource getMappingsSource() {
         if (mappingsSource == null) {
@@ -363,8 +363,8 @@ public class WireMockConfiguration implements Options {
         return this;
     }
 
-    public WireMockConfiguration trustAll(boolean enabled) {
-        this.trustAll = enabled;
+    public WireMockConfiguration trustAllProxyTargets(boolean enabled) {
+        this.trustAllProxyTargets = enabled;
         return this;
     }
 
@@ -529,7 +529,7 @@ public class WireMockConfiguration implements Options {
     }
 
     @Override
-    public boolean trustAll() {
-        return trustAll;
+    public boolean trustAllProxyTargets() {
+        return trustAllProxyTargets;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -60,7 +60,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     private final boolean preserveHostHeader;
     private final String hostHeaderValue;
     private final GlobalSettingsHolder globalSettingsHolder;
-    private final boolean trustAll;
+    private final boolean trustAllProxyTargets;
 
     public ProxyResponseRenderer(
         ProxySettings proxySettings,
@@ -68,10 +68,10 @@ public class ProxyResponseRenderer implements ResponseRenderer {
         boolean preserveHostHeader,
         String hostHeaderValue,
         GlobalSettingsHolder globalSettingsHolder,
-        boolean trustAll
+        boolean trustAllProxyTargets
     ) {
         this.globalSettingsHolder = globalSettingsHolder;
-        this.trustAll = trustAll;
+        this.trustAllProxyTargets = trustAllProxyTargets;
         client = HttpClientFactory.createClient(1000, 5 * MINUTES, proxySettings, trustStoreSettings, true);
         scepticalClient = HttpClientFactory.createClient(1000, 5 * MINUTES, proxySettings, trustStoreSettings, false);
 
@@ -109,7 +109,7 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 	}
 
     private HttpClient buildClient(boolean browserProxyRequest) {
-	    if (browserProxyRequest && !trustAll) {
+	    if (browserProxyRequest && !trustAllProxyTargets) {
             return scepticalClient;
         } else {
             return this.client;

--- a/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ProxyResponseRenderer.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
 
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static com.github.tomakehurst.wiremock.common.HttpClientUtils.getEntityAsByteArrayAndCloseStream;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.POST;
 import static com.github.tomakehurst.wiremock.http.RequestMethod.PUT;
@@ -55,13 +56,24 @@ public class ProxyResponseRenderer implements ResponseRenderer {
     );
 
     private final HttpClient client;
+    private final HttpClient scepticalClient;
     private final boolean preserveHostHeader;
     private final String hostHeaderValue;
     private final GlobalSettingsHolder globalSettingsHolder;
-	
-	public ProxyResponseRenderer(ProxySettings proxySettings, KeyStoreSettings trustStoreSettings, boolean preserveHostHeader, String hostHeaderValue, GlobalSettingsHolder globalSettingsHolder) {
+    private final boolean trustAll;
+
+    public ProxyResponseRenderer(
+        ProxySettings proxySettings,
+        KeyStoreSettings trustStoreSettings,
+        boolean preserveHostHeader,
+        String hostHeaderValue,
+        GlobalSettingsHolder globalSettingsHolder,
+        boolean trustAll
+    ) {
         this.globalSettingsHolder = globalSettingsHolder;
-        client = HttpClientFactory.createClient(1000, 5 * MINUTES, proxySettings, trustStoreSettings);
+        this.trustAll = trustAll;
+        client = HttpClientFactory.createClient(1000, 5 * MINUTES, proxySettings, trustStoreSettings, true);
+        scepticalClient = HttpClientFactory.createClient(1000, 5 * MINUTES, proxySettings, trustStoreSettings, false);
 
         this.preserveHostHeader = preserveHostHeader;
         this.hostHeaderValue = hostHeaderValue;
@@ -75,7 +87,8 @@ public class ProxyResponseRenderer implements ResponseRenderer {
 
 		try {
 			addBodyIfPostPutOrPatch(httpRequest, responseDefinition);
-			HttpResponse httpResponse = client.execute(httpRequest);
+            HttpClient client = buildClient(serveEvent.getRequest().isBrowserProxyRequest());
+            HttpResponse httpResponse = client.execute(httpRequest);
 
             return response()
                     .status(httpResponse.getStatusLine().getStatusCode())
@@ -91,9 +104,17 @@ public class ProxyResponseRenderer implements ResponseRenderer {
                     .chunkedDribbleDelay(responseDefinition.getChunkedDribbleDelay())
                     .build();
 		} catch (IOException e) {
-			throw new RuntimeException(e);
+			return throwUnchecked(e, null);
 		}
 	}
+
+    private HttpClient buildClient(boolean browserProxyRequest) {
+	    if (browserProxyRequest && !trustAll) {
+            return scepticalClient;
+        } else {
+            return this.client;
+        }
+    }
 
     private HttpHeaders headersFrom(HttpResponse httpResponse, ResponseDefinition responseDefinition) {
 	    List<HttpHeader> httpHeaders = new LinkedList<HttpHeader>();

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -198,7 +198,7 @@ public class WarConfiguration implements Options {
     }
 
     @Override
-    public boolean trustAll() {
+    public boolean trustAllProxyTargets() {
         return false;
     }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -196,4 +196,9 @@ public class WarConfiguration implements Options {
     public boolean getStubCorsEnabled() {
         return false;
     }
+
+    @Override
+    public boolean trustAll() {
+        return false;
+    }
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -96,7 +96,7 @@ public class CommandLineOptions implements Options {
     private static final String DISABLE_GZIP = "disable-gzip";
     private static final String DISABLE_REQUEST_LOGGING = "disable-request-logging";
     private static final String ENABLE_STUB_CORS = "enable-stub-cors";
-    private static final String TRUST_ALL = "trust-all";
+    private static final String TRUST_ALL_PROXY_TARGETS = "trust-all-proxy-targets";
 
     private final OptionSet optionSet;
     private final FileSource fileSource;
@@ -147,7 +147,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(DISABLE_GZIP, "Disable gzipping of request and response bodies");
         optionParser.accepts(DISABLE_REQUEST_LOGGING, "Disable logging of stub requests and responses to the notifier. Useful when performance testing.");
         optionParser.accepts(ENABLE_STUB_CORS, "Enable automatic sending of CORS headers with stub responses.");
-        optionParser.accepts(TRUST_ALL, "Trust all certificates presented by origins when browser proxying");
+        optionParser.accepts(TRUST_ALL_PROXY_TARGETS, "Trust all certificates presented by origins when browser proxying");
 
         optionParser.accepts(HELP, "Print this message");
 
@@ -562,8 +562,8 @@ public class CommandLineOptions implements Options {
     }
 
     @Override
-    public boolean trustAll() {
-        return optionSet.has(TRUST_ALL);
+    public boolean trustAllProxyTargets() {
+        return optionSet.has(TRUST_ALL_PROXY_TARGETS);
     }
 
     private Long getMaxTemplateCacheEntries() {

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -96,6 +96,7 @@ public class CommandLineOptions implements Options {
     private static final String DISABLE_GZIP = "disable-gzip";
     private static final String DISABLE_REQUEST_LOGGING = "disable-request-logging";
     private static final String ENABLE_STUB_CORS = "enable-stub-cors";
+    private static final String TRUST_ALL = "trust-all";
 
     private final OptionSet optionSet;
     private final FileSource fileSource;
@@ -146,6 +147,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(DISABLE_GZIP, "Disable gzipping of request and response bodies");
         optionParser.accepts(DISABLE_REQUEST_LOGGING, "Disable logging of stub requests and responses to the notifier. Useful when performance testing.");
         optionParser.accepts(ENABLE_STUB_CORS, "Enable automatic sending of CORS headers with stub responses.");
+        optionParser.accepts(TRUST_ALL, "Trust all certificates presented by origins when browser proxying");
 
         optionParser.accepts(HELP, "Print this message");
 
@@ -557,6 +559,11 @@ public class CommandLineOptions implements Options {
     @Override
     public boolean getStubCorsEnabled() {
         return optionSet.has(ENABLE_STUB_CORS);
+    }
+
+    @Override
+    public boolean trustAll() {
+        return optionSet.has(TRUST_ALL);
     }
 
     private Long getMaxTemplateCacheEntries() {

--- a/src/test/java/com/github/tomakehurst/wiremock/crypto/CertificateSpecification.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/crypto/CertificateSpecification.java
@@ -1,0 +1,11 @@
+package com.github.tomakehurst.wiremock.crypto;
+
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public interface CertificateSpecification {
+    X509Certificate certificateFor(KeyPair keyPair) throws CertificateException, InvalidKeyException, SignatureException;
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/crypto/InMemoryKeyStore.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/crypto/InMemoryKeyStore.java
@@ -1,0 +1,65 @@
+package com.github.tomakehurst.wiremock.crypto;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryKeyStore {
+
+    public enum KeyStoreType {
+        JKS("jks");
+
+        private final String type;
+
+        KeyStoreType(String type) {
+            this.type = type;
+        }
+    }
+
+    private final Secret password;
+    private final KeyStore keyStore;
+
+    public InMemoryKeyStore(
+        KeyStoreType type,
+        Secret password
+    ) {
+        this.password = requireNonNull(password, "password");
+        this.keyStore = initialise(requireNonNull(type, "type"));
+    }
+
+    private KeyStore initialise(KeyStoreType type) {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(type.type);
+            keyStore.load(null, password.getValue());
+            return keyStore;
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException e) {
+            return throwUnchecked(e, null);
+        }
+    }
+
+    public void addPrivateKey(String alias, KeyPair keyPair, CertificateSpecification specification) throws KeyStoreException, CertificateException, InvalidKeyException, SignatureException {
+        Certificate cert = specification.certificateFor(keyPair);
+        keyStore.setKeyEntry(alias, keyPair.getPrivate(), password.getValue(), new Certificate[] { cert });
+    }
+
+    public void saveAs(File file) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            try {
+                keyStore.store(fos, password.getValue());
+            } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+                throwUnchecked(e);
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/crypto/Secret.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/crypto/Secret.java
@@ -1,0 +1,46 @@
+package com.github.tomakehurst.wiremock.crypto;
+
+import java.util.Arrays;
+
+import static java.util.Arrays.copyOf;
+import static java.util.Arrays.fill;
+import static java.util.Objects.requireNonNull;
+
+public class Secret implements AutoCloseable {
+
+    private static final char[] EMPTY_VALUE = new char[0];
+    private volatile char[] value;
+
+    public Secret(char[] value) {
+        requireNonNull(value, "Secret value may not be null");
+
+        this.value = copyOf(value, value.length);
+    }
+
+    public Secret(String value) {
+        this(null == value ? null : value.toCharArray());
+    }
+
+    public char[] getValue() {
+        return Arrays.copyOf(value, value.length);
+    }
+
+    @Override
+    public void close() {
+        if (EMPTY_VALUE == value)
+            return;
+
+        char[] tempValue = value;
+        value = EMPTY_VALUE;
+
+        fill(tempValue, (char) 0x00);
+    }
+
+    public boolean compareTo(String password) {
+        if (password == null) {
+            return false;
+        }
+
+        return Arrays.equals(password.toCharArray(), value);
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/crypto/X509CertificateSpecification.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/crypto/X509CertificateSpecification.java
@@ -1,0 +1,81 @@
+package com.github.tomakehurst.wiremock.crypto;
+
+import sun.security.x509.AlgorithmId;
+import sun.security.x509.CertificateAlgorithmId;
+import sun.security.x509.CertificateSerialNumber;
+import sun.security.x509.CertificateValidity;
+import sun.security.x509.CertificateX509Key;
+import sun.security.x509.X500Name;
+import sun.security.x509.X509CertImpl;
+import sun.security.x509.X509CertInfo;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.SecureRandom;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+import static java.util.Objects.requireNonNull;
+
+public class X509CertificateSpecification implements CertificateSpecification {
+
+    private final X509CertificateVersion version;
+    private final String subject;
+    private final String issuer;
+    // java.time is JDK8 on
+    private final Date notBefore;
+    private final Date notAfter;
+
+    public X509CertificateSpecification(
+        X509CertificateVersion version,
+        String subject,
+        String issuer,
+        Date notBefore,
+        Date notAfter
+    ) {
+        this.version = requireNonNull(version);
+        this.subject = requireNonNull(subject);
+        this.issuer = requireNonNull(issuer);
+        this.notBefore = requireNonNull(notBefore);
+        this.notAfter = requireNonNull(notAfter);
+    }
+
+    @Override
+    public X509Certificate certificateFor(KeyPair keyPair) throws CertificateException, InvalidKeyException, SignatureException {
+        try {
+            SecureRandom random = new SecureRandom();
+
+            X509CertInfo info = new X509CertInfo();
+            info.set(X509CertInfo.VERSION, version.getVersion());
+            info.set(X509CertInfo.SUBJECT, new X500Name(subject));
+            info.set(X509CertInfo.ISSUER, new X500Name(issuer));
+            info.set(X509CertInfo.VALIDITY, new CertificateValidity(notBefore, notAfter));
+
+            info.set(X509CertInfo.KEY, new CertificateX509Key(keyPair.getPublic()));
+            info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(new BigInteger(64, random)));
+            info.set(X509CertInfo.ALGORITHM_ID,
+                    new CertificateAlgorithmId(new AlgorithmId(AlgorithmId.sha1WithRSAEncryption_oid)));
+
+            // Sign the cert to identify the algorithm that's used.
+            X509CertImpl cert = new X509CertImpl(info);
+            cert.sign(keyPair.getPrivate(), "SHA256withRSA");
+
+            // Update the algorithm and sign again.
+            info.set(CertificateAlgorithmId.NAME + '.' + CertificateAlgorithmId.ALGORITHM, cert.get(X509CertImpl.SIG_ALG));
+            cert = new X509CertImpl(info);
+            cert.sign(keyPair.getPrivate(), "SHA256withRSA");
+            cert.verify(keyPair.getPublic());
+
+            return cert;
+        } catch (IOException | NoSuchAlgorithmException | NoSuchProviderException e) {
+            return throwUnchecked(e, null);
+        }
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/crypto/X509CertificateVersion.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/crypto/X509CertificateVersion.java
@@ -1,0 +1,32 @@
+package com.github.tomakehurst.wiremock.crypto;
+
+import sun.security.x509.CertificateVersion;
+
+import java.io.IOException;
+
+import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
+
+public enum X509CertificateVersion {
+
+    V1(CertificateVersion.V1),
+    V2(CertificateVersion.V2),
+    V3(CertificateVersion.V3);
+
+    private final CertificateVersion version;
+
+    X509CertificateVersion(int version) {
+        this.version = getVersion(version);
+    }
+
+    private static CertificateVersion getVersion(int version) {
+        try {
+            return new CertificateVersion(version);
+        } catch (IOException e) {
+            return throwUnchecked(e, null);
+        }
+    }
+
+    public CertificateVersion getVersion() {
+        return version;
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -1,0 +1,109 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.common.KeyStoreSettings;
+import com.github.tomakehurst.wiremock.common.ProxySettings;
+import com.github.tomakehurst.wiremock.crypto.InMemoryKeyStore;
+import com.github.tomakehurst.wiremock.crypto.Secret;
+import com.github.tomakehurst.wiremock.crypto.X509CertificateSpecification;
+import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.junit.Rule;
+import org.junit.Test;
+import sun.security.x509.X500Name;
+
+import java.io.File;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.HashMap;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static com.github.tomakehurst.wiremock.crypto.X509CertificateVersion.V3;
+import static org.junit.Assert.assertEquals;
+
+public class ProxyResponseRendererTest {
+
+    @Rule
+    public WireMockRule origin = new WireMockRule(options()
+            .httpDisabled(true)
+            .dynamicHttpsPort()
+            .keystorePath(generateKeystore().getAbsolutePath())
+    );
+
+    @Test
+    public void acceptsAnyCertificateForStandardProxying() {
+
+        origin.stubFor(get("/proxied").willReturn(aResponse().withBody("Result")));
+
+        ProxyResponseRenderer proxyResponseRenderer = new ProxyResponseRenderer(
+                ProxySettings.NO_PROXY,
+                KeyStoreSettings.NO_STORE,
+                /* preserveHostHeader = */ false,
+                /* hostHeaderValue = */ null,
+                new GlobalSettingsHolder()
+        );
+
+        ServeEvent serveEvent = reverseProxyServeEvent("/proxied");
+
+        Response response = proxyResponseRenderer.render(serveEvent);
+
+        assertEquals(response.getBodyAsString(), "Result");
+    }
+
+    private ServeEvent reverseProxyServeEvent(String path) {
+        LoggedRequest loggedRequest = new LoggedRequest(
+                /* url = */path,
+                /* absoluteUrl = */origin.url(path),
+                /* method = */ RequestMethod.GET,
+                /* clientIp = */"127.0.0.1",
+                /* headers = */new HttpHeaders(),
+                /* cookies = */new HashMap<String, Cookie>(),
+                /* isBrowserProxyRequest = */false,
+                /* loggedDate = */new Date(),
+                /* body = */new byte[0],
+                /* multiparts = */null
+        );
+        ResponseDefinition responseDefinition = aResponse().proxiedFrom(origin.baseUrl()).build();
+        responseDefinition.setOriginalRequest(loggedRequest);
+
+        return ServeEvent.of(
+                loggedRequest,
+                responseDefinition,
+                new StubMapping()
+        );
+    }
+
+    private File generateKeystore() throws Exception {
+
+        InMemoryKeyStore ks = new InMemoryKeyStore(InMemoryKeyStore.KeyStoreType.JKS, new Secret("password"));
+
+        ks.addPrivateKey("wiremock", generateKeyPair(), new X509CertificateSpecification(
+                /* version = */V3,
+                /* subject = */"CN=wiremock.org",
+                /* issuer = */"CN=wiremock.org",
+                /* notBefore = */new Date(),
+                /* notAfter = */new Date(System.currentTimeMillis() + (365L * 24 * 60 * 60 * 1000))
+        ));
+
+        File keystoreFile = File.createTempFile("wiremock-test", "keystore");
+
+        ks.saveAs(keystoreFile);
+
+        return keystoreFile;
+    }
+
+    private KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(1024);
+        return keyGen.generateKeyPair();
+    }
+
+    // Just exists to make the compiler happy by having the throws clause
+    public ProxyResponseRendererTest() throws Exception {}
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -55,7 +55,7 @@ public class ProxyResponseRendererTest {
     }
 
     @Test
-    public void rejectsSelfSignedCertificateForReverseProxying() {
+    public void rejectsSelfSignedCertificateForForwardProxyingByDefault() {
 
         origin.stubFor(get("/proxied").willReturn(aResponse().withBody("Result")));
 
@@ -72,7 +72,7 @@ public class ProxyResponseRendererTest {
     }
 
     @Test
-    public void acceptsSelfSignedCertificateForReverseProxyingIfTrustAllProxyTargets() {
+    public void acceptsSelfSignedCertificateForForwardProxyingIfTrustAllProxyTargets() {
 
         final ProxyResponseRenderer trustAllProxyResponseRenderer = buildProxyResponseRenderer(true);
 

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ProxyResponseRendererTest.java
@@ -72,7 +72,7 @@ public class ProxyResponseRendererTest {
     }
 
     @Test
-    public void acceptsSelfSignedCertificateForReverseProxyingIfTrustAll() {
+    public void acceptsSelfSignedCertificateForReverseProxyingIfTrustAllProxyTargets() {
 
         final ProxyResponseRenderer trustAllProxyResponseRenderer = buildProxyResponseRenderer(true);
 
@@ -141,14 +141,14 @@ public class ProxyResponseRendererTest {
         return keyGen.generateKeyPair();
     }
 
-    private ProxyResponseRenderer buildProxyResponseRenderer(boolean trustAll) {
+    private ProxyResponseRenderer buildProxyResponseRenderer(boolean trustAllProxyTargets) {
         return new ProxyResponseRenderer(
                 ProxySettings.NO_PROXY,
                 KeyStoreSettings.NO_STORE,
                 /* preserveHostHeader = */ false,
                 /* hostHeaderValue = */ null,
                 new GlobalSettingsHolder(),
-                trustAll
+                trustAllProxyTargets
         );
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -481,6 +481,18 @@ public class CommandLineOptionsTest {
     }
 
     @Test
+    public void trustsAll() {
+        CommandLineOptions options = new CommandLineOptions("--trust-all");
+        assertThat(options.trustAll(), is(true));
+    }
+
+    @Test
+    public void defaultsToNotTrustingAll() {
+        CommandLineOptions options = new CommandLineOptions();
+        assertThat(options.trustAll(), is(false));
+    }
+
+    @Test
     public void printsBothActualPortsOnlyWhenHttpsEnabled() {
 	    CommandLineOptions options = new CommandLineOptions();
 	    options.setActualHttpPort(5432);

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -33,12 +33,9 @@ import com.google.common.base.Optional;
 import org.junit.Test;
 
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import static com.github.tomakehurst.wiremock.matching.MockRequest.mockRequest;
 import static com.github.tomakehurst.wiremock.testsupport.WireMatchers.matchesMultiLine;
-import static java.util.regex.Pattern.DOTALL;
-import static java.util.regex.Pattern.MULTILINE;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -482,14 +479,14 @@ public class CommandLineOptionsTest {
 
     @Test
     public void trustsAll() {
-        CommandLineOptions options = new CommandLineOptions("--trust-all");
-        assertThat(options.trustAll(), is(true));
+        CommandLineOptions options = new CommandLineOptions("--trust-all-proxy-targets");
+        assertThat(options.trustAllProxyTargets(), is(true));
     }
 
     @Test
     public void defaultsToNotTrustingAll() {
         CommandLineOptions options = new CommandLineOptions();
-        assertThat(options.trustAll(), is(false));
+        assertThat(options.trustAllProxyTargets(), is(false));
     }
 
     @Test


### PR DESCRIPTION
Provide an option `--trust-all` to allow turning this behaviour off.
