### PR TITLE
Exclude module-info form standalone jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -218,6 +218,7 @@ shadowJar {
     mergeServiceFiles()
 
     exclude 'META-INF/maven/javax.servlet/**'
+    exclude 'module-info.class'
 }
 
 def repoUser


### PR DESCRIPTION
Currently the WireMock standalone .jar distribution includes a Java module information file `module-info.class` that is coming from a transitive dependency during the class relocation by the shadow jar builder.

That module-info contains an incorrect module declaration unrelated to WireMock (I think it is for jackson data bind module).

The problem is that the module-info.class is getting recognized by the Maven compiler plugin as well as in runtime preventing the use of WireMock for testing  module Java applications due class loading error.

A compile time error looks like:
`package com.github.tomakehurst.wiremock does not exist
cannot find symbol
  symbol:   class WireMockServer`
  
A runtime error:  
```
java.lang.NoClassDefFoundError: com/github/tomakehurst/wiremock/WireMockServer
Caused by: java.lang.ClassNotFoundException: com.github.tomakehurst.wiremock.WireMockServer
```

Removing the unused incorrect module-info would turn the standalone wiremock .jar into a proper UNNAMED Java module.