### PR TITLE
#745 Need proxyUrlPrefixToRemove for proxy context url mapping

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilder.java
@@ -191,6 +191,7 @@ public class ResponseDefinitionBuilder {
     public static class ProxyResponseDefinitionBuilder extends ResponseDefinitionBuilder {
 
         private List<HttpHeader> additionalRequestHeaders = newArrayList();
+        private String proxyUrlPrefixToRemove;
 
         public ProxyResponseDefinitionBuilder(ResponseDefinitionBuilder from) {
             this.status = from.status;
@@ -215,9 +216,14 @@ public class ResponseDefinitionBuilder {
             return this;
         }
 
+        public ProxyResponseDefinitionBuilder withProxyUrlPrefixToRemove(String proxyUrlPrefixToRemove) {
+            this.proxyUrlPrefixToRemove = proxyUrlPrefixToRemove;
+            return this;
+        }
+
         @Override
         public ResponseDefinition build() {
-            return !additionalRequestHeaders.isEmpty() ? super.build(new HttpHeaders(additionalRequestHeaders)) : super.build();
+            return super.build(!additionalRequestHeaders.isEmpty() ? new HttpHeaders(additionalRequestHeaders) : null, proxyUrlPrefixToRemove);
         }
     }
 
@@ -227,7 +233,7 @@ public class ResponseDefinitionBuilder {
     }
 
     public ResponseDefinition build() {
-        return build(null);
+        return build(null, null);
     }
 
     private boolean isBinaryBody() {
@@ -238,7 +244,7 @@ public class ResponseDefinitionBuilder {
         return jsonBody != null;
     }
 
-    protected ResponseDefinition build(HttpHeaders additionalProxyRequestHeaders) {
+    protected ResponseDefinition build(HttpHeaders additionalProxyRequestHeaders, String proxyUrlPrefixToRemove) {
         HttpHeaders httpHeaders = headers == null || headers.isEmpty() ? null : new HttpHeaders(headers);
         Parameters transformerParameters = this.transformerParameters == null || this.transformerParameters.isEmpty() ? null : Parameters.from(this.transformerParameters);
         if (isBinaryBody()) {
@@ -255,6 +261,7 @@ public class ResponseDefinitionBuilder {
                     delayDistribution,
                     chunkedDribbleDelay,
                     proxyBaseUrl,
+                    proxyUrlPrefixToRemove,
                     fault,
                     responseTransformerNames,
                     transformerParameters,
@@ -274,6 +281,7 @@ public class ResponseDefinitionBuilder {
                     delayDistribution,
                     chunkedDribbleDelay,
                     proxyBaseUrl,
+                    proxyUrlPrefixToRemove,
                     fault,
                     responseTransformerNames,
                     transformerParameters,
@@ -292,6 +300,7 @@ public class ResponseDefinitionBuilder {
                     delayDistribution,
                     chunkedDribbleDelay,
                     proxyBaseUrl,
+                    proxyUrlPrefixToRemove,
                     fault,
                     responseTransformerNames,
                     transformerParameters,

--- a/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/ProxyAcceptanceTest.java
@@ -533,6 +533,22 @@ public class ProxyAcceptanceTest {
         assertThat(allowOriginHeaderValues.size(), is(0));
     }
 
+    @Test
+    public void removesPrefixFromProxyRequestWhenMatching() {
+        initWithDefaultConfig();
+
+        proxy.register(get("/other/service/doc/123")
+                .willReturn(aResponse()
+                        .proxiedFrom(targetServiceBaseUrl + "/approot")
+                        .withProxyUrlPrefixToRemove("/other/service")));
+
+        target.register(get("/approot/doc/123").willReturn(ok()));
+
+        WireMockResponse response = testClient.get("/other/service/doc/123");
+
+        assertThat(response.statusCode(), is(200));
+    }
+
     private void register200StubOnProxyAndTarget(String url) {
         target.register(get(urlEqualTo(url)).willReturn(aResponse().withStatus(200)));
         proxy.register(get(urlEqualTo(url)).willReturn(aResponse().proxiedFrom(targetServiceBaseUrl)));

--- a/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/client/ResponseDefinitionBuilderTest.java
@@ -93,66 +93,75 @@ public class ResponseDefinitionBuilderTest {
     }
 
     @Test
-    public void proxyResponseDefinitionWithoutExtraHeadersIsNotInResponseDefinition() {
+    public void proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinition() {
         ResponseDefinition proxyDefinition = ResponseDefinitionBuilder.responseDefinition()
                 .proxiedFrom("http://my.domain")
                 .build();
 
         assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(), nullValue());
+        assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), nullValue());
     }
 
     @Test
-    public void proxyResponseDefinitionWithoutExtraHeadersIsNotInResponseDefinitionWithJsonBody() {
+    public void proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinitionWithJsonBody() {
         ResponseDefinition proxyDefinition = ResponseDefinitionBuilder.responseDefinition()
                 .proxiedFrom("http://my.domain")
                 .withJsonBody(Json.read("{}", JsonNode.class))
                 .build();
 
         assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(), nullValue());
+        assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), nullValue());
     }
 
     @Test
-    public void proxyResponseDefinitionWithoutExtraHeadersIsNotInResponseDefinitionWithBinaryBody() {
+    public void proxyResponseDefinitionWithoutProxyInformationIsNotInResponseDefinitionWithBinaryBody() {
         ResponseDefinition proxyDefinition = ResponseDefinitionBuilder.responseDefinition()
                 .proxiedFrom("http://my.domain")
                 .withBody(new byte[] { 0x01 })
                 .build();
 
         assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(), nullValue());
+        assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), nullValue());
     }
 
     @Test
-    public void proxyResponseDefinitionWithExtraHeadersIsInResponseDefinition() {
+    public void proxyResponseDefinitionWithExtraInformationIsInResponseDefinition() {
         ResponseDefinition proxyDefinition = ResponseDefinitionBuilder.responseDefinition()
                 .proxiedFrom("http://my.domain")
                 .withAdditionalRequestHeader("header", "value")
+                .withProxyUrlPrefixToRemove("/remove")
                 .build();
 
         assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(),
                 equalTo(new HttpHeaders(newArrayList(new HttpHeader("header", "value")))));
+        assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
     }
 
     @Test
-    public void proxyResponseDefinitionWithExtraHeadersIsInResponseDefinitionWithJsonBody() {
+    public void proxyResponseDefinitionWithExtraInformationIsInResponseDefinitionWithJsonBody() {
         ResponseDefinition proxyDefinition = ResponseDefinitionBuilder.responseDefinition()
                 .proxiedFrom("http://my.domain")
                 .withAdditionalRequestHeader("header", "value")
+                .withProxyUrlPrefixToRemove("/remove")
                 .withJsonBody(Json.read("{}", JsonNode.class))
                 .build();
 
         assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(),
                 equalTo(new HttpHeaders(newArrayList(new HttpHeader("header", "value")))));
+        assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
     }
 
     @Test
-    public void proxyResponseDefinitionWithExtraHeadersIsInResponseDefinitionWithBinaryBody() {
+    public void proxyResponseDefinitionWithExtraInformationIsInResponseDefinitionWithBinaryBody() {
         ResponseDefinition proxyDefinition = ResponseDefinitionBuilder.responseDefinition()
                 .proxiedFrom("http://my.domain")
                 .withAdditionalRequestHeader("header", "value")
+                .withProxyUrlPrefixToRemove("/remove")
                 .withBody(new byte[] { 0x01 })
                 .build();
 
         assertThat(proxyDefinition.getAdditionalProxyRequestHeaders(),
                 equalTo(new HttpHeaders(newArrayList(new HttpHeader("header", "value")))));
+        assertThat(proxyDefinition.getProxyUrlPrefixToRemove(), equalTo("/remove"));
     }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
@@ -1,0 +1,30 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.MockRequest;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ResponseDefinitionTest {
+
+    @Test
+    public void getProxyUrlGivesBackRequestUrlIfBrowserProxyRequest() {
+        ResponseDefinition response = ResponseDefinition.browserProxy(MockRequest.mockRequest()
+                .host("http://my.domain").url("/path").isBrowserProxyRequest(true));
+
+        assertThat(response.getProxyUrl(), equalTo("http://my.domain/path"));
+    }
+
+    @Test
+    public void getProxyUrlGivesBackTheProxyUrlWhenNotBrowserProxy() {
+        ResponseDefinition response = ResponseDefinitionBuilder.responseDefinition()
+                .proxiedFrom("http://my.proxy.url")
+                .build();
+
+        response.setOriginalRequest(MockRequest.mockRequest().url("/path"));
+
+        assertThat(response.getProxyUrl(), equalTo("http://my.proxy.url/path"));
+    }
+}

--- a/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/ResponseDefinitionTest.java
@@ -27,4 +27,28 @@ public class ResponseDefinitionTest {
 
         assertThat(response.getProxyUrl(), equalTo("http://my.proxy.url/path"));
     }
+
+    @Test
+    public void doesNotRemoveRequestPathPrefixWhenPrefixToRemoveDoesNotMatch() {
+        ResponseDefinition response = ResponseDefinitionBuilder.responseDefinition()
+                .proxiedFrom("http://my.proxy.url")
+                .withProxyUrlPrefixToRemove("/no/match")
+                .build();
+
+        response.setOriginalRequest(MockRequest.mockRequest().url("/path"));
+
+        assertThat(response.getProxyUrl(), equalTo("http://my.proxy.url/path"));
+    }
+
+    @Test
+    public void removesRequestPathPrefixWhenPrefixToRemoveMatches() {
+        ResponseDefinition response = ResponseDefinitionBuilder.responseDefinition()
+                .proxiedFrom("http://my.proxy.url")
+                .withProxyUrlPrefixToRemove("/path")
+                .build();
+
+        response.setOriginalRequest(MockRequest.mockRequest().url("/path"));
+
+        assertThat(response.getProxyUrl(), equalTo("http://my.proxy.url"));
+    }
 }

--- a/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/http/StubResponseRendererTest.java
@@ -131,6 +131,7 @@ public class StubResponseRendererTest {
                     null,
                     null,
                     null,
+                    null,
                     true
             )
         );

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -48,6 +48,7 @@ public class MockRequest implements Request {
     private byte[] body;
     private String clientIp = "1.1.1.1";
     private Collection<Part> multiparts = null;
+    private boolean isBrowserProxyRequest = false;
 
     public static MockRequest mockRequest() {
         return new MockRequest();
@@ -114,6 +115,11 @@ public class MockRequest implements Request {
         }
 
         multiparts.add(part);
+        return this;
+    }
+
+    public MockRequest isBrowserProxyRequest(boolean isBrowserProxyRequest) {
+        this.isBrowserProxyRequest = isBrowserProxyRequest;
         return this;
     }
 

--- a/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/matching/MockRequest.java
@@ -220,7 +220,7 @@ public class MockRequest implements Request {
 
     @Override
     public boolean isBrowserProxyRequest() {
-        return false;
+        return isBrowserProxyRequest;
     }
 
     @Override

--- a/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/stubbing/ResponseDefinitionTest.java
@@ -50,6 +50,7 @@ public class ResponseDefinitionTest {
                 null,
                 null,
                 "http://base.com",
+                null,
                 Fault.EMPTY_RESPONSE,
                 ImmutableList.of("transformer-1"),
                 Parameters.one("name", "Jeff"),


### PR DESCRIPTION
Fix for #745. The original request mentions using a transformation parameter, but this PR follows a similar pattern as the additionalProxyRequestHeaders option in the response definition.  