### PR TITLE
Recognize multipart/related and multipart/mixed

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WireMockHttpServletRequestAdapter.java
@@ -276,7 +276,7 @@ public class WireMockHttpServletRequestAdapter implements Request {
     @Override
     public boolean isMultipart() {
         String header = getHeader("Content-Type");
-        return (header != null && header.contains("multipart/form-data"));
+        return (header != null && header.contains("multipart/"));
     }
 
     @Override


### PR DESCRIPTION
The newer version of Jetty seems to support multipart/related and multipart/mixed. At least the two new test cases don't fail (nor produce warnings). 

Reverts #973
Closes #1047 