### PR TITLE
Enable support for this codebase's to write JUnit5 tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,10 @@ dependencies {
     }
     compile "commons-io:commons-io:2.10.0"
 
-    testCompile "junit:junit:4.13"
+    testImplementation platform("org.junit:junit-bom:5.7.2")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
     testCompile "org.hamcrest:hamcrest-core:2.2"
     testCompile "org.hamcrest:hamcrest-library:2.2"
     testCompile("org.jmock:jmock:2.5.1") {
@@ -141,6 +144,8 @@ compileTestJava {
 }
 
 test {
+    useJUnitPlatform()
+
     // Set the timezone for testing somewhere other than my machine to increase the chances of catching timezone bugs
     systemProperty 'user.timezone', 'Australia/Sydney'
 


### PR DESCRIPTION
JUnit5 is arguably a better development experience, and we should allow
contributors to start writing unit tests using it, instead of JUnit4,
where possible.

However, until we've migrated the codebase between versions, we can use
the vintage-engine to run both JUnit4 and JUnit5 tests at the same time!

This also includes the platform-launcher, which will allow us to launch
the tests from an IDE.
