### PR TITLE
Fix broken link

### DIFF
--- a/docs-v2/_docs/getting-started.md
+++ b/docs-v2/_docs/getting-started.md
@@ -150,7 +150,7 @@ the Java API, JSON over HTTP or JSON files.
 This will start the server on port 8080:
 
 You can [download the standalone JAR from
-here](https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/{{ site.wiremock_version }}/wiremock-standalone-{{ site.wiremock_version }}.jar).
+here](https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/{{ site.wiremock_version }}/wiremock-jre8-standalone-{{ site.wiremock_version }}.jar).
 
 See [Running as a Standalone Process](/docs/running-standalone/) running-standalone for more details and commandline options.
 


### PR DESCRIPTION
The standalone-jar link in getting-started was broken, so I made it the same as download-and-installation and running-standalone.