### PR TITLE
Refactor creation of `RequestHandler` classes

### DIFF
--- a/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/core/WireMockApp.java
@@ -129,45 +129,13 @@ public class WireMockApp implements StubServer, Admin {
     }
 
     public AdminRequestHandler buildAdminRequestHandler() {
-        AdminRoutes adminRoutes = AdminRoutes.defaultsPlus(
-            options.extensionsOfType(AdminApiExtension.class).values(),
-            options.getNotMatchedRenderer()
-        );
-        return new AdminRequestHandler(
-            adminRoutes,
-            this,
-            new BasicResponseRenderer(),
-            options.getAdminAuthenticator(),
-            options.getHttpsRequiredForAdminApi(),
-            getAdminRequestFilters()
-        );
+        return new AdminRequestHandlerFactory(). // TODO: field? Static?
+        buildAdminRequestHandler(this, options, getAdminRequestFilters());
     }
 
     public StubRequestHandler buildStubRequestHandler() {
-        Map<String, PostServeAction> postServeActions = options.extensionsOfType(PostServeAction.class);
-        BrowserProxySettings browserProxySettings = options.browserProxySettings();
-        return new StubRequestHandler(
-            this,
-            new StubResponseRenderer(
-                options.filesRoot().child(FILES_ROOT),
-                getGlobalSettingsHolder(),
-                new ProxyResponseRenderer(
-                    options.proxyVia(),
-                    options.httpsSettings().trustStore(),
-                    options.shouldPreserveHostHeader(),
-                    options.proxyHostHeader(),
-                    globalSettingsHolder,
-                    browserProxySettings.trustAllProxyTargets(),
-                    browserProxySettings.trustedProxyTargets()
-                ),
-                ImmutableList.copyOf(options.extensionsOfType(ResponseTransformer.class).values())
-            ),
-            this,
-            postServeActions,
-            requestJournal,
-            getStubRequestFilters(),
-            options.getStubRequestLoggingDisabled()
-        );
+        return new StubRequestHandlerFactory(). // TODO: field? Static?
+                buildStubRequestHandler(this, this, options, globalSettingsHolder, requestJournal, getStubRequestFilters());
     }
 
     private List<RequestFilter> getAdminRequestFilters() {

--- a/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandlerFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/AdminRequestHandlerFactory.java
@@ -1,0 +1,28 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.admin.AdminRoutes;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.extension.AdminApiExtension;
+import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
+
+import java.util.List;
+
+public class AdminRequestHandlerFactory {
+
+    public AdminRequestHandler buildAdminRequestHandler(Admin admin,
+                                                        Options options, List<RequestFilter> adminRequestFilters) {
+        AdminRoutes adminRoutes = AdminRoutes.defaultsPlus(
+                options.extensionsOfType(AdminApiExtension.class).values(),
+                options.getNotMatchedRenderer()
+        );
+        return new AdminRequestHandler(
+                adminRoutes,
+                admin,
+                new BasicResponseRenderer(),
+                options.getAdminAuthenticator(),
+                options.getHttpsRequiredForAdminApi(),
+                adminRequestFilters
+        );
+    }
+}

--- a/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandlerFactory.java
+++ b/src/main/java/com/github/tomakehurst/wiremock/http/StubRequestHandlerFactory.java
@@ -1,0 +1,48 @@
+package com.github.tomakehurst.wiremock.http;
+
+import com.github.tomakehurst.wiremock.common.BrowserProxySettings;
+import com.github.tomakehurst.wiremock.core.Admin;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.core.StubServer;
+import com.github.tomakehurst.wiremock.extension.PostServeAction;
+import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
+import com.github.tomakehurst.wiremock.extension.requestfilter.RequestFilter;
+import com.github.tomakehurst.wiremock.global.GlobalSettingsHolder;
+import com.github.tomakehurst.wiremock.verification.RequestJournal;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Map;
+
+public class StubRequestHandlerFactory {
+
+    public static final String FILES_ROOT = "__files";
+
+    public StubRequestHandler buildStubRequestHandler(StubServer stubServer, Admin admin,
+                                                      Options options, GlobalSettingsHolder globalSettingsHolder, RequestJournal requestJournal, List<RequestFilter> stubRequestFilters) {
+        Map<String, PostServeAction> postServeActions = options.extensionsOfType(PostServeAction.class);
+        BrowserProxySettings browserProxySettings = options.browserProxySettings();
+        return new StubRequestHandler(
+                stubServer,
+                new StubResponseRenderer(
+                        options.filesRoot().child(FILES_ROOT),
+                        globalSettingsHolder,
+                        new ProxyResponseRenderer(
+                                options.proxyVia(),
+                                options.httpsSettings().trustStore(),
+                                options.shouldPreserveHostHeader(),
+                                options.proxyHostHeader(),
+                                globalSettingsHolder,
+                                browserProxySettings.trustAllProxyTargets(),
+                                browserProxySettings.trustedProxyTargets()
+                        ),
+                        ImmutableList.copyOf(options.extensionsOfType(ResponseTransformer.class).values())
+                ),
+                admin,
+                postServeActions,
+                requestJournal,
+                stubRequestFilters,
+                options.getStubRequestLoggingDisabled()
+        );
+    }
+}


### PR DESCRIPTION
As part of work towards #1476, we need to refactor this logic out of the
core `WireMockApp`, so we can then re-use it as part of the Direct HTTP
client setup.

This further simplifies the setup of the `WireMockApp`, too.