### PR TITLE
Update exampleTest in getting started doc

### DIFF
--- a/docs-v2/_docs/getting-started.md
+++ b/docs-v2/_docs/getting-started.md
@@ -54,7 +54,7 @@ Now you're ready to write a test case like this:
 ```java
 @Test
 public void exampleTest() {
-    stubFor(get(urlEqualTo("/my/resource"))
+    stubFor(post(urlEqualTo("/my/resource"))
             .withHeader("Accept", equalTo("text/xml"))
             .willReturn(aResponse()
                 .withStatus(200)


### PR DESCRIPTION
The `exampleTest()` sample had mis-matched HTTP methods in the `stubFor()` and `verify()`. If you stub for `get`, then you need to verify `getRequestedFor()` and vice versa. This caused me some confusion as I was working through this as a new user.