### PR TITLE
Revert upgrading conscrypt

### DIFF
--- a/java8/build.gradle
+++ b/java8/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     compile "org.eclipse.jetty:jetty-alpn-server:$jettyVersion"
     compile "org.eclipse.jetty:jetty-alpn-conscrypt-server:$jettyVersion"
     compile "org.eclipse.jetty:jetty-alpn-conscrypt-client:$jettyVersion"
-    compile 'org.conscrypt:conscrypt-openjdk-uber:2.4.0'
     compile 'net.javacrumbs.json-unit:json-unit-core:2.12.0'
 
     testCompile "org.eclipse.jetty:jetty-client:$jettyVersion"


### PR DESCRIPTION
conscrypt:2.4.0 depends on an OpenSSL version only found in OS/X Catalina, so
forces users to upgrade their O/S. Reverting to old version.