### PR TITLE
In scenarios where one wants to use a subclass of ResponseDefinition,…

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/ResponseDefinition.java
@@ -203,21 +203,25 @@ public class ResponseDefinition {
     }
 
     public static ResponseDefinition copyOf(ResponseDefinition original) {
+        return original.copy();
+    }
+
+    public ResponseDefinition copy() {
         ResponseDefinition newResponseDef = new ResponseDefinition(
-            original.status,
-            original.statusMessage,
-            original.body,
-            original.bodyFileName,
-            original.headers,
-            original.additionalProxyRequestHeaders,
-            original.fixedDelayMilliseconds,
-            original.delayDistribution,
-            original.chunkedDribbleDelay,
-            original.proxyBaseUrl,
-            original.fault,
-            original.transformers,
-            original.transformerParameters,
-            original.wasConfigured
+            this.status,
+            this.statusMessage,
+            this.body,
+            this.bodyFileName,
+            this.headers,
+            this.additionalProxyRequestHeaders,
+            this.fixedDelayMilliseconds,
+            this.delayDistribution,
+            this.chunkedDribbleDelay,
+            this.proxyBaseUrl,
+            this.fault,
+            this.transformers,
+            this.transformerParameters,
+            this.wasConfigured
         );
         return newResponseDef;
     }


### PR DESCRIPTION
… they should be able to override the copy method. The reason for that is that the static copyOf is already used in Wiremock codebase.

We are overriding the ResponseDefinition class, so we need to override the copy method as well.

Thanks!