### PR TITLE
Fix #1545 - Parse null json

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.common.Json;
 import java.io.IOException;
 import java.util.Map;
 import java.util.List;
+import java.util.HashMap;
 
 public class ParseJsonHelper extends HandlebarsHelper<Object> {
 
@@ -30,6 +31,10 @@ public class ParseJsonHelper extends HandlebarsHelper<Object> {
     public Object apply(Object context, Options options) throws IOException {
         CharSequence json;
         String variableName;
+        Map<String, Object> emptyJson = new HashMap<String, Object>();
+
+        // Edge case if null JSON object passed in
+        if(context == null) { return emptyJson; }
 
         boolean hasContext = context != options.context.model();
 
@@ -45,9 +50,14 @@ public class ParseJsonHelper extends HandlebarsHelper<Object> {
             variableName = options.params.length > 0 ? options.param(0) : null;
         }
 
-        Object result = null;
+        Object result = emptyJson;
         if(json != null) {
             String jsonAsString = json.toString().trim();
+
+            // Edge case if JSON object is empty {}
+            String jsonAsStringWithoutSpace = jsonAsString.replaceAll("\\s", "");
+            if(jsonAsStringWithoutSpace.equals("{}") || jsonAsStringWithoutSpace.equals("")) { return emptyJson; }
+
             if(jsonAsString.startsWith("[") && jsonAsString.endsWith("]")) {
                 result = Json.read(jsonAsString, new TypeReference<List<Object>>() {});
             } else {

--- a/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelper.java
@@ -31,10 +31,10 @@ public class ParseJsonHelper extends HandlebarsHelper<Object> {
     public Object apply(Object context, Options options) throws IOException {
         CharSequence json;
         String variableName;
-        Map<String, Object> emptyJson = new HashMap<String, Object>();
+        Object result = new HashMap<String, Object>();
 
         // Edge case if null JSON object passed in
-        if(context == null) { return emptyJson; }
+        if(context == null) { return result; }
 
         boolean hasContext = context != options.context.model();
 
@@ -50,13 +50,12 @@ public class ParseJsonHelper extends HandlebarsHelper<Object> {
             variableName = options.params.length > 0 ? options.param(0) : null;
         }
 
-        Object result = emptyJson;
         if(json != null) {
             String jsonAsString = json.toString().trim();
 
             // Edge case if JSON object is empty {}
             String jsonAsStringWithoutSpace = jsonAsString.replaceAll("\\s", "");
-            if(jsonAsStringWithoutSpace.equals("{}") || jsonAsStringWithoutSpace.equals("")) { return emptyJson; }
+            if(jsonAsStringWithoutSpace.equals("{}") || jsonAsStringWithoutSpace.equals("")) { return result; }
 
             if(jsonAsString.startsWith("[") && jsonAsString.endsWith("]")) {
                 result = Json.read(jsonAsString, new TypeReference<List<Object>>() {});

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -16,6 +16,7 @@
 package com.github.tomakehurst.wiremock.extension.responsetemplating.helpers;
 
 import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.Template;
 import com.github.jknack.handlebars.TagType;
 import com.github.jknack.handlebars.Context;
 import org.junit.Before;
@@ -139,7 +140,7 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
     
     private Object render(Object context, Object[] params, TagType tagType) throws IOException {
         return helper.apply(context,
-            new Options.Builder(null, null, tagType, createContext(), null)
+            new Options.Builder(null, null, tagType, createContext(), Template.EMPTY)
                 .setParams(params)
                 .build()
         );

--- a/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
+++ b/src/test/java/com/github/tomakehurst/wiremock/extension/responsetemplating/helpers/ParseJsonHelperTest.java
@@ -93,6 +93,50 @@ public class ParseJsonHelperTest extends HandlebarsHelperTestBase {
         assertThat(inner, hasEntry("key", "val"));
     }
 
+    @Test
+    public void parsesNullJsonIfSection() throws Exception {
+        String inputJson = null;
+        Object output = render(inputJson, new Object[]{}, TagType.SECTION);
+
+        // Check that it returns empty object
+        assertThat(output, instanceOf(Map.class));
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result, aMapWithSize(0));
+    }
+
+    @Test
+    public void parsesNullJsonIfNotSection() throws Exception {
+        String inputJson = null;
+        Object output = render(inputJson, new Object[]{}, TagType.VAR);
+
+        // Check that it returns empty object
+        assertThat(output, instanceOf(Map.class));
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result, aMapWithSize(0));
+    }
+
+    @Test
+    public void parsesEmptyJsonIfSection() throws Exception {
+        String inputJson = "{}";
+        Object output = render(inputJson, new Object[]{}, TagType.SECTION);
+
+        // Check that it returns empty object
+        assertThat(output, instanceOf(Map.class));
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result, aMapWithSize(0));
+    }
+
+    @Test
+    public void parsesEmptyJsonIfNotSection() throws Exception {
+        String inputJson = "{}";
+        Object output = render(inputJson, new Object[]{}, TagType.VAR);
+
+        // Check that it returns empty object
+        assertThat(output, instanceOf(Map.class));
+        Map<String, Object> result = (Map<String, Object>) output;
+        assertThat(result, aMapWithSize(0));
+    }
+    
     private Object render(Object context, Object[] params, TagType tagType) throws IOException {
         return helper.apply(context,
             new Options.Builder(null, null, tagType, createContext(), null)


### PR DESCRIPTION
fixes #1545 

- Add 2 unit tests for if null is passed in (TAGTYPE.Section as an extra condition)
- Add 2 unit tests for if "{}" is passed in (TAGTYPE.Section as an extra condition)  

- Fix these two edge cases by adding a conditional at the beginning and returning an empty map in this case