### PR TITLE
Add support for jsonpath defaults

### DIFF
--- a/docs-v2/_docs/response-templating.md
+++ b/docs-v2/_docs/response-templating.md
@@ -374,6 +374,14 @@ And for the same JSON the following will render `{ "inner": "Stuff" }`:
 ```
 {% endraw %}
 
+Default value can be specified if the path evaluates to null or undefined:
+
+{% raw %}
+```
+{{jsonPath request.body '$.size' default='M'}}
+```
+{% endraw %}
+
 
 ## Date and time helpers
 A helper is present to render the current date/time, with the ability to specify the format ([via Java's SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html)) and offset.

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelper.java
@@ -18,10 +18,14 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.common.Json;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.RenderCache;
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.InvalidJsonException;
+import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.JsonPathException;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.ParseContext;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -31,6 +35,12 @@ import java.io.StringReader;
 import java.util.Map;
 
 public class HandlebarsJsonPathHelper extends HandlebarsHelper<Object> {
+
+    private final Configuration config = Configuration
+        .defaultConfiguration()
+        .addOptions(Option.DEFAULT_PATH_LEAF_TO_NULL);
+
+    private final ParseContext parseContext = JsonPath.using(config);
 
     @Override
     public Object apply(final Object input, final Options options) throws IOException {
@@ -42,27 +52,34 @@ public class HandlebarsJsonPathHelper extends HandlebarsHelper<Object> {
             return this.handleError("The JSONPath cannot be empty");
         }
 
-        final String jsonPath = options.param(0);
+        final String jsonPathString = options.param(0);
 
         try {
             final DocumentContext jsonDocument = getJsonDocument(input, options);
+            final JsonPath jsonPath = JsonPath.compile(jsonPathString);
             Object result = getValue(jsonPath, jsonDocument, options);
             return JsonData.create(result);
         } catch (InvalidJsonException e) {
             return this.handleError(
                     input + " is not valid JSON",
                     e.getJson(), e);
-        } catch (JsonPathException e) {
-            return this.handleError(jsonPath + " is not a valid JSONPath expression", e);
+        } catch (InvalidPathException e) {
+            return this.handleError(jsonPathString + " is not a valid JSONPath expression", e);
         }
     }
 
-    private Object getValue(String jsonPath, DocumentContext jsonDocument, Options options) {
+    private Object getValue(JsonPath jsonPath, DocumentContext jsonDocument, Options options) {
         RenderCache renderCache = getRenderCache(options);
         RenderCache.Key cacheKey = RenderCache.Key.keyFor(Object.class, jsonPath, jsonDocument);
         Object value = renderCache.get(cacheKey);
         if (value == null) {
             value = jsonDocument.read(jsonPath);
+            if (value == null && options.hash != null) {
+                value = options.hash("default");
+            }
+            if (value == null) {
+                value = "";
+            }
             renderCache.put(cacheKey, value);
         }
 
@@ -75,8 +92,8 @@ public class HandlebarsJsonPathHelper extends HandlebarsHelper<Object> {
         DocumentContext document = renderCache.get(cacheKey);
         if (document == null) {
             document = json instanceof String ?
-                    JsonPath.parse((String) json) :
-                    JsonPath.parse(json);
+                    parseContext.parse((String) json) :
+                    parseContext.parse(json);
             renderCache.put(cacheKey, document);
         }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/ResponseTemplateTransformerTest.java
@@ -308,7 +308,7 @@ public class ResponseTemplateTransformerTest {
 
         assertThat(transformedResponseDef.getBody(), is("5"));
     }
-    
+
     @Test
     public void areConditionalHelpersLoaded() {
 
@@ -322,9 +322,9 @@ public class ResponseTemplateTransformerTest {
 
         assertThat(transformedResponseDef.getBody(), is("y"));
     }
-    
-    
-    
+
+
+
 
     @Test
     public void proxyBaseUrlWithAdditionalRequestHeader() {
@@ -359,6 +359,32 @@ public class ResponseTemplateTransformerTest {
                 Parameters.empty());
 
         assertThat(responseDefinition.getBody(), is("{\"test\": \"look at my &#x27;single quotes&#x27;\"}"));
+    }
+
+    @Test
+    public void jsonPathValueDefaultsToEmptyString() {
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+            mockRequest()
+                .url("/json").
+                body("{\"a\": \"1\"}"),
+            aResponse()
+                .withBody("{{jsonPath request.body '$.b'}}").build(),
+            noFileSource(),
+            Parameters.empty());
+        assertThat(responseDefinition.getBody(), is(""));
+    }
+
+    @Test
+    public void jsonPathValueDefaultCanBeProvided() {
+        final ResponseDefinition responseDefinition = this.transformer.transform(
+            mockRequest()
+                .url("/json").
+                body("{\"a\": \"1\"}"),
+            aResponse()
+                .withBody("{{jsonPath request.body '$.b' default='foo'}}").build(),
+            noFileSource(),
+            Parameters.empty());
+        assertThat(responseDefinition.getBody(), is("foo"));
     }
 
     @Test

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelperTestBase.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsHelperTestBase.java
@@ -78,11 +78,19 @@ public abstract class HandlebarsHelperTestBase {
     }
 
     protected Options createOptions(String optionParam, RenderCache renderCache) {
-        Context context = Context.newBuilder(null)
-                .combine("renderCache", renderCache)
-                .build();
+        Context context = createContext(renderCache);
 
         return new Options(null, null, null, context, null, null,
                            new Object[]{optionParam}, null, new ArrayList<String>(0));
+    }
+
+    protected Context createContext() {
+        return createContext(renderCache);
+    }
+
+    private Context createContext(RenderCache renderCache) {
+        return Context.newBuilder(null)
+            .combine("renderCache", renderCache)
+            .build();
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsJsonPathHelperTest.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.github.tomakehurst.wiremock.testsupport.WireMatchers;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
@@ -196,7 +197,63 @@ public class HandlebarsJsonPathHelperTest extends HandlebarsHelperTestBase {
 
     @Test
     public void rendersAMeaningfulErrorWhenJsonPathIsInvalid() {
-        testHelperError(helper, "{\"test\":\"success\"}", "$.\\test", is("[ERROR: $.\\test is not a valid JSONPath expression]"));
+        testHelperError(helper, "{\"test\":\"success\"}", "$==test", is("[ERROR: $==test is not a valid JSONPath expression]"));
+    }
+
+    @Test
+    public void rendersAnEmptyStringWhenJsonValueUndefined() {
+        testHelperError(helper, "{\"test\":\"success\"}", "$.test2", is(""));
+    }
+
+    @Test
+    public void rendersAnEmptyStringWhenJsonValueUndefinedAndOptionsEmpty() throws Exception {
+        Map<String, Object> options = ImmutableMap.<String, Object>of();
+        String output = render("{\"test\":\"success\"}", "$.test2", options);
+        assertThat(output, is(""));
+    }
+
+    @Test
+    public void rendersDefaultValueWhenJsonValueUndefined() throws Exception {
+        Map<String, Object> options = ImmutableMap.<String, Object>of(
+            "default", "0"
+        );
+        String output = render("{}", "$.test", options);
+        assertThat(output, is("0"));
+    }
+
+    @Test
+    public void rendersDefaultValueWhenJsonValueNull() throws Exception {
+        Map<String, Object> options = ImmutableMap.<String, Object>of(
+            "default", "0"
+        );
+        String output = render("{\"test\":null}", "$.test", options);
+        assertThat(output, is("0"));
+    }
+
+    @Test
+    public void ignoresDefaultWhenJsonValueEmpty() throws Exception {
+        Map<String, Object> options = ImmutableMap.<String, Object>of(
+            "default", "0"
+        );
+        String output = render("{\"test\":\"\"}", "$.test", options);
+        assertThat(output, is(""));
+    }
+
+    @Test
+    public void ignoresDefaultWhenJsonValueZero() throws Exception {
+        Map<String, Object> options = ImmutableMap.<String, Object>of(
+            "default", "1"
+        );
+        String output = render("{\"test\":0}", "$.test", options);
+        assertThat(output, is("0"));
+    }
+
+    private String render(String content, String path, Map<String, Object> options) throws IOException {
+        return helper.apply(content,
+            new Options.Builder(null, null, null, createContext(), null)
+                .setParams(new Object[] { path })
+                .setHash(options).build()
+        ).toString();
     }
 
     @Test


### PR DESCRIPTION
This PR includes two related changes to the JsonPath template helper:

1. output nothing (empty string) when no path matched instead of error message
2. allow overriding the default value when no path matched

The default value is static only. There may be a more generic solution to apply defaults for example by adding a "default" helper.

Gradle build didn't work for me on Oracle JDK 14 so I just ran a subset of the unit tests in Intellij.

Let me know if you want docs updated.