### PR TITLE
Response templating: Add support for random hexadecimal strings

### DIFF
--- a/docs-v2/_docs/response-templating.md
+++ b/docs-v2/_docs/response-templating.md
@@ -428,6 +428,7 @@ Random strings of various kinds can be generated:
 {{randomValue length=10 type='NUMERIC'}}
 {{randomValue length=5 type='ALPHANUMERIC_AND_SYMBOLS'}}
 {{randomValue type='UUID'}}
+{{randomValue length=32 type='HEXADECIMAL' uppercase=true}}
 ```
 {% endraw %}
 

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelper.java
@@ -47,6 +47,9 @@ public class HandlebarsRandomValuesHelper extends HandlebarsHelper<Void> {
             case "UUID":
                 rawValue = UUID.randomUUID().toString();
                 break;
+            case "HEXADECIMAL":
+                rawValue = RandomStringUtils.random(length, "ABCDEF0123456789");
+                break;
             default:
                 rawValue = RandomStringUtils.randomAscii(length);
                 break;

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/HandlebarsRandomValuesHelperTest.java
@@ -113,6 +113,19 @@ public class HandlebarsRandomValuesHelperTest {
     }
 
     @Test
+    public void generatesRandomHexadecimalOfSpecifiedLength() throws Exception {
+        ImmutableMap<String, Object> optionsHash = ImmutableMap.<String, Object>of(
+                "length", 64,
+                "type", "HEXADECIMAL"
+        );
+
+        String output = render(optionsHash);
+
+        assertThat(output.length(), is(64));
+        assertThat(output, WireMatchers.matches("^[0-9a-f]+$"));
+    }
+
+    @Test
     public void randomValuesCanBeAssignedToVariables() {
         final ResponseDefinition responseDefinition = this.transformer.transform(
             mockRequest().url("/random-value"),


### PR DESCRIPTION
I would like to be able to use the standalone mock to generate hexadecimal strings without having to write any Java code, but it seems that the current version of wiremock does not support this.

With this merge request, a hexadecimal string can be generated using the [response templating](http://wiremock.org/docs/response-templating/) feature.

