### PR TITLE
Fix 1547 parse json helper

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.common.Json;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.List;
 
 public class ParseJsonHelper extends HandlebarsHelper<Object> {
 
@@ -44,15 +45,21 @@ public class ParseJsonHelper extends HandlebarsHelper<Object> {
             variableName = options.params.length > 0 ? options.param(0) : null;
         }
 
-        Map<String, Object> map = json != null ?
-                Json.read(json.toString(), new TypeReference<Map<String, Object>>() {}) :
-                null;
+        Object result = null;
+        if(json != null) {
+            String jsonAsString = json.toString().trim();
+            if(jsonAsString.startsWith("[") && jsonAsString.endsWith("]")) {
+                result = Json.read(jsonAsString, new TypeReference<List<Object>>() {});
+            } else {
+                result = Json.read(jsonAsString, new TypeReference<Map<String, Object>>() {});
+            }
+        }
 
         if (variableName != null) {
-            options.context.data(variableName, map);
+            options.context.data(variableName, result);
             return null;
         }
 
-        return map;
+        return result;
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Arrays;
+import java.util.ArrayList;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -75,6 +77,21 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
         assertThat(result.get("parent"), instanceOf(Map.class));
         Map<String, Object> parent = (Map<String, Object>) result.get("parent");
         assertThat(parent, hasEntry("child", "val"));
+    }
+
+    @Test
+    public void parsesJsonWithTopLevelArray() throws Exception {
+        String inputJson = "[{\"key\": \"val\"}]";
+        Object output = render(inputJson, new Object[]{}, TagType.VAR);
+
+        // Check list returns
+        assertThat(output, instanceOf(ArrayList.class));
+        ArrayList<Object> result = (ArrayList<Object>) output;
+        assertThat(result, hasSize(1));
+        // Check inner is a map
+        assertThat(result.get(0), instanceOf(Map.class));
+        Map<String, Object> inner = (Map<String, Object>) result.get(0);
+        assertThat(inner, hasEntry("key", "val"));
     }
 
     private Object render(Object context, Object[] params, TagType tagType) throws IOException {

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Arrays;
-import java.util.ArrayList;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -58,7 +58,7 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
         Map<String, Object> result = (Map<String, Object>) output;
         assertThat(result, aMapWithSize(1));
         assertThat(result, hasKey("arr"));
-        assertThat(result.get("arr"), instanceOf(ArrayList.class));
+        assertThat(result.get("arr"), instanceOf(List.class));
         assertThat(result, hasEntry("arr", Arrays.asList(new String[]{"one", "two", "three"})));
     }
 
@@ -84,8 +84,8 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
         Object output = render(inputJson, new Object[]{}, TagType.VAR);
 
         // Check list returns
-        assertThat(output, instanceOf(ArrayList.class));
-        ArrayList<Object> result = (ArrayList<Object>) output;
+        assertThat(output, instanceOf(List.class));
+        List<Object> result = (List<Object>) output;
         assertThat(result, hasSize(1));
         // Check inner is a map
         assertThat(result.get(0), instanceOf(Map.class));

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -18,7 +18,6 @@ package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.TagType;
 import com.github.jknack.handlebars.Context;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -49,6 +49,19 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
     }
 
     @Test
+    public void parsesAJsonObjectContainingArray() throws Exception {
+        String inputJson = "{\"arr\": [\"one\", \"two\", \"three\"]}";
+        Object output = render(inputJson, new Object[]{}, TagType.VAR);
+
+        assertThat(output, instanceOf(Map.class));
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result, aMapWithSize(1));
+        assertThat(result, hasKey("arr"));
+        assertThat(result.get("arr"), instanceOf(ArrayList.class));
+        assertThat(result, hasEntry("arr", Arrays.asList(new String[]{"one", "two", "three"})));
+    }
+
+    @Test
     public void parseANestedJsonObject() throws Exception {
         String inputJson = "{\"parent\": {\"child\": \"val\"}}";
         Object output = render(inputJson, new Object[]{}, TagType.VAR);

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -41,11 +41,11 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
         String inputJson = "{\"testKey1\": \"val1\", \"testKey2\": \"val2\"}";
         Object output = render(inputJson, new Object[]{}, TagType.VAR);
 
-        String expectedJson = "Test";
         assertThat(output, instanceOf(Map.class));
-        assertThat((Map<String, Object>)output, aMapWithSize(2));
-        assertThat((Map<String, Object>)output, hasEntry("testKey1", "val1"));
-        assertThat((Map<String, Object>)output, hasEntry("testKey2", "val2"));
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result, aMapWithSize(2));
+        assertThat(result, hasEntry("testKey1", "val1"));
+        assertThat(result, hasEntry("testKey2", "val2"));
     }
 
     private Object render(Object context, Object[] params, TagType tagType) throws IOException {

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -48,6 +48,22 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
         assertThat(result, hasEntry("testKey2", "val2"));
     }
 
+    @Test
+    public void parseANestedJsonObject() throws Exception {
+        String inputJson = "{\"parent\": {\"child\": \"val\"}}";
+        Object output = render(inputJson, new Object[]{}, TagType.VAR);
+
+        // Check parent level
+        assertThat(output, instanceOf(Map.class));
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result, aMapWithSize(1));
+        assertThat(result, hasKey("parent"));
+        // Check child level
+        assertThat(result.get("parent"), instanceOf(Map.class));
+        Map<String, Object> parent = (Map<String, Object>) result.get("parent");
+        assertThat(parent, hasEntry("child", "val"));
+    }
+
     private Object render(Object context, Object[] params, TagType tagType) throws IOException {
         return helper.apply(context,
             new Options.Builder(null, null, tagType, createContext(), null)

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2011 Thomas Akehurst
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
+
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.TagType;
+import com.github.jknack.handlebars.Context;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
+    private ParseJsonHelper helper;
+
+    @Before
+    public void init() {
+        helper = new ParseJsonHelper();
+    }
+
+    @Test
+    public void parsesASimpleJsonObject() throws Exception {
+        String inputJson = "{\"testKey1\": \"val1\", \"testKey2\": \"val2\"}";
+        Object output = render(inputJson, new Object[]{}, TagType.VAR);
+
+        String expectedJson = "Test";
+        assertThat(output, instanceOf(Map.class));
+        assertThat((Map<String, Object>)output, aMapWithSize(2));
+        assertThat((Map<String, Object>)output, hasEntry("testKey1", "val1"));
+        assertThat((Map<String, Object>)output, hasEntry("testKey2", "val2"));
+    }
+
+    private Object render(Object context, Object[] params, TagType tagType) throws IOException {
+        return helper.apply(context,
+            new Options.Builder(null, null, tagType, createContext(), null)
+                .setParams(params)
+                .build()
+        );
+    }
+}


### PR DESCRIPTION
fixes #1547

- Adds a ParseJsonHelperTest.java test file.
- Adds 5 test cases including 2 where the array is at the top level.
- Checks whether the json is enclosed by array tags.
   - If it is then a List <Object> is returned instead of a Map <String, Object>.
   - This way it does not interfere with other test cases.
