### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 # https://dependabot.com/#how-it-works
 updates:
-  - package-ecosystem: "maven"
+  - package-ecosystem: "gradle"
     # Look for `pom.xml` in the `root` directory. It will recursively scan any submodules.
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,8 @@
 version: 2
-# https://dependabot.com/#how-it-works
 updates:
-  - package-ecosystem: "gradle"
-    # Look for `pom.xml` in the `root` directory. It will recursively scan any submodules.
-    directory: "/"
-    schedule:
-      # Check for updates once a day. This can be changed later on to `weekly` if desired.
-      interval: "daily"
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+# https://dependabot.com/#how-it-works
+updates:
+  - package-ecosystem: "maven"
+    # Look for `pom.xml` in the `root` directory. It will recursively scan any submodules.
+    directory: "/"
+    schedule:
+      # Check for updates once a day. This can be changed later on to `weekly` if desired.
+      interval: "daily"


### PR DESCRIPTION
:wave: Dependabot is moving natively into GitHub! This pull request migrates your configuration from Dependabot.com to a config file, using the [new syntax](https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates). When you merge this pull request, we'll swap out `dependabot-preview` (me) for a new `dependabot` app, and you'll be all set!

With this change, you'll now use the [Dependabot page in GitHub](https://github.com/hilmarf/wiremock/network/updates), rather than the [Dependabot dashboard](https://app.dependabot.com/), to monitor your version updates. Dependabot is now configured exclusively using config files.



The new version does not yet support private git dependencies. If you use these we recommend recommend leaving Dependabot Preview active.








If you've got any questions or feedback for us, please let us know by creating an issue in the [dependabot/dependabot-core](https://github.com/dependabot/dependabot-core/issues) repository.

[Learn more about the relaunch of Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)

Please note that regular `@dependabot` commands do not work on this pull request.

:robot::yellow_heart:
