### PR TITLE
Add the ability to specify Jetty's idleTimeout

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/JettySettings.java
@@ -25,15 +25,18 @@ public class JettySettings {
     private final Optional<Integer> acceptQueueSize;
     private final Optional<Integer> requestHeaderSize;
     private final Optional<Long> stopTimeout;
+    private final Optional<Long> idleTimeout;
 
     private JettySettings(Optional<Integer> acceptors,
                           Optional<Integer> acceptQueueSize,
                           Optional<Integer> requestHeaderSize,
-                          Optional<Long> stopTimeout) {
+                          Optional<Long> stopTimeout,
+                          Optional<Long> idleTimeout) {
         this.acceptors = acceptors;
         this.acceptQueueSize = acceptQueueSize;
         this.requestHeaderSize = requestHeaderSize;
         this.stopTimeout = stopTimeout;
+        this.idleTimeout = idleTimeout;
     }
 
     public Optional<Integer> getAcceptors() {
@@ -52,6 +55,10 @@ public class JettySettings {
         return stopTimeout;
     }
 
+    public Optional<Long> getIdleTimeout() {
+        return idleTimeout;
+    }
+
     @Override
     public String toString() {
         return "JettySettings{" +
@@ -66,6 +73,7 @@ public class JettySettings {
         private Integer acceptQueueSize;
         private Integer requestHeaderSize;
         private Long stopTimeout;
+        private Long idleTimeout;
 
         private Builder() {
         }
@@ -94,11 +102,17 @@ public class JettySettings {
             return this;
         }
 
+        public Builder withIdleTimeout(Long idleTimeout) {
+            this.idleTimeout = idleTimeout;
+            return this;
+        }
+
         public JettySettings build() {
             return new JettySettings(Optional.fromNullable(acceptors),
                     Optional.fromNullable(acceptQueueSize),
                     Optional.fromNullable(requestHeaderSize),
-                    Optional.fromNullable(stopTimeout));
+                    Optional.fromNullable(stopTimeout),
+                    Optional.fromNullable(idleTimeout));
         }
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -95,6 +95,7 @@ public class WireMockConfiguration implements Options {
     private Integer jettyAcceptQueueSize;
     private Integer jettyHeaderBufferSize;
     private Long jettyStopTimeout;
+    private Long jettyIdleTimeout;
 
     private Map<String, Extension> extensions = newLinkedHashMap();
     private WiremockNetworkTrafficListener networkTrafficListener = new DoNothingWiremockNetworkTrafficListener();
@@ -175,6 +176,11 @@ public class WireMockConfiguration implements Options {
 
     public WireMockConfiguration jettyStopTimeout(Long jettyStopTimeout) {
         this.jettyStopTimeout = jettyStopTimeout;
+        return this;
+    }
+
+    public WireMockConfiguration jettyIdleTimeout(Long jettyIdleTimeout) {
+        this.jettyIdleTimeout = jettyIdleTimeout;
         return this;
     }
 
@@ -451,6 +457,7 @@ public class WireMockConfiguration implements Options {
                 .withAcceptQueueSize(jettyAcceptQueueSize)
                 .withRequestHeaderSize(jettyHeaderBufferSize)
                 .withStopTimeout(jettyStopTimeout)
+                .withIdleTimeout(jettyIdleTimeout)
                 .build();
     }
 

--- a/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/jetty9/JettyHttpServer.java
@@ -349,6 +349,10 @@ public class JettyHttpServer implements HttpServer {
         if (jettySettings.getAcceptQueueSize().isPresent()) {
             connector.setAcceptQueueSize(jettySettings.getAcceptQueueSize().get());
         }
+
+        if (jettySettings.getIdleTimeout().isPresent()) {
+            connector.setIdleTimeout(jettySettings.getIdleTimeout().get());
+        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -93,6 +93,7 @@ public class CommandLineOptions implements Options {
     private static final String JETTY_ACCEPT_QUEUE_SIZE = "jetty-accept-queue-size";
     private static final String JETTY_HEADER_BUFFER_SIZE = "jetty-header-buffer-size";
     private static final String JETTY_STOP_TIMEOUT = "jetty-stop-timeout";
+    private static final String JETTY_IDLE_TIMEOUT = "jetty-idle-timeout";
     private static final String ROOT_DIR = "root-dir";
     private static final String CONTAINER_THREADS = "container-threads";
     private static final String GLOBAL_RESPONSE_TEMPLATING = "global-response-templating";
@@ -152,6 +153,7 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(JETTY_ACCEPT_QUEUE_SIZE, "The size of Jetty's accept queue size").withRequiredArg();
         optionParser.accepts(JETTY_HEADER_BUFFER_SIZE, "The size of Jetty's buffer for request headers").withRequiredArg();
         optionParser.accepts(JETTY_STOP_TIMEOUT, "Timeout in milliseconds for Jetty to stop").withRequiredArg();
+        optionParser.accepts(JETTY_IDLE_TIMEOUT, "Idle timeout in milliseconds for Jetty connections").withRequiredArg();
         optionParser.accepts(PRINT_ALL_NETWORK_TRAFFIC, "Print all raw incoming and outgoing network traffic to console");
         optionParser.accepts(GLOBAL_RESPONSE_TEMPLATING, "Preprocess all responses with Handlebars templates");
         optionParser.accepts(LOCAL_RESPONSE_TEMPLATING, "Preprocess selected responses with Handlebars templates");
@@ -314,6 +316,10 @@ public class CommandLineOptions implements Options {
 
         if (optionSet.hasArgument(JETTY_STOP_TIMEOUT)) {
             builder = builder.withStopTimeout(Long.parseLong((String) optionSet.valueOf(JETTY_STOP_TIMEOUT)));
+        }
+
+        if (optionSet.hasArgument(JETTY_IDLE_TIMEOUT)) {
+            builder = builder.withIdleTimeout(Long.parseLong((String) optionSet.valueOf(JETTY_IDLE_TIMEOUT)));
         }
 
         return builder.build();

--- a/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
@@ -35,7 +35,8 @@ public class JettySettingsTest {
         builder.withAcceptors(number)
                 .withAcceptQueueSize(number)
                 .withRequestHeaderSize(number)
-                .withStopTimeout(longNumber);
+                .withStopTimeout(longNumber)
+                .withIdleTimeout(longNumber);
         JettySettings jettySettings = builder.build();
 
         ensurePresent(jettySettings.getAcceptors());

--- a/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/common/JettySettingsTest.java
@@ -42,6 +42,7 @@ public class JettySettingsTest {
         ensurePresent(jettySettings.getAcceptQueueSize());
         ensurePresent(jettySettings.getRequestHeaderSize());
         ensureLongPresent(jettySettings.getStopTimeout());
+        ensureLongPresent(jettySettings.getIdleTimeout());
     }
 
     @Test
@@ -55,6 +56,7 @@ public class JettySettingsTest {
         assertFalse(jettySettings.getAcceptQueueSize().isPresent());
         assertFalse(jettySettings.getRequestHeaderSize().isPresent());
         assertFalse(jettySettings.getStopTimeout().isPresent());
+        assertFalse(jettySettings.getIdleTimeout().isPresent());
     }
 
     private void ensurePresent(Optional<Integer> optional) {

--- a/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/core/WireMockConfigurationTest.java
@@ -42,6 +42,23 @@ public class WireMockConfigurationTest {
     }
 
     @Test
+    public void testJettyIdleTimeout() {
+        Long expectedIdleTimeout = 500L;
+        WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig().jettyIdleTimeout(expectedIdleTimeout);
+        Optional<Long> jettyIdleTimeout = wireMockConfiguration.jettySettings().getIdleTimeout();
+
+        assertThat(jettyIdleTimeout.isPresent(), is(true));
+        assertThat(jettyIdleTimeout.get(), is(expectedIdleTimeout));
+    }
+
+    @Test
+    public void testJettyIdleTimeoutNotSet() {
+        WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig();
+        Optional<Long> jettyIdleTimeout = wireMockConfiguration.jettySettings().getIdleTimeout();
+        assertThat(jettyIdleTimeout.isPresent(), is(false));
+    }
+
+    @Test
     public void shouldUseQueuedThreadPoolByDefault() {
         int maxThreads = 20;
         WireMockConfiguration wireMockConfiguration = WireMockConfiguration.wireMockConfig().containerThreads(maxThreads);

--- a/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptionsTest.java
@@ -289,6 +289,12 @@ public class CommandLineOptionsTest {
     }
 
     @Test
+    public void returnsCorrectlyParsedJettyIdleTimeout() {
+        CommandLineOptions options = new CommandLineOptions("--jetty-idle-timeout", "2000");
+        assertThat(options.jettySettings().getIdleTimeout().get(), is(2000L));
+    }
+
+    @Test
     public void returnsAbsentIfJettyAcceptQueueSizeNotSet() {
         CommandLineOptions options = new CommandLineOptions();
         assertThat(options.jettySettings().getAcceptQueueSize().isPresent(), is(false));


### PR DESCRIPTION
### PR Purpose
The purpose of this PR is to add the ability to set Jetty's idleTimeout parameter.

### What this solves
This PR solves the issue of the nginx LB returning 502 errors when calling a downstream Wiremock Jetty server. This nginx / Jetty issue is a known one:
https://github.com/eclipse/jetty.project/issues/2791#issuecomment-413173044
https://stackoverflow.com/questions/51865009/http-502-bad-gateway-writev-failed-104-connection-reset-by-peer

Nginx holds an open connection to Wiremock for a set amount of time: https://www.nginx.com/blog/http-keepalives-and-web-performance/

If the nginx keepalive is longer than the Jetty idleTimeout, the result is sporadic closing of connections by Jetty that causes nginx to return a 502 error to the upstream caller.

As you can see from the attached issues, given a system where it is not possible (for whatever reason) to change the nginx settings, the adjustment has to be made on the Jetty side, so that Jetty `idleTimeout` > nginx `keepalive_timeout`

