### PR TITLE
#1420 Timeout & disable optimize xml factories loading

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlDocument.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/common/xml/XmlDocument.java
@@ -1,26 +1,19 @@
 package com.github.tomakehurst.wiremock.common.xml;
 
 import com.github.tomakehurst.wiremock.common.ListOrSingle;
-import org.custommonkey.xmlunit.SimpleNamespaceContext;
-import org.custommonkey.xmlunit.jaxp13.XMLUnitNamespaceContext2Jaxp13;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xmlunit.util.Convert;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
-import javax.xml.transform.Transformer;
 import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 
-import java.io.StringWriter;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
-import static com.github.tomakehurst.wiremock.common.Exceptions.throwUnchecked;
 import static javax.xml.xpath.XPathConstants.NODESET;
 
 public class XmlDocument extends XmlNode {

--- a/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/Options.java
@@ -41,6 +41,7 @@ public interface Options {
 
     int DEFAULT_PORT = 8080;
     int DYNAMIC_PORT = 0;
+    int DEFAULT_TIMEOUT = 300_000;
     int DEFAULT_CONTAINER_THREADS = 25;
     String DEFAULT_BIND_ADDRESS = "0.0.0.0";
 
@@ -79,4 +80,6 @@ public interface Options {
     boolean getGzipDisabled();
     boolean getStubRequestLoggingDisabled();
     boolean getStubCorsEnabled();
+    long timeout();
+    boolean getDisableOptimizeXmlFactoriesLoading();
 }

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -38,6 +38,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 
 import java.util.Collections;
 import java.util.List;
@@ -56,6 +57,7 @@ public class WireMockApp implements StubServer, Admin {
     public static final String FILES_ROOT = "__files";
     public static final String ADMIN_CONTEXT_ROOT = "/__admin";
     public static final String MAPPINGS_ROOT = "mappings";
+    private static final MutableBoolean FACTORIES_LOADING_OPTIMIZED = new MutableBoolean(false);
 
     private final Scenarios scenarios;
     private final StubMappings stubMappings;
@@ -71,11 +73,12 @@ public class WireMockApp implements StubServer, Admin {
 
     private Options options;
 
-    static {
-        Xml.optimizeFactoriesLoading();
-    }
-
     public WireMockApp(Options options, Container container) {
+        if (!options.getDisableOptimizeXmlFactoriesLoading() && FACTORIES_LOADING_OPTIMIZED.isFalse()) {
+            Xml.optimizeFactoriesLoading();
+            FACTORIES_LOADING_OPTIMIZED.setTrue();
+        }
+
         this.options = options;
 
         FileSource fileSource = options.filesRoot();

--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockConfiguration.java
@@ -54,6 +54,8 @@ import static java.util.Collections.emptyList;
 
 public class WireMockConfiguration implements Options {
 
+    private long timeout = DEFAULT_TIMEOUT;
+    private boolean disableOptimizeXmlFactoriesLoading = false;
     private int portNumber = DEFAULT_PORT;
     private boolean httpDisabled = false;
     private String bindAddress = DEFAULT_BIND_ADDRESS;
@@ -127,6 +129,11 @@ public class WireMockConfiguration implements Options {
 
     public static WireMockConfiguration options() {
         return wireMockConfig();
+    }
+
+    public WireMockConfiguration timeout(int timeout) {
+        this.timeout = timeout;
+        return this;
     }
 
     public WireMockConfiguration port(int portNumber) {
@@ -580,6 +587,21 @@ public class WireMockConfiguration implements Options {
     @Override
     public boolean getStubCorsEnabled() {
         return stubCorsEnabled;
+    }
+
+    @Override
+    public long timeout() {
+        return timeout;
+    }
+
+    @Override
+    public boolean getDisableOptimizeXmlFactoriesLoading() {
+        return disableOptimizeXmlFactoriesLoading;
+    }
+
+    public WireMockConfiguration disableOptimizeXmlFactoriesLoading(boolean disableOptimizeXmlFactoriesLoading) {
+        this.disableOptimizeXmlFactoriesLoading = disableOptimizeXmlFactoriesLoading;
+        return this;
     }
 
     @Override

--- a/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/servlet/WarConfiguration.java
@@ -201,6 +201,16 @@ public class WarConfiguration implements Options {
     }
 
     @Override
+    public long timeout() {
+        return 0;
+    }
+
+    @Override
+    public boolean getDisableOptimizeXmlFactoriesLoading() {
+        return false;
+    }
+
+    @Override
     public BrowserProxySettings browserProxySettings() {
         return BrowserProxySettings.DISABLED;
     }

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/CommandLineOptions.java
@@ -23,7 +23,6 @@ import com.github.tomakehurst.wiremock.core.Options;
 import com.github.tomakehurst.wiremock.core.WireMockApp;
 import com.github.tomakehurst.wiremock.extension.Extension;
 import com.github.tomakehurst.wiremock.extension.ExtensionLoader;
-import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.http.CaseInsensitiveKey;
 import com.github.tomakehurst.wiremock.http.HttpServerFactory;
@@ -70,6 +69,7 @@ public class CommandLineOptions implements Options {
 	private static final String PROXY_ALL = "proxy-all";
     private static final String PRESERVE_HOST_HEADER = "preserve-host-header";
     private static final String PROXY_VIA = "proxy-via";
+    private static final String TIMEOUT = "timeout";
     private static final String PORT = "port";
     private static final String DISABLE_HTTP = "disable-http";
     private static final String BIND_ADDRESS = "bind-address";
@@ -113,6 +113,7 @@ public class CommandLineOptions implements Options {
     private static final String HTTPS_CA_KEYSTORE = "ca-keystore";
     private static final String HTTPS_CA_KEYSTORE_PASSWORD = "ca-keystore-password";
     private static final String HTTPS_CA_KEYSTORE_TYPE = "ca-keystore-type";
+    private static final String DISABLE_OPTIMIZE_XML_FACTORIES_LOADING = "disable-optimize-xml-factories-loading";
 
     private final OptionSet optionSet;
     private final FileSource fileSource;
@@ -130,6 +131,8 @@ public class CommandLineOptions implements Options {
         optionParser.accepts(HTTPS_PORT, "If this option is present WireMock will enable HTTPS on the specified port").withRequiredArg();
         optionParser.accepts(BIND_ADDRESS, "The IP to listen connections").withRequiredArg();
         optionParser.accepts(CONTAINER_THREADS, "The number of container threads").withRequiredArg();
+        optionParser.accepts(TIMEOUT, "The default global timeout.");
+        optionParser.accepts(DISABLE_OPTIMIZE_XML_FACTORIES_LOADING, "Whether to disable optimize XML factories loading or not.");
         optionParser.accepts(REQUIRE_CLIENT_CERT, "Make the server require a trusted client certificate to enable a connection");
         optionParser.accepts(HTTPS_TRUSTSTORE_TYPE, "The HTTPS trust store type").withRequiredArg().defaultsTo("JKS");
         optionParser.accepts(HTTPS_TRUSTSTORE_PASSWORD, "Password for the trust store").withRequiredArg();
@@ -605,6 +608,16 @@ public class CommandLineOptions implements Options {
     @Override
     public boolean getStubCorsEnabled() {
         return optionSet.has(ENABLE_STUB_CORS);
+    }
+
+    @Override
+    public long timeout() {
+        return optionSet.has(TIMEOUT) ? Long.parseLong((String)optionSet.valueOf(TIMEOUT)) : DEFAULT_TIMEOUT;
+    }
+
+    @Override
+    public boolean getDisableOptimizeXmlFactoriesLoading() {
+        return optionSet.has(DISABLE_OPTIMIZE_XML_FACTORIES_LOADING);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/standalone/WireMockServerRunner.java
@@ -42,10 +42,6 @@ public class WireMockServerRunner {
             "| $$/   \\  $$| $$| $$      |  $$$$$$$| $$ \\/  | $$|  $$$$$$/|  $$$$$$$| $$ \\  $$\n" +
             "|__/     \\__/|__/|__/       \\_______/|__/     |__/ \\______/  \\_______/|__/  \\__/";
 
-    static {
-        System.setProperty("org.mortbay.log.class", "com.github.tomakehurst.wiremock.jetty.LoggerAdapter");
-    }
-
 	private WireMockServer wireMockServer;
 
 	public void run(String... args) {


### PR DESCRIPTION
Add configuration options for the global default timeout, as well as the disabling of optimize factories loading

Leave optimize factories loading enabled by default, for backwards compatibility
Remove no longer used org.mortbay.log.class system property setting